### PR TITLE
Add Plan B: AI drafting agent for blog + YouTube

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,20 @@
+# Claude subscription auth — obtain via `claude setup-token`
+CLAUDE_CODE_OAUTH_TOKEN=
+
+# Notion integration token — create at https://www.notion.so/profile/integrations
+# Share the Content DB with the integration after creating it.
+NOTION_TOKEN=
+
+# YouTube Data API v3 key — create at https://console.cloud.google.com/apis/credentials
+YOUTUBE_API_KEY=
+
+# GitHub PAT for opening agent PRs (local dev only — CI uses AGENT_GH_TOKEN secret)
+# Fine-grained, scope: contents:write + pull-requests:write on this repo.
+AGENT_GH_TOKEN=
+
+# Config (also settable as GH repo variables in CI)
+NOTION_CONTENT_DB_ID=
+YOUTUBE_CHANNEL_ID=
+SCAN_REPO_ORG=shariqh
+SCAN_REPO_INCLUDE=blog-site,lognote
+SCAN_REPO_ACTIVE_DAYS=30

--- a/.env.local.example
+++ b/.env.local.example
@@ -2,7 +2,7 @@
 CLAUDE_CODE_OAUTH_TOKEN=
 
 # Notion integration token — create at https://www.notion.so/profile/integrations
-# Share the Content DB with the integration after creating it.
+# Share the CMS DB with the integration after creating it.
 NOTION_TOKEN=
 
 # YouTube Data API v3 key — create at https://console.cloud.google.com/apis/credentials
@@ -13,7 +13,7 @@ YOUTUBE_API_KEY=
 AGENT_GH_TOKEN=
 
 # Config (also settable as GH repo variables in CI)
-NOTION_CONTENT_DB_ID=
+NOTION_CMS_DB_ID=d25e9f1c0a3345589592fce32f7bc02b
 YOUTUBE_CHANNEL_ID=
 SCAN_REPO_ORG=shariqh
 SCAN_REPO_INCLUDE=blog-site,lognote

--- a/.github/workflows/agent-discover.yml
+++ b/.github/workflows/agent-discover.yml
@@ -1,0 +1,34 @@
+name: Agent — discover
+
+on:
+  schedule:
+    - cron: '0 3 * * 0' # Sunday 03:00 UTC
+  workflow_dispatch:
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      - name: Run discovery
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          NOTION_CMS_DB_ID: ${{ vars.NOTION_CMS_DB_ID }}
+          YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
+          YOUTUBE_CHANNEL_ID: ${{ vars.YOUTUBE_CHANNEL_ID }}
+          AGENT_GH_TOKEN: ${{ secrets.AGENT_GH_TOKEN }}
+          SCAN_REPO_ORG: ${{ vars.SCAN_REPO_ORG }}
+          SCAN_REPO_INCLUDE: ${{ vars.SCAN_REPO_INCLUDE }}
+          SCAN_REPO_ACTIVE_DAYS: ${{ vars.SCAN_REPO_ACTIVE_DAYS }}
+        run: npm run agent:discover

--- a/.github/workflows/agent-draft.yml
+++ b/.github/workflows/agent-draft.yml
@@ -1,0 +1,50 @@
+name: Agent — draft
+
+on:
+  schedule:
+    - cron: '0 2 * * *' # Daily 02:00 UTC
+  workflow_dispatch:
+
+jobs:
+  draft:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.AGENT_GH_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      - name: Install Vale
+        run: |
+          curl -fsSL -o vale.tar.gz https://github.com/errata-ai/vale/releases/download/v3.14.2/vale_3.14.2_Linux_64-bit.tar.gz
+          tar -xzf vale.tar.gz vale
+          sudo mv vale /usr/local/bin/
+
+      - name: Configure git
+        run: |
+          git config user.name "shariq-dev-agent"
+          git config user.email "agent@shariq.dev"
+
+      - name: Run drafting
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          NOTION_CMS_DB_ID: ${{ vars.NOTION_CMS_DB_ID }}
+          YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
+          YOUTUBE_CHANNEL_ID: ${{ vars.YOUTUBE_CHANNEL_ID }}
+          AGENT_GH_TOKEN: ${{ secrets.AGENT_GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.AGENT_GH_TOKEN }}
+          SCAN_REPO_ORG: ${{ vars.SCAN_REPO_ORG }}
+          SCAN_REPO_INCLUDE: ${{ vars.SCAN_REPO_INCLUDE }}
+          SCAN_REPO_ACTIVE_DAYS: ${{ vars.SCAN_REPO_ACTIVE_DAYS }}
+        run: npm run agent:draft

--- a/.github/workflows/agent-promote.yml
+++ b/.github/workflows/agent-promote.yml
@@ -1,0 +1,32 @@
+name: Agent — promote
+
+on:
+  schedule:
+    - cron: '0 4 * * *' # Daily 04:00 UTC (2h after draft)
+  workflow_dispatch:
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      - name: Run promotion
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          NOTION_CMS_DB_ID: ${{ vars.NOTION_CMS_DB_ID }}
+          # The rest are unused by promote.ts but required by config.ts on import:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
+          YOUTUBE_CHANNEL_ID: ${{ vars.YOUTUBE_CHANNEL_ID }}
+          AGENT_GH_TOKEN: ${{ secrets.AGENT_GH_TOKEN }}
+        run: npm run agent:promote

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - run: npm run astro check

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ npm-debug.log*
 .env
 .env.local
 .env.*.local
+
+# Agent local env
+.env.local

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,31 @@ Vale warnings/suggestions don't block CI; only errors do (today, only
 broken frontmatter). The drafting agent in Plan B is expected to run
 Vale before opening its PR.
 
+## AI drafting agent (Plan B)
+
+Three GHA workflows under `.github/workflows/agent-*.yml` run on cron:
+
+- **agent-discover** — Sunday 03:00 UTC: scans Notion ideas, recent commits, GH trending, HN, and YT performance; proposes up to 3 blog + 3 YT candidates as Notion rows.
+- **agent-draft** — Daily 02:00 UTC: picks up Content rows with `Stage=Ready`. Blog rows → MDX file + PR. YT rows → script blocks written to the Notion row body.
+- **agent-promote** — Daily 04:00 UTC: for published YT rows with `Cross-post Targets` includes `blog`, mints a linked blog derivative row in `Stage=Proposed`.
+
+Source of truth for content: the restructured Notion CMS DB (see `docs/superpowers/specs/2026-06-02-plan-b-ai-drafting-agent-design.md`).
+
+Local invocation (for prompt iteration without burning CI):
+
+```sh
+npm run agent:discover
+npm run agent:draft
+npm run agent:promote
+```
+
+Each reads `.env.local` (see `.env.local.example`).
+
+Style contracts:
+
+- Blog: `docs/EDITORIAL.md`
+- YouTube: `docs/SHORTS-STYLE.md`
+
 ## Deploy
 
 Cloudflare Pages via `.github/workflows/deploy.yml`. `main` → production

--- a/README.md
+++ b/README.md
@@ -77,3 +77,9 @@ wrangler pages deploy dist --project-name=shariq-dev --branch=hotfix
 wrangler pages domain add shariq.dev --project-name=shariq-dev
 wrangler pages domain list --project-name=shariq-dev
 ```
+
+## Drafting pipeline
+
+Posts and YouTube scripts are drafted by a Claude-based agent that reads from a Notion DB of ideas + my recent commits + AI/dev tool trends. The agent never publishes — every blog post goes through PR review on Cloudflare Pages preview; every YouTube script lives in Notion for me to record manually.
+
+See [`docs/superpowers/specs/2026-06-02-plan-b-ai-drafting-agent-design.md`](docs/superpowers/specs/2026-06-02-plan-b-ai-drafting-agent-design.md) for the design.

--- a/docs/EDITORIAL.md
+++ b/docs/EDITORIAL.md
@@ -4,6 +4,8 @@ Rules for **any public-facing prose** on shariq.dev: blog posts, the about page,
 
 This document is authoritative. Every writer — human, agent, or hybrid — applies these rules before publishing. The AI drafting agent (Plan B) loads this file into its system prompt as required reading.
 
+For YouTube scripts, the agent loads [`SHORTS-STYLE.md`](./SHORTS-STYLE.md) — same role, different format.
+
 If a rule below is wrong or outdated, **update this file** before writing copy that contradicts it.
 
 ---

--- a/docs/SHORTS-STYLE.md
+++ b/docs/SHORTS-STYLE.md
@@ -1,0 +1,84 @@
+# YouTube shorts / long-form style guide
+
+Rules for AI-generated scripts for the **shariq.dev YouTube channel** (https://www.youtube.com/@ShariqHirani). The drafting agent (Plan B) loads this file verbatim into the system prompt for any row with `Kind` in `[YT short, YT long]`.
+
+If a rule below is wrong or outdated, **update this file** before the next agent run.
+
+---
+
+## Voice
+
+- **First person.** Peer-to-peer, not influencer.
+- **No "what's up guys" / "smash like" / "in this video we'll" openers.** Get straight to the payoff.
+- **Speak like a working engineer**, not a tutorial host. Concrete, opinionated, fast.
+- **Admit gaps.** "Haven't tried X yet" beats fake authority.
+
+## Hook (first 3 seconds)
+
+The hook decides whether anyone watches the rest. It must:
+
+- Promise a concrete payoff in plain language ("here's the one thing that broke for me")
+- Avoid "you won't believe" / "the trick that…" / "no one is talking about…" patterns
+- Be one sentence, ideally under 12 words
+
+**Good:** "Cursor's new agent mode quietly rewrote my git config. Here's what to check."
+
+**Bad:** "AI agents are everywhere, but no one is talking about this scary thing…"
+
+## Length
+
+| Kind     | Target duration | Word count guide |
+| -------- | --------------- | ---------------- |
+| YT short | 50-60 seconds   | 130-170 words    |
+| YT long  | 4-7 minutes     | 600-1100 words   |
+
+Going over kills retention. Going under wastes the spot.
+
+## Script structure (shorts)
+
+1. **Hook** (0-3s) — one sentence
+2. **Setup** (3-15s) — what is the thing / why care
+3. **Payoff** (15-50s) — the demo, the surprise, the take
+4. **Tag** (50-60s) — one-line implication or follow-up question. No "subscribe" CTA in script (channel banner handles it).
+
+## Script structure (long)
+
+1. **Hook + thesis** (0-15s)
+2. **Demo / walk-through** (15s-3m)
+3. **What surprised me / what I'd do differently**
+4. **Where this fits in your stack**
+5. **Tag** — close with a take, not a CTA
+
+## On-screen text
+
+- Used to reinforce key terms, commands, or punchlines — never to repeat what the audio says.
+- Each on-screen text is timestamped, ≤6 words, present-tense.
+
+## B-roll
+
+- For each timestamp, describe what visual should be on screen (screen recording, terminal, IDE, etc.).
+- Avoid stock-footage cues — this channel is screen-cap-heavy.
+
+## Thumbnail prompt
+
+- One sentence describing the image to make.
+- Include: subject, mood (matter-of-fact, not shocked-face), text overlay (≤4 words, sentence case, not all-caps).
+
+## Titles
+
+- 3 variants per video.
+- Each ≤60 chars, sentence case, no clickbait.
+- One should include a tool name; one should describe the outcome; one should be intentionally curiosity-driven without lying.
+
+## Hashtags
+
+- 5-8 per video, lowercase, no spaces.
+- Mix: 2-3 broad (`ai`, `developer`, `programming`), 2-3 tool-specific (`claudecode`, `cursorai`), 1-2 niche (`agenticworkflows`).
+
+## Don't
+
+- Fake reactions ("WAIT, what?!")
+- Reading the README aloud
+- "Here's what I learned" recaps that aren't a take
+- Mentioning competitors uncharitably
+- Talking about Anthropic / OpenAI / Google as personalities

--- a/docs/superpowers/plans/2026-06-02-plan-b-ai-drafting-agent.md
+++ b/docs/superpowers/plans/2026-06-02-plan-b-ai-drafting-agent.md
@@ -1,0 +1,3979 @@
+# Plan B — AI Drafting Agent Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the v1 AI drafting agent as designed in [2026-06-02-plan-b-ai-drafting-agent-design.md](../specs/2026-06-02-plan-b-ai-drafting-agent-design.md). End state: three GitHub Actions workflows that propose, draft, and promote blog posts + YouTube scripts based on Notion ideas and recent commits, with all output reviewed by the user before publishing.
+
+**Architecture:** Three TypeScript scripts under `scripts/agent/` invoked by separate GitHub Actions workflows on cron + manual dispatch. All call the Claude Agent SDK via subscription OAuth (no per-token billing). Notion is HTTP, GitHub PRs are `gh` CLI. No MCP servers spawned in CI. A new `Content` Notion DB replaces the existing `CMS` DB via a one-shot migration script.
+
+**Tech Stack:** Node 22, TypeScript strict, `@anthropic-ai/claude-agent-sdk`, `tsx` (TS runner), Vitest, native `fetch`, `gh` CLI, Vale, Notion HTTP API v2025-09-03, YouTube Data API v3, Hacker News Firebase API.
+
+**Out of scope (deferred to v2):** hero image generation; Notion webhooks (replaces hourly poll); blog→YT derivative direction; podcast/presentation/IG-reel drafting (schema reserves Kind slots but no per-Kind drafting code).
+
+---
+
+## File structure
+
+Files this plan creates or modifies. Use this as the map; each task points to specific paths.
+
+**New files:**
+
+```
+docs/
+  SHORTS-STYLE.md                          # Style guide for YT shorts/long agent
+
+scripts/
+  agent/
+    discover.ts                            # Entry: discovery workflow
+    draft.ts                               # Entry: drafting workflow
+    promote.ts                             # Entry: promotion workflow
+    migrate-cms.ts                         # One-shot CMS → Content migration
+
+    lib/
+      config.ts                            # Env var reader, typed config
+      types.ts                             # Shared types (NotionRow, Candidate, etc.)
+      notion.ts                            # Notion HTTP client + row mapping
+      claude.ts                            # Agent SDK wrapper for OAuth-authed prompts
+      git-scan.ts                          # GH REST scanner for recent commits
+      trending.ts                          # GH trending scrape + HN feed
+      youtube.ts                           # YT Data API client
+      editorial.ts                         # Loads EDITORIAL.md / SHORTS-STYLE.md
+      pr.ts                                # gh CLI wrapper for branch + PR creation
+      validate.ts                          # Frontmatter Zod validator + Vale runner
+      dedupe.ts                            # Title-similarity + Tools-overlap dedupe
+      bucket.ts                            # Re-exports src/lib/buckets resolveBucket
+
+    tests/
+      notion.test.ts                       # Row-mapper unit tests
+      dedupe.test.ts                       # Dedupe rule unit tests
+      validate.test.ts                     # Frontmatter validator tests
+      migrate.test.ts                      # CMS → Content mapping tests
+      bucket.test.ts                       # Bucket resolution from agent output
+
+.github/workflows/
+  agent-discover.yml                       # cron: '0 3 * * 0' + workflow_dispatch
+  agent-draft.yml                          # cron: '0 2 * * *' + workflow_dispatch
+  agent-promote.yml                        # cron: '0 4 * * *' + workflow_dispatch
+
+.env.local.example                         # Template for local dev (gitignored sibling)
+```
+
+**Modified files:**
+
+```
+package.json                               # Add scripts + deps
+src/content.config.ts                      # Export writingSchema standalone for agent reuse
+.gitignore                                 # Add .env.local
+docs/EDITORIAL.md                          # Cross-link to SHORTS-STYLE.md (one-line)
+README.md                                  # Add brief "agent pipeline" section
+CLAUDE.md                                  # Add agent commands + workflow overview
+```
+
+---
+
+## Phases overview
+
+| Phase | What ships                                           | Can pause here?               |
+| ----- | ---------------------------------------------------- | ----------------------------- |
+| 0     | `SHORTS-STYLE.md` doc                                | Yes                           |
+| 1     | Project scaffolding, deps, config module             | Yes                           |
+| 2     | Notion DB hand-creation + migration script + execute | **Yes, big checkpoint**       |
+| 3     | Shared lib modules (notion, claude, sources, etc.)   | Yes                           |
+| 4     | Blog drafting branch end-to-end + smoke              | **Yes — first useful output** |
+| 5     | YT drafting branch + smoke                           | Yes                           |
+| 6     | Discovery workflow + smoke                           | Yes                           |
+| 7     | Promotion workflow + smoke                           | Yes                           |
+| 8     | Cutover: enable crons, update docs                   | Done                          |
+
+Pauseable checkpoints: phase 2 (after migration, before any agent code) and phase 4 (first PR drafted by agent). Each phase ends with a commit and a known-good state.
+
+---
+
+## Phase 0: Style contract
+
+### Task 0.1: Write `docs/SHORTS-STYLE.md`
+
+**Files:**
+
+- Create: `docs/SHORTS-STYLE.md`
+- Modify: `docs/EDITORIAL.md` (add one-line cross-link)
+
+- [ ] **Step 1: Write the new file**
+
+Create `docs/SHORTS-STYLE.md`:
+
+```markdown
+# YouTube shorts / long-form style guide
+
+Rules for AI-generated scripts for the **shariq.dev YouTube channel** (https://www.youtube.com/@ShariqHirani). The drafting agent (Plan B) loads this file verbatim into the system prompt for any row with `Kind` in `[YT short, YT long]`.
+
+If a rule below is wrong or outdated, **update this file** before the next agent run.
+
+---
+
+## Voice
+
+- **First person.** Peer-to-peer, not influencer.
+- **No "what's up guys" / "smash like" / "in this video we'll" openers.** Get straight to the payoff.
+- **Speak like a working engineer**, not a tutorial host. Concrete, opinionated, fast.
+- **Admit gaps.** "Haven't tried X yet" beats fake authority.
+
+## Hook (first 3 seconds)
+
+The hook decides whether anyone watches the rest. It must:
+
+- Promise a concrete payoff in plain language ("here's the one thing that broke for me")
+- Avoid "you won't believe" / "the trick that…" / "no one is talking about…" patterns
+- Be one sentence, ideally under 12 words
+
+**Good:** "Cursor's new agent mode quietly rewrote my git config. Here's what to check."
+
+**Bad:** "AI agents are everywhere, but no one is talking about this scary thing…"
+
+## Length
+
+| Kind     | Target duration | Word count guide |
+| -------- | --------------- | ---------------- |
+| YT short | 50-60 seconds   | 130-170 words    |
+| YT long  | 4-7 minutes     | 600-1100 words   |
+
+Going over kills retention. Going under wastes the spot.
+
+## Script structure (shorts)
+
+1. **Hook** (0-3s) — one sentence
+2. **Setup** (3-15s) — what is the thing / why care
+3. **Payoff** (15-50s) — the demo, the surprise, the take
+4. **Tag** (50-60s) — one-line implication or follow-up question. No "subscribe" CTA in script (channel banner handles it).
+
+## Script structure (long)
+
+1. **Hook + thesis** (0-15s)
+2. **Demo / walk-through** (15s-3m)
+3. **What surprised me / what I'd do differently**
+4. **Where this fits in your stack**
+5. **Tag** — close with a take, not a CTA
+
+## On-screen text
+
+- Used to reinforce key terms, commands, or punchlines — never to repeat what the audio says.
+- Each on-screen text is timestamped, ≤6 words, present-tense.
+
+## B-roll
+
+- For each timestamp, describe what visual should be on screen (screen recording, terminal, IDE, etc.).
+- Avoid stock-footage cues — this channel is screen-cap-heavy.
+
+## Thumbnail prompt
+
+- One sentence describing the image to make.
+- Include: subject, mood (matter-of-fact, not shocked-face), text overlay (≤4 words, sentence case, not all-caps).
+
+## Titles
+
+- 3 variants per video.
+- Each ≤60 chars, sentence case, no clickbait.
+- One should include a tool name; one should describe the outcome; one should be intentionally curiosity-driven without lying.
+
+## Hashtags
+
+- 5-8 per video, lowercase, no spaces.
+- Mix: 2-3 broad (`ai`, `developer`, `programming`), 2-3 tool-specific (`claudecode`, `cursorai`), 1-2 niche (`agenticworkflows`).
+
+## Don't
+
+- Fake reactions ("WAIT, what?!")
+- Reading the README aloud
+- "Here's what I learned" recaps that aren't a take
+- Mentioning competitors uncharitably
+- Talking about Anthropic / OpenAI / Google as personalities
+```
+
+- [ ] **Step 2: Cross-link from EDITORIAL.md**
+
+In `docs/EDITORIAL.md`, find the first paragraph that mentions "the AI drafting agent (Plan B)" and append after it:
+
+```markdown
+For YouTube scripts, the agent loads [`SHORTS-STYLE.md`](./SHORTS-STYLE.md) — same role, different format.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/SHORTS-STYLE.md docs/EDITORIAL.md
+git commit -m "add SHORTS-STYLE.md for YT script generation"
+```
+
+---
+
+## Phase 1: Scaffolding, deps, config
+
+### Task 1.1: Install dependencies
+
+**Files:**
+
+- Modify: `package.json`
+
+- [ ] **Step 1: Install runtime deps**
+
+Run:
+
+```bash
+npm install --save-dev @anthropic-ai/claude-agent-sdk tsx dotenv
+```
+
+Expected: `package.json` `devDependencies` gains `@anthropic-ai/claude-agent-sdk`, `tsx`, `dotenv`. `package-lock.json` updates.
+
+Why dev deps: these only run in agent scripts (not the site build) and we don't ship them with the Astro bundle.
+
+- [ ] **Step 2: Add `gray-matter` if not present**
+
+Check `package.json` for `gray-matter`. If absent:
+
+```bash
+npm install --save-dev gray-matter
+```
+
+- [ ] **Step 3: Commit deps**
+
+```bash
+git add package.json package-lock.json
+git commit -m "add agent runtime deps: @anthropic-ai/claude-agent-sdk, tsx, dotenv, gray-matter"
+```
+
+### Task 1.2: Add npm scripts
+
+**Files:**
+
+- Modify: `package.json`
+
+- [ ] **Step 1: Add scripts**
+
+In `package.json` `"scripts"` block, add (alphabetize with existing):
+
+```json
+"agent:discover": "tsx scripts/agent/discover.ts",
+"agent:draft": "tsx scripts/agent/draft.ts",
+"agent:promote": "tsx scripts/agent/promote.ts",
+"migrate:cms": "tsx scripts/agent/migrate-cms.ts"
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add package.json
+git commit -m "add agent + migration npm scripts"
+```
+
+### Task 1.3: Add `.env.local.example` and update `.gitignore`
+
+**Files:**
+
+- Create: `.env.local.example`
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Create `.env.local.example`**
+
+```bash
+# Claude subscription auth — obtain via `claude setup-token`
+CLAUDE_CODE_OAUTH_TOKEN=
+
+# Notion integration token — create at https://www.notion.so/profile/integrations
+# Share the Content DB with the integration after creating it.
+NOTION_TOKEN=
+
+# YouTube Data API v3 key — create at https://console.cloud.google.com/apis/credentials
+YOUTUBE_API_KEY=
+
+# GitHub PAT for opening agent PRs (local dev only — CI uses AGENT_GH_TOKEN secret)
+# Fine-grained, scope: contents:write + pull-requests:write on this repo.
+AGENT_GH_TOKEN=
+
+# Config (also settable as GH repo variables in CI)
+NOTION_CONTENT_DB_ID=
+YOUTUBE_CHANNEL_ID=
+SCAN_REPO_ORG=shariqh
+SCAN_REPO_INCLUDE=blog-site,lognote
+SCAN_REPO_ACTIVE_DAYS=30
+```
+
+- [ ] **Step 2: Update `.gitignore`**
+
+Append (if not present):
+
+```
+# Agent local env
+.env.local
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .env.local.example .gitignore
+git commit -m "add agent .env.local.example template + gitignore"
+```
+
+### Task 1.4: Write `scripts/agent/lib/config.ts`
+
+**Files:**
+
+- Create: `scripts/agent/lib/config.ts`
+- Test: (none — pure env reader, exercised by every other test)
+
+- [ ] **Step 1: Write the module**
+
+```typescript
+// scripts/agent/lib/config.ts
+import 'dotenv/config'
+
+function required(key: string): string {
+  const val = process.env[key]
+  if (!val) throw new Error(`Missing required env var: ${key}`)
+  return val
+}
+
+function optional(key: string, fallback: string): string {
+  return process.env[key] ?? fallback
+}
+
+export const CONFIG = {
+  claudeOauthToken: required('CLAUDE_CODE_OAUTH_TOKEN'),
+  notionToken: required('NOTION_TOKEN'),
+  notionContentDbId: required('NOTION_CONTENT_DB_ID'),
+  youtubeApiKey: required('YOUTUBE_API_KEY'),
+  youtubeChannelId: required('YOUTUBE_CHANNEL_ID'),
+  agentGhToken: required('AGENT_GH_TOKEN'),
+
+  scanRepoOrg: optional('SCAN_REPO_ORG', 'shariqh'),
+  scanRepoInclude: optional('SCAN_REPO_INCLUDE', 'blog-site,lognote').split(','),
+  scanRepoActiveDays: parseInt(optional('SCAN_REPO_ACTIVE_DAYS', '30'), 10),
+
+  // Set by `npm run migrate:cms` — old DB to read from once before deprecation.
+  notionLegacyCmsDbId: process.env.NOTION_LEGACY_CMS_DB_ID,
+} as const
+
+export type Config = typeof CONFIG
+```
+
+- [ ] **Step 2: Verify it imports**
+
+Run:
+
+```bash
+NOTION_TOKEN=x NOTION_CONTENT_DB_ID=x CLAUDE_CODE_OAUTH_TOKEN=x YOUTUBE_API_KEY=x YOUTUBE_CHANNEL_ID=x AGENT_GH_TOKEN=x npx tsx -e "import('./scripts/agent/lib/config.ts').then(m => console.log(Object.keys(m.CONFIG)))"
+```
+
+Expected: prints the array of config keys.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/agent/lib/config.ts
+git commit -m "add agent config module (env vars with required/optional)"
+```
+
+### Task 1.5: Write `scripts/agent/lib/types.ts`
+
+**Files:**
+
+- Create: `scripts/agent/lib/types.ts`
+- Test: (used by every other test)
+
+- [ ] **Step 1: Write the type definitions**
+
+```typescript
+// scripts/agent/lib/types.ts
+
+export type Kind =
+  | 'blog'
+  | 'YT short'
+  | 'YT long'
+  | 'podcast'
+  | 'presentation'
+  | 'IG reel'
+  | 'stand up'
+
+export type Stage =
+  | 'Idea'
+  | 'Proposed'
+  | 'Ready'
+  | 'Drafted'
+  | 'Recorded'
+  | 'Edited'
+  | 'Published'
+  | 'Abandoned'
+
+export type Origin = 'OC' | 'Agent Proposed' | 'Derivative'
+
+export type CrossPostTarget = 'blog' | 'YT short' | 'YT long'
+
+export interface ContentRow {
+  id: string // Notion page ID
+  title: string
+  kind: Kind
+  stage: Stage
+  origin: Origin
+  sourceRowId?: string
+  crossPostTargets: CrossPostTarget[]
+  tags: string[]
+  tools: string[]
+  hint: string
+  sourceUrls: string[]
+  draftUrl?: string
+  publishedUrl?: string
+  publishingDate?: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface Candidate {
+  title: string
+  hint: string
+  tags?: string[]
+  tools?: string[]
+  sourceUrls: string[]
+  rationale: string
+}
+
+export interface DiscoveryOutput {
+  blogCandidates: Candidate[]
+  ytCandidates: Candidate[]
+}
+
+export interface YTScriptBlocks {
+  hook: string
+  script: string
+  onScreenText: Array<{ timestampSeconds: number; text: string }>
+  bRoll: Array<{ timestampSeconds: number; description: string }>
+  thumbnailPrompt: string
+  titleVariants: string[]
+  hashtags: string[]
+}
+
+export interface CommitInfo {
+  repo: string // e.g. "shariqh/lognote"
+  sha: string
+  message: string
+  date: string
+  filesChanged: string[]
+  url: string
+}
+
+export interface TrendingItem {
+  source: 'gh-trending' | 'hn'
+  title: string
+  url: string
+  hint?: string // e.g. HN score, GH stars-this-week
+}
+
+export interface YouTubeStat {
+  videoId: string
+  title: string
+  views: number
+  likes: number
+  publishedAt: string
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run:
+
+```bash
+npx tsc --noEmit scripts/agent/lib/types.ts
+```
+
+Expected: no output (clean compile).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/agent/lib/types.ts
+git commit -m "add agent shared types"
+```
+
+---
+
+## Phase 2: Notion redesign + migration
+
+### Task 2.1: Hand-create the `Content` Notion DB
+
+**This is a manual user action.** Pause for the user to do this before any agent code runs.
+
+- [ ] **Step 1: Create the DB**
+
+In Notion:
+
+1. Open your workspace, click `+ New Page`
+2. Select `Database — Full page`
+3. Title it `Content`
+4. Delete the default Name property → keep `Title` (Notion forces a title field; rename if needed)
+
+- [ ] **Step 2: Add properties in this exact order with these exact options**
+
+| Property             | Type         | Options                                                                                |
+| -------------------- | ------------ | -------------------------------------------------------------------------------------- |
+| `Kind`               | Select       | `blog`, `YT short`, `YT long`, `podcast`, `presentation`, `IG reel`, `stand up`        |
+| `Stage`              | Select       | `Idea`, `Proposed`, `Ready`, `Drafted`, `Recorded`, `Edited`, `Published`, `Abandoned` |
+| `Origin`             | Select       | `OC`, `Agent Proposed`, `Derivative`                                                   |
+| `Source Row`         | Relation     | Target: this same `Content` DB. Show on related: yes. Limit: 1.                        |
+| `Cross-post Targets` | Multi-select | `blog`, `YT short`, `YT long`                                                          |
+| `Tags`               | Multi-select | (leave empty — agent + you add over time)                                              |
+| `Tools`              | Multi-select | (leave empty)                                                                          |
+| `Hint`               | Text         |                                                                                        |
+| `Source URLs`        | Text         |                                                                                        |
+| `Draft URL`          | URL          |                                                                                        |
+| `Published URL`      | URL          |                                                                                        |
+| `Publishing`         | Date         |                                                                                        |
+
+Notion adds `Created` and `Updated` automatically. Don't add `Created time` / `Last edited time` manually.
+
+- [ ] **Step 3: Share with Claude Code MCP integration**
+
+Top-right `...` → `Connections` → add `Claude Code MCP`. Same integration you connected to the legacy CMS DB.
+
+- [ ] **Step 4: Copy DB ID for env config**
+
+Copy the URL of the Content DB page. The DB ID is the 32-char hex segment before `?v=`. Example: `https://www.notion.so/<DB_ID>?v=...`
+
+Add to your local `.env.local`:
+
+```
+NOTION_CONTENT_DB_ID=<that-id>
+```
+
+Also set in GitHub repo variables (next phase will use it; can do now or later):
+
+```bash
+gh variable set NOTION_CONTENT_DB_ID --body "<that-id>"
+```
+
+- [ ] **Step 5: Note legacy CMS DB ID**
+
+In `.env.local` add:
+
+```
+NOTION_LEGACY_CMS_DB_ID=d25e9f1c0a3345589592fce32f7bc02b
+```
+
+This is only used by the migration script.
+
+### Task 2.2: TDD `scripts/agent/lib/dedupe.ts`
+
+**Files:**
+
+- Create: `scripts/agent/lib/dedupe.ts`
+- Test: `scripts/agent/tests/dedupe.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// scripts/agent/tests/dedupe.test.ts
+import { describe, it, expect } from 'vitest'
+import { isTitleDuplicate, hasFullToolsOverlap } from '../lib/dedupe'
+
+describe('isTitleDuplicate', () => {
+  it('treats identical titles as duplicates', () => {
+    expect(isTitleDuplicate('Claude Code agents in CI', ['Claude Code agents in CI'])).toBe(true)
+  })
+
+  it('treats titles differing only by case as duplicates', () => {
+    expect(isTitleDuplicate('claude code agents in ci', ['Claude Code agents in CI'])).toBe(true)
+  })
+
+  it('treats near-identical titles (>80% similar) as duplicates', () => {
+    expect(
+      isTitleDuplicate('Claude Code agents in CI workflows', ['Claude Code agents in CI'])
+    ).toBe(true)
+  })
+
+  it('does not flag unrelated titles', () => {
+    expect(isTitleDuplicate('A totally different post', ['Claude Code agents in CI'])).toBe(false)
+  })
+
+  it('returns false for empty existing list', () => {
+    expect(isTitleDuplicate('Anything', [])).toBe(false)
+  })
+})
+
+describe('hasFullToolsOverlap', () => {
+  it('returns true when all proposed tools are covered', () => {
+    expect(hasFullToolsOverlap(['claude-code'], [['claude-code', 'cursor']])).toBe(true)
+  })
+
+  it('returns true when proposed tools are subset of any one row', () => {
+    expect(
+      hasFullToolsOverlap(['claude-code', 'cursor'], [['claude-code', 'cursor', 'gemini']])
+    ).toBe(true)
+  })
+
+  it('returns false when proposed tools partially covered across multiple rows', () => {
+    expect(hasFullToolsOverlap(['claude-code', 'cursor'], [['claude-code'], ['cursor']])).toBe(
+      false
+    )
+  })
+
+  it('returns false for empty proposed tools', () => {
+    expect(hasFullToolsOverlap([], [['claude-code']])).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run:
+
+```bash
+npx vitest run scripts/agent/tests/dedupe.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `dedupe.ts`**
+
+```typescript
+// scripts/agent/lib/dedupe.ts
+
+function levenshtein(a: string, b: string): number {
+  const m = a.length
+  const n = b.length
+  if (m === 0) return n
+  if (n === 0) return m
+  const dp = Array.from({ length: m + 1 }, () => new Array<number>(n + 1).fill(0))
+  for (let i = 0; i <= m; i++) dp[i][0] = i
+  for (let j = 0; j <= n; j++) dp[0][j] = j
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1
+      dp[i][j] = Math.min(dp[i - 1][j] + 1, dp[i][j - 1] + 1, dp[i - 1][j - 1] + cost)
+    }
+  }
+  return dp[m][n]
+}
+
+function normalize(s: string): string {
+  return s.trim().toLowerCase().replace(/\s+/g, ' ')
+}
+
+/**
+ * Returns true if `candidate` is within 20% normalized edit distance of any
+ * title in `existing`. Used to skip re-proposing similar candidates.
+ */
+export function isTitleDuplicate(candidate: string, existing: string[]): boolean {
+  if (existing.length === 0) return false
+  const cand = normalize(candidate)
+  for (const ex of existing) {
+    const a = cand
+    const b = normalize(ex)
+    const maxLen = Math.max(a.length, b.length)
+    if (maxLen === 0) continue
+    const ratio = levenshtein(a, b) / maxLen
+    if (ratio <= 0.2) return true
+  }
+  return false
+}
+
+/**
+ * Returns true if every tool in `proposed` is contained in at least one row's
+ * tool list in `existingRows`. (One row must cover the whole proposed set.)
+ */
+export function hasFullToolsOverlap(proposed: string[], existingRows: string[][]): boolean {
+  if (proposed.length === 0) return false
+  const propSet = new Set(proposed.map((t) => t.toLowerCase()))
+  for (const row of existingRows) {
+    const rowSet = new Set(row.map((t) => t.toLowerCase()))
+    let allIn = true
+    for (const t of propSet) {
+      if (!rowSet.has(t)) {
+        allIn = false
+        break
+      }
+    }
+    if (allIn) return true
+  }
+  return false
+}
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+```bash
+npx vitest run scripts/agent/tests/dedupe.test.ts
+```
+
+Expected: PASS — all 9 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/agent/lib/dedupe.ts scripts/agent/tests/dedupe.test.ts
+git commit -m "add dedupe lib: title similarity + tools overlap"
+```
+
+### Task 2.3: Write Notion HTTP client (`scripts/agent/lib/notion.ts`)
+
+**Files:**
+
+- Create: `scripts/agent/lib/notion.ts`
+- Test: `scripts/agent/tests/notion.test.ts`
+
+Test focuses on the pure row-mapping function (no network). The HTTP wrappers are exercised in integration tests later.
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// scripts/agent/tests/notion.test.ts
+import { describe, it, expect } from 'vitest'
+import { pageToContentRow } from '../lib/notion'
+
+const samplePage = {
+  id: '2467cc75-7fe9-8052-b08e-e9327ac7fbf1',
+  created_time: '2025-08-05T10:32:00.000Z',
+  last_edited_time: '2025-08-12T16:36:00.000Z',
+  properties: {
+    Title: { type: 'title', title: [{ plain_text: 'A test row' }] },
+    Kind: { type: 'select', select: { name: 'blog' } },
+    Stage: { type: 'select', select: { name: 'Proposed' } },
+    Origin: { type: 'select', select: { name: 'Agent Proposed' } },
+    'Source Row': { type: 'relation', relation: [] },
+    'Cross-post Targets': {
+      type: 'multi_select',
+      multi_select: [{ name: 'YT short' }],
+    },
+    Tags: { type: 'multi_select', multi_select: [{ name: 'ai' }, { name: 'cli' }] },
+    Tools: { type: 'multi_select', multi_select: [{ name: 'claude-code' }] },
+    Hint: { type: 'rich_text', rich_text: [{ plain_text: 'a one-line angle' }] },
+    'Source URLs': { type: 'rich_text', rich_text: [{ plain_text: 'https://example.com' }] },
+    'Draft URL': { type: 'url', url: null },
+    'Published URL': { type: 'url', url: 'https://shariq.dev/blog/x' },
+    Publishing: { type: 'date', date: { start: '2026-06-10' } },
+  },
+}
+
+describe('pageToContentRow', () => {
+  it('maps a fully-populated page to a ContentRow', () => {
+    const row = pageToContentRow(samplePage as never)
+    expect(row.title).toBe('A test row')
+    expect(row.kind).toBe('blog')
+    expect(row.stage).toBe('Proposed')
+    expect(row.origin).toBe('Agent Proposed')
+    expect(row.crossPostTargets).toEqual(['YT short'])
+    expect(row.tags).toEqual(['ai', 'cli'])
+    expect(row.tools).toEqual(['claude-code'])
+    expect(row.hint).toBe('a one-line angle')
+    expect(row.sourceUrls).toEqual(['https://example.com'])
+    expect(row.draftUrl).toBeUndefined()
+    expect(row.publishedUrl).toBe('https://shariq.dev/blog/x')
+    expect(row.publishingDate).toBe('2026-06-10')
+  })
+
+  it('handles empty Source URLs as empty array', () => {
+    const empty = {
+      ...samplePage,
+      properties: {
+        ...samplePage.properties,
+        'Source URLs': { type: 'rich_text', rich_text: [] },
+      },
+    }
+    expect(pageToContentRow(empty as never).sourceUrls).toEqual([])
+  })
+
+  it('splits comma-or-newline-separated Source URLs', () => {
+    const multi = {
+      ...samplePage,
+      properties: {
+        ...samplePage.properties,
+        'Source URLs': {
+          type: 'rich_text',
+          rich_text: [{ plain_text: 'https://a.com\nhttps://b.com' }],
+        },
+      },
+    }
+    expect(pageToContentRow(multi as never).sourceUrls).toEqual(['https://a.com', 'https://b.com'])
+  })
+
+  it('returns sourceRowId when relation has an entry', () => {
+    const withRel = {
+      ...samplePage,
+      properties: {
+        ...samplePage.properties,
+        'Source Row': { type: 'relation', relation: [{ id: 'abc123' }] },
+      },
+    }
+    expect(pageToContentRow(withRel as never).sourceRowId).toBe('abc123')
+  })
+})
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+```bash
+npx vitest run scripts/agent/tests/notion.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `notion.ts`**
+
+```typescript
+// scripts/agent/lib/notion.ts
+import { CONFIG } from './config'
+import type { ContentRow, Kind, Stage, Origin, CrossPostTarget } from './types'
+
+const BASE = 'https://api.notion.com/v1'
+const VERSION = '2025-09-03'
+
+function headers(extra: Record<string, string> = {}): Record<string, string> {
+  return {
+    Authorization: `Bearer ${CONFIG.notionToken}`,
+    'Notion-Version': VERSION,
+    'Content-Type': 'application/json',
+    ...extra,
+  }
+}
+
+async function fetchJson(path: string, init?: RequestInit): Promise<unknown> {
+  const res = await fetch(`${BASE}${path}`, {
+    ...init,
+    headers: { ...headers(), ...(init?.headers ?? {}) },
+  })
+  if (!res.ok) {
+    const body = await res.text()
+    throw new Error(`Notion ${init?.method ?? 'GET'} ${path} ${res.status}: ${body}`)
+  }
+  return res.json()
+}
+
+// ---------- Row mapping ----------
+
+type AnyProp = { type: string; [k: string]: unknown }
+type NotionPage = {
+  id: string
+  created_time: string
+  last_edited_time: string
+  properties: Record<string, AnyProp>
+}
+
+function textOf(prop: AnyProp | undefined): string {
+  if (!prop) return ''
+  if (prop.type === 'title') {
+    return ((prop as { title: Array<{ plain_text: string }> }).title ?? [])
+      .map((t) => t.plain_text)
+      .join('')
+  }
+  if (prop.type === 'rich_text') {
+    return ((prop as { rich_text: Array<{ plain_text: string }> }).rich_text ?? [])
+      .map((t) => t.plain_text)
+      .join('')
+  }
+  return ''
+}
+
+function selectName<T extends string>(prop: AnyProp | undefined): T | undefined {
+  if (!prop || prop.type !== 'select') return undefined
+  const sel = (prop as { select: { name: string } | null }).select
+  return sel ? (sel.name as T) : undefined
+}
+
+function multiSelectNames<T extends string>(prop: AnyProp | undefined): T[] {
+  if (!prop || prop.type !== 'multi_select') return []
+  return ((prop as { multi_select: Array<{ name: string }> }).multi_select ?? []).map(
+    (m) => m.name as T
+  )
+}
+
+function urlOf(prop: AnyProp | undefined): string | undefined {
+  if (!prop || prop.type !== 'url') return undefined
+  const v = (prop as { url: string | null }).url
+  return v ?? undefined
+}
+
+function dateStartOf(prop: AnyProp | undefined): string | undefined {
+  if (!prop || prop.type !== 'date') return undefined
+  return (prop as { date: { start: string } | null }).date?.start
+}
+
+function relationFirstId(prop: AnyProp | undefined): string | undefined {
+  if (!prop || prop.type !== 'relation') return undefined
+  const rel = (prop as { relation: Array<{ id: string }> }).relation
+  return rel?.[0]?.id
+}
+
+export function pageToContentRow(page: NotionPage): ContentRow {
+  const p = page.properties
+  const sourceUrlsRaw = textOf(p['Source URLs']).trim()
+  const sourceUrls = sourceUrlsRaw
+    ? sourceUrlsRaw
+        .split(/[\n,]+/)
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0)
+    : []
+  return {
+    id: page.id,
+    title: textOf(p['Title']),
+    kind: (selectName<Kind>(p['Kind']) ?? 'blog') as Kind,
+    stage: (selectName<Stage>(p['Stage']) ?? 'Idea') as Stage,
+    origin: (selectName<Origin>(p['Origin']) ?? 'OC') as Origin,
+    sourceRowId: relationFirstId(p['Source Row']),
+    crossPostTargets: multiSelectNames<CrossPostTarget>(p['Cross-post Targets']),
+    tags: multiSelectNames<string>(p['Tags']),
+    tools: multiSelectNames<string>(p['Tools']),
+    hint: textOf(p['Hint']),
+    sourceUrls,
+    draftUrl: urlOf(p['Draft URL']),
+    publishedUrl: urlOf(p['Published URL']),
+    publishingDate: dateStartOf(p['Publishing']),
+    createdAt: page.created_time,
+    updatedAt: page.last_edited_time,
+  }
+}
+
+// ---------- Public DB ops ----------
+
+export async function queryContentRows(filter: object, sorts?: object[]): Promise<ContentRow[]> {
+  const dataSourceId = await getDataSourceIdForDb(CONFIG.notionContentDbId)
+  const rows: ContentRow[] = []
+  let cursor: string | undefined
+  do {
+    const body = JSON.stringify({ filter, sorts, start_cursor: cursor, page_size: 100 })
+    const data = (await fetchJson(`/data_sources/${dataSourceId}/query`, {
+      method: 'POST',
+      body,
+    })) as { results: NotionPage[]; has_more: boolean; next_cursor?: string }
+    rows.push(...data.results.map(pageToContentRow))
+    cursor = data.has_more ? data.next_cursor : undefined
+  } while (cursor)
+  return rows
+}
+
+async function getDataSourceIdForDb(dbId: string): Promise<string> {
+  const db = (await fetchJson(`/databases/${dbId}`)) as {
+    data_sources: Array<{ id: string }>
+  }
+  const ds = db.data_sources?.[0]
+  if (!ds) throw new Error(`No data source for DB ${dbId}`)
+  return ds.id
+}
+
+export interface CreateRowInput {
+  title: string
+  kind: Kind
+  stage: Stage
+  origin: Origin
+  crossPostTargets?: CrossPostTarget[]
+  tags?: string[]
+  tools?: string[]
+  hint?: string
+  sourceUrls?: string[]
+  draftUrl?: string
+  publishedUrl?: string
+  sourceRowId?: string
+  publishingDate?: string
+}
+
+export async function createContentRow(input: CreateRowInput): Promise<string> {
+  const dataSourceId = await getDataSourceIdForDb(CONFIG.notionContentDbId)
+  const body = {
+    parent: { type: 'data_source_id', data_source_id: dataSourceId },
+    properties: buildPropertiesPayload(input),
+  }
+  const data = (await fetchJson('/pages', { method: 'POST', body: JSON.stringify(body) })) as {
+    id: string
+  }
+  return data.id
+}
+
+export async function updateContentRow(
+  pageId: string,
+  patch: Partial<CreateRowInput>
+): Promise<void> {
+  const body = { properties: buildPropertiesPayload(patch) }
+  await fetchJson(`/pages/${pageId}`, { method: 'PATCH', body: JSON.stringify(body) })
+}
+
+function buildPropertiesPayload(input: Partial<CreateRowInput>): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  if (input.title !== undefined)
+    out['Title'] = { title: [{ type: 'text', text: { content: input.title } }] }
+  if (input.kind !== undefined) out['Kind'] = { select: { name: input.kind } }
+  if (input.stage !== undefined) out['Stage'] = { select: { name: input.stage } }
+  if (input.origin !== undefined) out['Origin'] = { select: { name: input.origin } }
+  if (input.crossPostTargets !== undefined)
+    out['Cross-post Targets'] = {
+      multi_select: input.crossPostTargets.map((n) => ({ name: n })),
+    }
+  if (input.tags !== undefined) out['Tags'] = { multi_select: input.tags.map((n) => ({ name: n })) }
+  if (input.tools !== undefined)
+    out['Tools'] = { multi_select: input.tools.map((n) => ({ name: n })) }
+  if (input.hint !== undefined)
+    out['Hint'] = { rich_text: [{ type: 'text', text: { content: input.hint } }] }
+  if (input.sourceUrls !== undefined)
+    out['Source URLs'] = {
+      rich_text: [{ type: 'text', text: { content: input.sourceUrls.join('\n') } }],
+    }
+  if (input.draftUrl !== undefined) out['Draft URL'] = { url: input.draftUrl }
+  if (input.publishedUrl !== undefined) out['Published URL'] = { url: input.publishedUrl }
+  if (input.sourceRowId !== undefined) out['Source Row'] = { relation: [{ id: input.sourceRowId }] }
+  if (input.publishingDate !== undefined)
+    out['Publishing'] = { date: { start: input.publishingDate } }
+  return out
+}
+
+export async function appendBlocks(pageId: string, blocks: unknown[]): Promise<void> {
+  await fetchJson(`/blocks/${pageId}/children`, {
+    method: 'PATCH',
+    body: JSON.stringify({ children: blocks }),
+  })
+}
+
+export async function replacePageBody(pageId: string, blocks: unknown[]): Promise<void> {
+  // Fetch existing children and archive each, then append new.
+  const existing = (await fetchJson(`/blocks/${pageId}/children?page_size=100`)) as {
+    results: Array<{ id: string }>
+  }
+  for (const child of existing.results) {
+    await fetchJson(`/blocks/${child.id}`, {
+      method: 'DELETE',
+    })
+  }
+  if (blocks.length > 0) await appendBlocks(pageId, blocks)
+}
+
+export async function addPageComment(pageId: string, text: string): Promise<void> {
+  const body = {
+    parent: { page_id: pageId },
+    rich_text: [{ type: 'text', text: { content: text } }],
+  }
+  await fetchJson('/comments', { method: 'POST', body: JSON.stringify(body) })
+}
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+```bash
+npx vitest run scripts/agent/tests/notion.test.ts
+```
+
+Expected: PASS — all 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/agent/lib/notion.ts scripts/agent/tests/notion.test.ts
+git commit -m "add Notion HTTP client + row mapper"
+```
+
+### Task 2.4: TDD CMS-to-Content row mapper
+
+**Files:**
+
+- Create: `scripts/agent/tests/migrate.test.ts`
+- Modify: `scripts/agent/lib/types.ts` (add `CmsRow` type)
+- Create: `scripts/agent/lib/migrate-mapping.ts` (pure logic, no I/O)
+
+- [ ] **Step 1: Add `CmsRow` type to `lib/types.ts`**
+
+Append to `scripts/agent/lib/types.ts`:
+
+```typescript
+export type LegacyStatus =
+  | 'Prepping'
+  | 'Ready To Record'
+  | 'Recording'
+  | 'Post-Processing'
+  | 'Published'
+  | 'Abandoned'
+  | '✅'
+
+export type LegacyMedium =
+  | 'blog'
+  | 'youtube'
+  | 'YT short'
+  | 'podcast'
+  | 'presentation'
+  | 'IG reel'
+  | 'stand up'
+
+export type LegacyOrigin = 'OC' | 'x-post:bundle' | 'x-post:blog'
+
+export interface CmsRow {
+  id: string
+  title: string
+  status?: LegacyStatus
+  medium: LegacyMedium[]
+  origin?: LegacyOrigin
+  tags: string[]
+  type?: string
+  keywords: string
+  sources: string
+  publishedLink?: string
+  publishing?: string
+  no?: number
+}
+
+export interface MappedRow {
+  // The new row's intended properties (no ID — caller assigns)
+  title: string
+  kind: Kind
+  stage: Stage
+  origin: Origin
+  crossPostTargets: CrossPostTarget[]
+  tags: string[]
+  tools: string[]
+  hint: string
+  sourceUrls: string[]
+  publishedUrl?: string
+  publishingDate?: string
+  // Bookkeeping for derivatives:
+  // If the row was split, the first piece keeps the original Notion page ID
+  // and this is null. The subsequent piece(s) are NEW rows; this points at
+  // the original page ID to install as Source Row after creation.
+  sourceRowOriginalPageId?: string
+}
+
+export interface MigrationReport {
+  totalInputRows: number
+  rowsKept: number
+  rowsSplit: number
+  newRowsCreated: number
+  abandoned: number
+  unresolvedXPostBlog: string[] // titles where Source Row couldn't be matched
+}
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+```typescript
+// scripts/agent/tests/migrate.test.ts
+import { describe, it, expect } from 'vitest'
+import { mapCmsRowToContentRows, statusToStage, mediumToKind } from '../lib/migrate-mapping'
+import type { CmsRow } from '../lib/types'
+
+const baseRow: CmsRow = {
+  id: 'orig-page-1',
+  title: 'Sample',
+  status: 'Prepping',
+  medium: ['blog'],
+  origin: 'OC',
+  tags: ['ai'],
+  keywords: '',
+  sources: '',
+}
+
+describe('statusToStage', () => {
+  it('maps each legacy status', () => {
+    expect(statusToStage('Prepping')).toBe('Idea')
+    expect(statusToStage('Ready To Record')).toBe('Ready')
+    expect(statusToStage('Recording')).toBe('Recorded')
+    expect(statusToStage('Post-Processing')).toBe('Edited')
+    expect(statusToStage('Published')).toBe('Published')
+    expect(statusToStage('✅')).toBe('Published')
+    expect(statusToStage('Abandoned')).toBe('Abandoned')
+    expect(statusToStage(undefined)).toBe('Idea')
+  })
+})
+
+describe('mediumToKind', () => {
+  it('maps youtube to YT short by default', () => {
+    expect(mediumToKind('youtube')).toBe('YT short')
+  })
+  it('preserves explicit kinds', () => {
+    expect(mediumToKind('YT short')).toBe('YT short')
+    expect(mediumToKind('blog')).toBe('blog')
+    expect(mediumToKind('podcast')).toBe('podcast')
+  })
+})
+
+describe('mapCmsRowToContentRows', () => {
+  it('produces one row when medium has a single entry', () => {
+    const out = mapCmsRowToContentRows(baseRow)
+    expect(out).toHaveLength(1)
+    expect(out[0].kind).toBe('blog')
+    expect(out[0].stage).toBe('Idea')
+    expect(out[0].origin).toBe('OC')
+    expect(out[0].sourceRowOriginalPageId).toBeUndefined() // first piece keeps original ID
+  })
+
+  it('splits multi-medium rows into one row per kind, linking subsequents to first via sourceRowOriginalPageId', () => {
+    const row: CmsRow = { ...baseRow, medium: ['blog', 'YT short'] }
+    const out = mapCmsRowToContentRows(row)
+    expect(out).toHaveLength(2)
+    expect(out[0].kind).toBe('blog')
+    expect(out[0].origin).toBe('OC')
+    expect(out[0].crossPostTargets).toEqual(['YT short'])
+    expect(out[1].kind).toBe('YT short')
+    expect(out[1].origin).toBe('Derivative')
+    expect(out[1].sourceRowOriginalPageId).toBe('orig-page-1')
+  })
+
+  it('maps x-post:bundle origin to OC + populates Cross-post Targets from other media', () => {
+    const row: CmsRow = { ...baseRow, origin: 'x-post:bundle', medium: ['blog', 'YT short'] }
+    const out = mapCmsRowToContentRows(row)
+    expect(out[0].origin).toBe('OC')
+    expect(out[0].crossPostTargets).toEqual(['YT short'])
+  })
+
+  it('maps x-post:blog origin to Derivative', () => {
+    const row: CmsRow = { ...baseRow, origin: 'x-post:blog' }
+    const out = mapCmsRowToContentRows(row)
+    expect(out[0].origin).toBe('Derivative')
+  })
+
+  it('appends Keywords to Hint when both present', () => {
+    const row: CmsRow = { ...baseRow, keywords: 'tdd, claude' }
+    expect(mapCmsRowToContentRows(row)[0].hint).toContain('tdd, claude')
+  })
+
+  it('splits Source(s) on commas and newlines', () => {
+    const row: CmsRow = { ...baseRow, sources: 'https://a.com,\nhttps://b.com' }
+    expect(mapCmsRowToContentRows(row)[0].sourceUrls).toEqual(['https://a.com', 'https://b.com'])
+  })
+
+  it('carries Published Link through to Published URL', () => {
+    const row: CmsRow = { ...baseRow, publishedLink: 'https://example.com' }
+    expect(mapCmsRowToContentRows(row)[0].publishedUrl).toBe('https://example.com')
+  })
+})
+```
+
+- [ ] **Step 3: Run tests, verify they fail**
+
+```bash
+npx vitest run scripts/agent/tests/migrate.test.ts
+```
+
+Expected: FAIL — `migrate-mapping` not found.
+
+- [ ] **Step 4: Implement `migrate-mapping.ts`**
+
+```typescript
+// scripts/agent/lib/migrate-mapping.ts
+import type {
+  CmsRow,
+  Kind,
+  Stage,
+  Origin,
+  CrossPostTarget,
+  LegacyStatus,
+  LegacyMedium,
+  MappedRow,
+} from './types'
+
+const STATUS_MAP: Record<LegacyStatus, Stage> = {
+  Prepping: 'Idea',
+  'Ready To Record': 'Ready',
+  Recording: 'Recorded',
+  'Post-Processing': 'Edited',
+  Published: 'Published',
+  Abandoned: 'Abandoned',
+  '✅': 'Published',
+}
+
+const MEDIUM_TO_KIND: Record<LegacyMedium, Kind> = {
+  blog: 'blog',
+  youtube: 'YT short', // default YouTube to short; user can adjust
+  'YT short': 'YT short',
+  podcast: 'podcast',
+  presentation: 'presentation',
+  'IG reel': 'IG reel',
+  'stand up': 'stand up',
+}
+
+export function statusToStage(s?: LegacyStatus): Stage {
+  if (!s) return 'Idea'
+  return STATUS_MAP[s] ?? 'Idea'
+}
+
+export function mediumToKind(m: LegacyMedium): Kind {
+  return MEDIUM_TO_KIND[m] ?? 'blog'
+}
+
+function splitSources(s: string): string[] {
+  if (!s) return []
+  return s
+    .split(/[\n,]+/)
+    .map((x) => x.trim())
+    .filter((x) => x.length > 0)
+}
+
+function buildHint(row: CmsRow): string {
+  const parts: string[] = []
+  if (row.keywords) parts.push(row.keywords.trim())
+  return parts.join(' · ')
+}
+
+function isCrossPostTarget(k: Kind): k is CrossPostTarget {
+  return k === 'blog' || k === 'YT short' || k === 'YT long'
+}
+
+export function mapCmsRowToContentRows(row: CmsRow): MappedRow[] {
+  const mediums = row.medium.length > 0 ? row.medium : (['blog'] as LegacyMedium[])
+  const kinds = mediums.map(mediumToKind)
+  const stage = statusToStage(row.status)
+  const hint = buildHint(row)
+  const sourceUrls = splitSources(row.sources)
+  const baseOrigin: Origin = row.origin === 'x-post:blog' ? 'Derivative' : 'OC'
+
+  // x-post:bundle → primary row's Cross-post Targets gets the *other* kinds
+  // When splitting multi-medium without bundle, the primary still gets Cross-post Targets
+  // so the future agent run can recognize the relationship.
+  const crossPostsForPrimary: CrossPostTarget[] = kinds.slice(1).filter(isCrossPostTarget)
+
+  const primary: MappedRow = {
+    title: row.title,
+    kind: kinds[0],
+    stage,
+    origin: baseOrigin,
+    crossPostTargets: crossPostsForPrimary,
+    tags: row.tags,
+    tools: [],
+    hint,
+    sourceUrls,
+    publishedUrl: row.publishedLink || undefined,
+    publishingDate: row.publishing,
+    // primary keeps the original Notion page ID — no source row marker needed
+  }
+
+  const derivatives: MappedRow[] = kinds.slice(1).map((k) => ({
+    title: row.title,
+    kind: k,
+    stage,
+    origin: 'Derivative' as Origin,
+    crossPostTargets: [],
+    tags: row.tags,
+    tools: [],
+    hint,
+    sourceUrls,
+    publishingDate: row.publishing,
+    sourceRowOriginalPageId: row.id,
+  }))
+
+  return [primary, ...derivatives]
+}
+```
+
+- [ ] **Step 5: Run tests, verify they pass**
+
+```bash
+npx vitest run scripts/agent/tests/migrate.test.ts
+```
+
+Expected: PASS — all 11 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/agent/lib/migrate-mapping.ts scripts/agent/lib/types.ts scripts/agent/tests/migrate.test.ts
+git commit -m "add CMS-to-Content row mapping with tests"
+```
+
+### Task 2.5: Write `migrate-cms.ts` (dry-run mode)
+
+**Files:**
+
+- Create: `scripts/agent/migrate-cms.ts`
+
+- [ ] **Step 1: Write the script**
+
+```typescript
+// scripts/agent/migrate-cms.ts
+import { CONFIG } from './lib/config'
+import { mapCmsRowToContentRows } from './lib/migrate-mapping'
+import { createContentRow } from './lib/notion'
+import type { CmsRow, MappedRow, LegacyMedium, LegacyStatus, LegacyOrigin } from './lib/types'
+
+const DRY_RUN = process.argv.includes('--dry-run')
+const EXECUTE = process.argv.includes('--execute')
+
+if (!DRY_RUN && !EXECUTE) {
+  console.error('Usage: npm run migrate:cms -- (--dry-run | --execute)')
+  process.exit(1)
+}
+
+const NOTION_VERSION = '2025-09-03'
+
+async function fetchLegacyCmsRows(legacyDbId: string): Promise<CmsRow[]> {
+  // Get data source for legacy DB
+  const dbRes = await fetch(`https://api.notion.com/v1/databases/${legacyDbId}`, {
+    headers: {
+      Authorization: `Bearer ${CONFIG.notionToken}`,
+      'Notion-Version': NOTION_VERSION,
+    },
+  })
+  if (!dbRes.ok) throw new Error(`Failed to fetch legacy DB: ${dbRes.status}`)
+  const db = (await dbRes.json()) as { data_sources: Array<{ id: string }> }
+  const ds = db.data_sources[0]?.id
+  if (!ds) throw new Error('No data source on legacy CMS DB')
+
+  const rows: CmsRow[] = []
+  let cursor: string | undefined
+  do {
+    const body = JSON.stringify({ start_cursor: cursor, page_size: 100 })
+    const res = await fetch(`https://api.notion.com/v1/data_sources/${ds}/query`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${CONFIG.notionToken}`,
+        'Notion-Version': NOTION_VERSION,
+        'Content-Type': 'application/json',
+      },
+      body,
+    })
+    if (!res.ok) throw new Error(`Legacy query failed: ${res.status} ${await res.text()}`)
+    const data = (await res.json()) as {
+      results: Array<{ id: string; properties: Record<string, unknown> }>
+      has_more: boolean
+      next_cursor?: string
+    }
+    for (const p of data.results) {
+      rows.push(extractCmsRow(p))
+    }
+    cursor = data.has_more ? data.next_cursor : undefined
+  } while (cursor)
+  return rows
+}
+
+function extractCmsRow(page: { id: string; properties: Record<string, unknown> }): CmsRow {
+  const p = page.properties as Record<string, { type: string; [k: string]: unknown }>
+  const text = (prop: { type: string; [k: string]: unknown } | undefined): string => {
+    if (!prop) return ''
+    if (prop.type === 'title')
+      return ((prop as { title: Array<{ plain_text: string }> }).title ?? [])
+        .map((t) => t.plain_text)
+        .join('')
+    if (prop.type === 'rich_text')
+      return ((prop as { rich_text: Array<{ plain_text: string }> }).rich_text ?? [])
+        .map((t) => t.plain_text)
+        .join('')
+    return ''
+  }
+  const select = <T extends string>(
+    prop: { type: string; [k: string]: unknown } | undefined
+  ): T | undefined => {
+    if (!prop || prop.type !== 'select') return undefined
+    const sel = (prop as { select: { name: string } | null }).select
+    return sel ? (sel.name as T) : undefined
+  }
+  const multi = <T extends string>(
+    prop: { type: string; [k: string]: unknown } | undefined
+  ): T[] => {
+    if (!prop || prop.type !== 'multi_select') return []
+    return ((prop as { multi_select: Array<{ name: string }> }).multi_select ?? []).map(
+      (m) => m.name as T
+    )
+  }
+  const url = (prop: { type: string; [k: string]: unknown } | undefined): string | undefined => {
+    if (!prop || prop.type !== 'url') return undefined
+    return (prop as { url: string | null }).url ?? undefined
+  }
+  const date = (prop: { type: string; [k: string]: unknown } | undefined): string | undefined => {
+    if (!prop || prop.type !== 'date') return undefined
+    return (prop as { date: { start: string } | null }).date?.start
+  }
+  const num = (prop: { type: string; [k: string]: unknown } | undefined): number | undefined => {
+    if (!prop || prop.type !== 'number') return undefined
+    return (prop as { number: number | null }).number ?? undefined
+  }
+  return {
+    id: page.id,
+    title: text(p['Title']),
+    status: select<LegacyStatus>(p['Status']),
+    medium: multi<LegacyMedium>(p['Medium']),
+    origin: select<LegacyOrigin>(p['Origin']),
+    tags: multi<string>(p['Tags']),
+    type: select<string>(p['Type']),
+    keywords: text(p['Keywords']),
+    sources: text(p['Source(s)']),
+    publishedLink: url(p['Published Link']),
+    publishing: date(p['Publishing']),
+    no: num(p['No.']),
+  }
+}
+
+async function main(): Promise<void> {
+  const legacyId = CONFIG.notionLegacyCmsDbId
+  if (!legacyId) {
+    console.error('Set NOTION_LEGACY_CMS_DB_ID in .env.local')
+    process.exit(1)
+  }
+  console.log(`Fetching legacy CMS rows from ${legacyId}...`)
+  const rows = await fetchLegacyCmsRows(legacyId)
+  console.log(`Fetched ${rows.length} legacy rows.`)
+
+  const mapped: Array<{ source: CmsRow; out: MappedRow[] }> = rows.map((r) => ({
+    source: r,
+    out: mapCmsRowToContentRows(r),
+  }))
+
+  // Report
+  const splits = mapped.filter((m) => m.out.length > 1)
+  const totalOutRows = mapped.reduce((s, m) => s + m.out.length, 0)
+
+  console.log('\n=== Migration report ===')
+  console.log(`Input rows:      ${rows.length}`)
+  console.log(`Output rows:     ${totalOutRows}`)
+  console.log(`Rows being split:${splits.length}`)
+  console.log(
+    `New rows created:${totalOutRows - rows.length} (from splits; primary rows reuse original page ID)`
+  )
+
+  if (splits.length > 0) {
+    console.log('\nSplit rows:')
+    for (const s of splits) {
+      console.log(
+        `  ${s.source.title}: ${s.source.medium.join(',')} → ${s.out.map((o) => o.kind).join(',')}`
+      )
+    }
+  }
+
+  if (DRY_RUN) {
+    console.log('\n[dry-run] No writes performed. Re-run with --execute to apply.')
+    return
+  }
+
+  // Execute mode — refuse if Content DB has any rows
+  console.log('\nChecking destination DB is empty...')
+  const dest = await fetch(
+    `https://api.notion.com/v1/data_sources/${await getDataSourceId(CONFIG.notionContentDbId)}/query`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${CONFIG.notionToken}`,
+        'Notion-Version': NOTION_VERSION,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ page_size: 1 }),
+    }
+  )
+  if (!dest.ok) throw new Error(`Destination check failed: ${dest.status}`)
+  const destData = (await dest.json()) as { results: unknown[] }
+  if (destData.results.length > 0) {
+    console.error('Destination Content DB is not empty. Aborting to avoid double-import.')
+    process.exit(1)
+  }
+
+  console.log('Executing migration...')
+  let created = 0
+  for (const m of mapped) {
+    // Create primary first; capture its new ID so derivatives in this group
+    // can link to it directly. This avoids the title-collision risk of a
+    // post-hoc title-based linking pass.
+    const newIdsByOriginalPageId = new Map<string, string>()
+    let primaryNewId: string | null = null
+    for (const out of m.out) {
+      const sourceRowId = out.sourceRowOriginalPageId && primaryNewId ? primaryNewId : undefined
+      const id = await createContentRow({
+        title: out.title,
+        kind: out.kind,
+        stage: out.stage,
+        origin: out.origin,
+        crossPostTargets: out.crossPostTargets,
+        tags: out.tags,
+        tools: out.tools,
+        hint: out.hint,
+        sourceUrls: out.sourceUrls,
+        publishedUrl: out.publishedUrl,
+        publishingDate: out.publishingDate,
+        sourceRowId,
+      })
+      if (!out.sourceRowOriginalPageId) primaryNewId = id
+      newIdsByOriginalPageId.set(m.source.id, id)
+      created++
+      if (created % 10 === 0) console.log(`  created ${created} rows...`)
+    }
+  }
+
+  console.log(`Done. Created ${created} rows.`)
+}
+
+async function getDataSourceId(dbId: string): Promise<string> {
+  const dbRes = await fetch(`https://api.notion.com/v1/databases/${dbId}`, {
+    headers: {
+      Authorization: `Bearer ${CONFIG.notionToken}`,
+      'Notion-Version': NOTION_VERSION,
+    },
+  })
+  const db = (await dbRes.json()) as { data_sources: Array<{ id: string }> }
+  return db.data_sources[0].id
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})
+```
+
+- [ ] **Step 2: Test dry-run mode locally**
+
+Run:
+
+```bash
+npm run migrate:cms -- --dry-run
+```
+
+Expected: prints `Migration report` with input count, output count, split rows. No Notion writes.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/agent/migrate-cms.ts
+git commit -m "add CMS-to-Content migration script with dry-run + execute modes"
+```
+
+### Task 2.6: Run the migration (one-time human action)
+
+**This task is for the human, not the agent.**
+
+- [ ] **Step 1: Run dry-run, review output**
+
+```bash
+npm run migrate:cms -- --dry-run
+```
+
+Confirm:
+
+- Input row count matches what you see in Notion
+- Split rows make sense (multi-medium rows split as expected)
+- No rows missing
+
+- [ ] **Step 2: Run execute mode**
+
+```bash
+npm run migrate:cms -- --execute
+```
+
+Expected: prints "Created N rows. Done." Refuses if Content DB has any rows already.
+
+- [ ] **Step 3: Spot-check in Notion**
+
+Open the `Content` DB. Verify:
+
+- All rows present with expected Kind/Stage/Origin
+- Split rows show up as separate rows with Source Row relation populated on the derivatives
+- Old `CMS` DB untouched
+
+- [ ] **Step 4: Build the recommended views in Notion**
+
+Manually create these views (Notion UI):
+
+| View               | Filter                                      | Sort                        |
+| ------------------ | ------------------------------------------- | --------------------------- |
+| Triage             | Stage in [Proposed, Ready]                  | Created desc                |
+| In flight          | Stage in [Ready, Drafted, Recorded, Edited] | Updated desc                |
+| Recently published | Stage = Published                           | Publishing desc             |
+| Ideas inbox        | Stage = Idea                                | Created desc                |
+| By Kind            | (no filter)                                 | grouped by Kind, then Stage |
+
+---
+
+## Phase 3: Shared lib — sources + claude wrapper
+
+### Task 3.1: Refactor `src/content.config.ts` to export the schema standalone
+
+**Files:**
+
+- Modify: `src/content.config.ts`
+
+- [ ] **Step 1: Edit to export `writingSchema`**
+
+Replace `src/content.config.ts` contents with:
+
+```typescript
+import { defineCollection, z } from 'astro:content'
+import { glob } from 'astro/loaders'
+
+export const writingSchema = z.object({
+  title: z.string(),
+  date: z.coerce.date(),
+  tags: z.array(z.string()).default([]),
+  summary: z.string().max(280),
+  hero: z
+    .object({
+      // Path served from /public/ (e.g. /static/images/blog/<slug>/hero.png).
+      // Rendered as a plain <img> in PostHeader. Skips Astro's image
+      // optimization, which is fine for v1 — banner PNGs are already small.
+      image: z.string(),
+      alt: z.string(),
+      prompt: z.string().optional(),
+      background: z.enum(['ink', 'ink-soft', 'ochre', 'terracotta', 'paper']).optional(),
+      titleStyle: z.enum(['italic', 'upper-mono', 'serif-display']).optional(),
+    })
+    .optional(),
+  draft: z.boolean().default(false),
+  updatedAt: z.coerce.date().optional(),
+  canonical: z.string().url().optional(),
+})
+
+const writing = defineCollection({
+  loader: glob({ pattern: '**/*.mdx', base: './src/content/writing' }),
+  schema: () => writingSchema,
+})
+
+export const collections = { writing }
+```
+
+- [ ] **Step 2: Verify site still builds**
+
+Run:
+
+```bash
+npm run astro check
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/content.config.ts
+git commit -m "export writingSchema standalone so agent can reuse Zod validator"
+```
+
+### Task 3.2: Write `scripts/agent/lib/validate.ts` (TDD)
+
+**Files:**
+
+- Create: `scripts/agent/lib/validate.ts`
+- Test: `scripts/agent/tests/validate.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// scripts/agent/tests/validate.test.ts
+import { describe, it, expect } from 'vitest'
+import { validateMdxFrontmatter } from '../lib/validate'
+
+describe('validateMdxFrontmatter', () => {
+  it('passes a valid post', () => {
+    const mdx = `---
+title: A test post
+date: 2026-06-01
+tags: ['ai', 'engineering']
+summary: A short summary under 280 chars.
+---
+
+Body goes here.
+`
+    const result = validateMdxFrontmatter(mdx)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.title).toBe('A test post')
+      expect(result.data.tags).toEqual(['ai', 'engineering'])
+    }
+  })
+
+  it('fails when summary too long', () => {
+    const mdx = `---
+title: x
+date: 2026-06-01
+summary: ${'a'.repeat(300)}
+---
+body`
+    const result = validateMdxFrontmatter(mdx)
+    expect(result.ok).toBe(false)
+  })
+
+  it('fails when title missing', () => {
+    const mdx = `---
+date: 2026-06-01
+summary: hi
+---
+body`
+    expect(validateMdxFrontmatter(mdx).ok).toBe(false)
+  })
+
+  it('fails when date is unparseable', () => {
+    const mdx = `---
+title: x
+date: not-a-date
+summary: hi
+---
+body`
+    expect(validateMdxFrontmatter(mdx).ok).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+```bash
+npx vitest run scripts/agent/tests/validate.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `validate.ts`**
+
+```typescript
+// scripts/agent/lib/validate.ts
+import matter from 'gray-matter'
+import { writingSchema } from '../../../src/content.config'
+import { spawnSync } from 'node:child_process'
+
+export type ValidationResult =
+  | { ok: true; data: ReturnType<typeof writingSchema.parse> }
+  | { ok: false; error: string }
+
+export function validateMdxFrontmatter(mdx: string): ValidationResult {
+  let parsed
+  try {
+    parsed = matter(mdx)
+  } catch (e) {
+    return { ok: false, error: `gray-matter parse failed: ${(e as Error).message}` }
+  }
+  const result = writingSchema.safeParse(parsed.data)
+  if (!result.success) {
+    return { ok: false, error: result.error.toString() }
+  }
+  return { ok: true, data: result.data }
+}
+
+export interface ValeFinding {
+  line: number
+  column: number
+  rule: string
+  severity: 'error' | 'warning' | 'suggestion'
+  message: string
+}
+
+/**
+ * Runs Vale on a single file. Returns parsed findings (empty array if clean).
+ * If Vale is not installed, returns []. Failure to invoke Vale is non-fatal.
+ */
+export function runVale(filePath: string): ValeFinding[] {
+  const proc = spawnSync('vale', ['--output=JSON', filePath], { encoding: 'utf8' })
+  if (proc.error) return [] // Vale not installed
+  if (!proc.stdout) return []
+  let json: Record<
+    string,
+    Array<{ Line: number; Span: number[]; Check: string; Severity: string; Message: string }>
+  >
+  try {
+    json = JSON.parse(proc.stdout)
+  } catch {
+    return []
+  }
+  const findings: ValeFinding[] = []
+  for (const file of Object.values(json)) {
+    for (const f of file) {
+      findings.push({
+        line: f.Line,
+        column: f.Span?.[0] ?? 0,
+        rule: f.Check,
+        severity: (f.Severity ?? 'warning').toLowerCase() as ValeFinding['severity'],
+        message: f.Message,
+      })
+    }
+  }
+  return findings
+}
+
+export function formatValeReport(findings: ValeFinding[]): string {
+  if (findings.length === 0) return '_(Vale clean)_'
+  const groups = {
+    error: [] as ValeFinding[],
+    warning: [] as ValeFinding[],
+    suggestion: [] as ValeFinding[],
+  }
+  for (const f of findings) groups[f.severity].push(f)
+  const lines: string[] = []
+  for (const sev of ['error', 'warning', 'suggestion'] as const) {
+    if (groups[sev].length === 0) continue
+    lines.push(`**${sev}** (${groups[sev].length}):`)
+    for (const f of groups[sev]) {
+      lines.push(`- L${f.line}: \`${f.rule}\` — ${f.message}`)
+    }
+    lines.push('')
+  }
+  return lines.join('\n')
+}
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+```bash
+npx vitest run scripts/agent/tests/validate.test.ts
+```
+
+Expected: PASS — all 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/agent/lib/validate.ts scripts/agent/tests/validate.test.ts
+git commit -m "add MDX frontmatter validator + Vale runner"
+```
+
+### Task 3.3: Write `scripts/agent/lib/claude.ts` (Agent SDK wrapper)
+
+**Files:**
+
+- Create: `scripts/agent/lib/claude.ts`
+- Test: (skipped — wraps an external SDK; covered by integration smoke)
+
+- [ ] **Step 1: Write the wrapper**
+
+````typescript
+// scripts/agent/lib/claude.ts
+import { query } from '@anthropic-ai/claude-agent-sdk'
+
+export interface PromptOptions {
+  systemPrompt: string
+  userPrompt: string
+  model?: string
+  maxTurns?: number
+}
+
+/**
+ * Runs a one-shot Claude prompt via the Agent SDK using subscription OAuth.
+ * Returns the assistant's full text response.
+ *
+ * Auth: reads CLAUDE_CODE_OAUTH_TOKEN from env (set by config import side effect
+ * via 'dotenv/config' in callers' lib/config.ts).
+ */
+export async function runPrompt(opts: PromptOptions): Promise<string> {
+  const result = query({
+    prompt: opts.userPrompt,
+    options: {
+      systemPrompt: opts.systemPrompt,
+      model: opts.model ?? 'claude-sonnet-4-6',
+      // Disable file/bash tools — we feed all context in the prompt.
+      allowedTools: [],
+      maxTurns: opts.maxTurns ?? 1,
+    },
+  })
+
+  let text = ''
+  for await (const message of result) {
+    if (message.type === 'assistant' && Array.isArray(message.message.content)) {
+      for (const block of message.message.content) {
+        if (block.type === 'text') text += block.text
+      }
+    }
+  }
+  return text.trim()
+}
+
+/**
+ * Parses a Claude response we expect to be JSON. The model often wraps JSON in
+ * markdown code fences; this strips those before parsing.
+ */
+export function parseJsonResponse<T>(text: string): T {
+  const fenced = text.match(/```(?:json)?\s*([\s\S]+?)```/)
+  const raw = fenced ? fenced[1] : text
+  return JSON.parse(raw.trim()) as T
+}
+````
+
+- [ ] **Step 2: Smoke-test with a trivial prompt**
+
+Run (requires real `CLAUDE_CODE_OAUTH_TOKEN`):
+
+```bash
+npx tsx -e "import('./scripts/agent/lib/claude.ts').then(async m => { const r = await m.runPrompt({ systemPrompt: 'Reply with exactly the word OK.', userPrompt: 'go' }); console.log(JSON.stringify(r)) })"
+```
+
+Expected: prints `"OK"` (or close to it — model may add punctuation; that's fine).
+
+If you hit rate limits, log and skip — the wrapper works regardless.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/agent/lib/claude.ts
+git commit -m "add Claude Agent SDK wrapper using subscription OAuth"
+```
+
+### Task 3.4: Write `scripts/agent/lib/editorial.ts`
+
+**Files:**
+
+- Create: `scripts/agent/lib/editorial.ts`
+
+- [ ] **Step 1: Write the module**
+
+```typescript
+// scripts/agent/lib/editorial.ts
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const REPO_ROOT = join(__dirname, '..', '..', '..')
+
+export function loadEditorialGuide(): string {
+  return readFileSync(join(REPO_ROOT, 'docs', 'EDITORIAL.md'), 'utf8')
+}
+
+export function loadShortsStyleGuide(): string {
+  return readFileSync(join(REPO_ROOT, 'docs', 'SHORTS-STYLE.md'), 'utf8')
+}
+```
+
+Note: `tsx` provides `__dirname` even in ESM. If your build complains, replace with:
+
+```typescript
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..')
+```
+
+- [ ] **Step 2: Quick verify**
+
+```bash
+npx tsx -e "import('./scripts/agent/lib/editorial.ts').then(m => console.log(m.loadEditorialGuide().length))"
+```
+
+Expected: prints a number > 1000 (the length of EDITORIAL.md).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/agent/lib/editorial.ts
+git commit -m "add editorial guide loaders"
+```
+
+### Task 3.5: Write `scripts/agent/lib/git-scan.ts`
+
+**Files:**
+
+- Create: `scripts/agent/lib/git-scan.ts`
+
+- [ ] **Step 1: Write the module**
+
+```typescript
+// scripts/agent/lib/git-scan.ts
+import { CONFIG } from './config'
+import type { CommitInfo } from './types'
+
+interface GhCommit {
+  sha: string
+  html_url: string
+  commit: { message: string; author: { date: string } }
+}
+
+interface GhCommitFile {
+  filename: string
+}
+
+interface GhRepo {
+  name: string
+  pushed_at: string
+  private: boolean
+}
+
+const GH_API = 'https://api.github.com'
+
+function ghHeaders(): Record<string, string> {
+  return {
+    Authorization: `Bearer ${CONFIG.agentGhToken}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+  }
+}
+
+/**
+ * Returns commits across all repos in scope from the last N days.
+ * Scope = always-on repos (CONFIG.scanRepoInclude) + any public repo under
+ * CONFIG.scanRepoOrg with a push in the last CONFIG.scanRepoActiveDays days.
+ */
+export async function recentCommits(daysBack: number = 7): Promise<CommitInfo[]> {
+  const since = new Date(Date.now() - daysBack * 86_400_000).toISOString()
+  const repos = await reposInScope()
+  const allCommits: CommitInfo[] = []
+  for (const repo of repos) {
+    try {
+      const commits = await fetchCommits(repo, since)
+      allCommits.push(...commits)
+    } catch (err) {
+      console.warn(`Failed to fetch commits for ${repo}: ${(err as Error).message}`)
+    }
+  }
+  return allCommits
+}
+
+async function reposInScope(): Promise<string[]> {
+  const always = CONFIG.scanRepoInclude.map((r) => `${CONFIG.scanRepoOrg}/${r}`)
+  const opportunistic = await activeRepos()
+  const set = new Set<string>([...always, ...opportunistic])
+  return [...set]
+}
+
+async function activeRepos(): Promise<string[]> {
+  const url = `${GH_API}/users/${CONFIG.scanRepoOrg}/repos?per_page=100&sort=pushed&type=public`
+  const res = await fetch(url, { headers: ghHeaders() })
+  if (!res.ok) {
+    console.warn(`Failed to list ${CONFIG.scanRepoOrg} repos: ${res.status}`)
+    return []
+  }
+  const repos = (await res.json()) as GhRepo[]
+  const cutoff = Date.now() - CONFIG.scanRepoActiveDays * 86_400_000
+  return repos
+    .filter((r) => !r.private && new Date(r.pushed_at).getTime() >= cutoff)
+    .map((r) => `${CONFIG.scanRepoOrg}/${r.name}`)
+}
+
+async function fetchCommits(repo: string, sinceISO: string): Promise<CommitInfo[]> {
+  const url = `${GH_API}/repos/${repo}/commits?since=${sinceISO}&per_page=50`
+  const res = await fetch(url, { headers: ghHeaders() })
+  if (!res.ok) throw new Error(`${res.status}`)
+  const commits = (await res.json()) as GhCommit[]
+  const results: CommitInfo[] = []
+  for (const c of commits) {
+    const files = await fetchFiles(repo, c.sha)
+    results.push({
+      repo,
+      sha: c.sha,
+      message: c.commit.message,
+      date: c.commit.author.date,
+      filesChanged: files.slice(0, 10),
+      url: c.html_url,
+    })
+  }
+  return results
+}
+
+async function fetchFiles(repo: string, sha: string): Promise<string[]> {
+  const url = `${GH_API}/repos/${repo}/commits/${sha}`
+  const res = await fetch(url, { headers: ghHeaders() })
+  if (!res.ok) return []
+  const data = (await res.json()) as { files?: GhCommitFile[] }
+  return (data.files ?? []).map((f) => f.filename)
+}
+```
+
+- [ ] **Step 2: Smoke-test**
+
+```bash
+npx tsx -e "import('./scripts/agent/lib/git-scan.ts').then(async m => { const c = await m.recentCommits(7); console.log('commits:', c.length); console.log(c.slice(0, 2)) })"
+```
+
+Expected: prints commit count and 2 sample commits.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/agent/lib/git-scan.ts
+git commit -m "add git-scan lib for recent commits across active repos"
+```
+
+### Task 3.6: Write `scripts/agent/lib/trending.ts`
+
+**Files:**
+
+- Create: `scripts/agent/lib/trending.ts`
+
+- [ ] **Step 1: Write the module**
+
+```typescript
+// scripts/agent/lib/trending.ts
+import type { TrendingItem } from './types'
+
+const HN_TOP = 'https://hacker-news.firebaseio.com/v0/topstories.json'
+const HN_ITEM = (id: number): string => `https://hacker-news.firebaseio.com/v0/item/${id}.json`
+
+const HN_KEYWORDS = [
+  'cli',
+  'agent',
+  'claude',
+  'gemini',
+  'copilot',
+  'codex',
+  'cursor',
+  'tool',
+  'mcp',
+]
+
+export async function fetchTrending(extraTools: string[] = []): Promise<TrendingItem[]> {
+  const [hn, gh] = await Promise.all([
+    fetchHnFiltered([...HN_KEYWORDS, ...extraTools]),
+    fetchGhTrending(),
+  ])
+  return [...hn, ...gh]
+}
+
+async function fetchHnFiltered(keywords: string[]): Promise<TrendingItem[]> {
+  try {
+    const topRes = await fetch(HN_TOP)
+    if (!topRes.ok) return []
+    const ids = (await topRes.json()) as number[]
+    const sample = ids.slice(0, 100) // top 100 stories
+    const items: TrendingItem[] = []
+    const kws = keywords.map((k) => k.toLowerCase())
+    for (const id of sample) {
+      const itemRes = await fetch(HN_ITEM(id))
+      if (!itemRes.ok) continue
+      const it = (await itemRes.json()) as {
+        title?: string
+        url?: string
+        score?: number
+        type?: string
+      }
+      if (it.type !== 'story' || !it.title) continue
+      const title = it.title
+      const lower = title.toLowerCase()
+      if (!kws.some((k) => lower.includes(k))) continue
+      items.push({
+        source: 'hn',
+        title,
+        url: it.url ?? `https://news.ycombinator.com/item?id=${id}`,
+        hint: it.score ? `HN ${it.score} points` : undefined,
+      })
+      if (items.length >= 10) break
+    }
+    return items
+  } catch (err) {
+    console.warn(`HN fetch failed: ${(err as Error).message}`)
+    return []
+  }
+}
+
+async function fetchGhTrending(): Promise<TrendingItem[]> {
+  const langs = ['typescript', 'python', 'rust']
+  const items: TrendingItem[] = []
+  for (const lang of langs) {
+    try {
+      const url = `https://github.com/trending/${lang}?since=weekly`
+      const res = await fetch(url, {
+        headers: { 'User-Agent': 'shariq-dev-agent/1.0' },
+      })
+      if (!res.ok) continue
+      const html = await res.text()
+      // Match the standard trending repo card structure
+      const matches = html.match(/href="\/[^\/\s]+\/[^\/\s"]+"[^>]*>\s*<svg/g) ?? []
+      const seen = new Set<string>()
+      for (const m of matches) {
+        const path = m.match(/href="(\/[^\/]+\/[^\/"]+)"/)?.[1]
+        if (!path) continue
+        if (seen.has(path)) continue
+        seen.add(path)
+        items.push({
+          source: 'gh-trending',
+          title: path.slice(1),
+          url: `https://github.com${path}`,
+          hint: `trending ${lang}`,
+        })
+        if (items.length >= 15) break
+      }
+    } catch (err) {
+      console.warn(`GH trending ${lang} failed: ${(err as Error).message}`)
+    }
+  }
+  return items
+}
+```
+
+- [ ] **Step 2: Smoke-test**
+
+```bash
+npx tsx -e "import('./scripts/agent/lib/trending.ts').then(async m => { const t = await m.fetchTrending(); console.log('trending:', t.length); console.log(t.slice(0, 3)) })"
+```
+
+Expected: prints some trending items. HN may be empty if no AI keywords match top stories; GH trending should have ~15 items.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/agent/lib/trending.ts
+git commit -m "add trending lib: GH trending scrape + HN filtered feed"
+```
+
+### Task 3.7: Write `scripts/agent/lib/youtube.ts`
+
+**Files:**
+
+- Create: `scripts/agent/lib/youtube.ts`
+
+- [ ] **Step 1: Write the module**
+
+```typescript
+// scripts/agent/lib/youtube.ts
+import { CONFIG } from './config'
+import type { YouTubeStat } from './types'
+
+const YT = 'https://www.googleapis.com/youtube/v3'
+
+interface YtVideo {
+  id: string
+  snippet: { title: string; publishedAt: string }
+  statistics: { viewCount?: string; likeCount?: string }
+}
+
+interface YtSearchItem {
+  id: { videoId?: string }
+  snippet: { publishedAt: string }
+}
+
+/**
+ * Returns view + like stats for the channel's videos published in the last N days.
+ */
+export async function recentChannelStats(daysBack: number = 30): Promise<YouTubeStat[]> {
+  const publishedAfter = new Date(Date.now() - daysBack * 86_400_000).toISOString()
+  const searchUrl = `${YT}/search?part=id,snippet&channelId=${CONFIG.youtubeChannelId}&type=video&order=date&publishedAfter=${publishedAfter}&maxResults=50&key=${CONFIG.youtubeApiKey}`
+  const searchRes = await fetch(searchUrl)
+  if (!searchRes.ok) {
+    console.warn(`YT search failed: ${searchRes.status}`)
+    return []
+  }
+  const search = (await searchRes.json()) as { items: YtSearchItem[] }
+  const ids = search.items.map((i) => i.id.videoId).filter((x): x is string => !!x)
+  if (ids.length === 0) return []
+
+  const videosUrl = `${YT}/videos?part=snippet,statistics&id=${ids.join(',')}&key=${CONFIG.youtubeApiKey}`
+  const vidRes = await fetch(videosUrl)
+  if (!vidRes.ok) return []
+  const vids = (await vidRes.json()) as { items: YtVideo[] }
+  return vids.items.map((v) => ({
+    videoId: v.id,
+    title: v.snippet.title,
+    views: parseInt(v.statistics.viewCount ?? '0', 10),
+    likes: parseInt(v.statistics.likeCount ?? '0', 10),
+    publishedAt: v.snippet.publishedAt,
+  }))
+}
+```
+
+- [ ] **Step 2: Smoke-test**
+
+```bash
+npx tsx -e "import('./scripts/agent/lib/youtube.ts').then(async m => { const s = await m.recentChannelStats(30); console.log('videos:', s.length); console.log(s.slice(0, 3)) })"
+```
+
+Expected: prints stats for recent videos.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/agent/lib/youtube.ts
+git commit -m "add YouTube Data API v3 stats client"
+```
+
+### Task 3.8: Write `scripts/agent/lib/pr.ts`
+
+**Files:**
+
+- Create: `scripts/agent/lib/pr.ts`
+
+- [ ] **Step 1: Write the module**
+
+```typescript
+// scripts/agent/lib/pr.ts
+import { spawnSync } from 'node:child_process'
+
+export interface PrInput {
+  branchName: string
+  commitMessage: string
+  prTitle: string
+  prBody: string
+}
+
+export interface PrResult {
+  branch: string
+  prUrl: string
+}
+
+function run(cmd: string, args: string[]): { code: number; stdout: string; stderr: string } {
+  const proc = spawnSync(cmd, args, { encoding: 'utf8' })
+  return {
+    code: proc.status ?? 1,
+    stdout: proc.stdout ?? '',
+    stderr: proc.stderr ?? '',
+  }
+}
+
+/**
+ * Creates a branch from the current HEAD, commits whatever's staged, pushes,
+ * and opens a PR via `gh`. Returns the PR URL.
+ *
+ * Caller is responsible for `git add`ing the relevant files before calling.
+ */
+export function createBranchAndPr(input: PrInput): PrResult {
+  // Create branch
+  const co = run('git', ['checkout', '-b', input.branchName])
+  if (co.code !== 0) throw new Error(`git checkout -b failed: ${co.stderr}`)
+
+  // Commit
+  const commit = run('git', ['commit', '-m', input.commitMessage])
+  if (commit.code !== 0) throw new Error(`git commit failed: ${commit.stderr}`)
+
+  // Push
+  const push = run('git', ['push', '-u', 'origin', input.branchName])
+  if (push.code !== 0) throw new Error(`git push failed: ${push.stderr}`)
+
+  // PR
+  const pr = run('gh', [
+    'pr',
+    'create',
+    '--title',
+    input.prTitle,
+    '--body',
+    input.prBody,
+    '--label',
+    'agent-draft',
+  ])
+  if (pr.code !== 0) throw new Error(`gh pr create failed: ${pr.stderr}`)
+  const url = pr.stdout.trim().split('\n').pop() ?? ''
+  if (!url.startsWith('https://')) {
+    throw new Error(`Unexpected gh pr create output: ${pr.stdout}`)
+  }
+  return { branch: input.branchName, prUrl: url }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add scripts/agent/lib/pr.ts
+git commit -m "add gh CLI PR-creation wrapper"
+```
+
+### Task 3.9: Write `scripts/agent/lib/bucket.ts`
+
+**Files:**
+
+- Create: `scripts/agent/lib/bucket.ts`
+
+- [ ] **Step 1: Re-export**
+
+```typescript
+// scripts/agent/lib/bucket.ts
+export { resolveBucket, BUCKETS } from '../../../src/lib/buckets'
+export type { Bucket, BucketKey } from '../../../src/lib/buckets'
+```
+
+- [ ] **Step 2: Verify import works**
+
+```bash
+npx tsx -e "import('./scripts/agent/lib/bucket.ts').then(m => console.log(m.resolveBucket(['ai'])))"
+```
+
+Expected: prints `{ key: 'ai', label: 'AI' }`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/agent/lib/bucket.ts
+git commit -m "add bucket re-export so agent shares src/lib/buckets logic"
+```
+
+---
+
+## Phase 4: Drafting — blog branch
+
+### Task 4.1: Write blog-drafting prompt builder + tests
+
+**Files:**
+
+- Create: `scripts/agent/lib/draft-blog.ts`
+- Test: `scripts/agent/tests/draft-blog.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// scripts/agent/tests/draft-blog.test.ts
+import { describe, it, expect } from 'vitest'
+import { buildBlogSystemPrompt, buildBlogUserPrompt, slugify } from '../lib/draft-blog'
+
+describe('slugify', () => {
+  it('lowercases and dashes a title', () => {
+    expect(slugify('Claude Code agents in CI')).toBe('claude-code-agents-in-ci')
+  })
+  it('strips punctuation', () => {
+    expect(slugify('Why TDD? It works.')).toBe('why-tdd-it-works')
+  })
+  it('collapses multiple dashes', () => {
+    expect(slugify('a -- b')).toBe('a-b')
+  })
+})
+
+describe('buildBlogSystemPrompt', () => {
+  it('includes EDITORIAL guide and bucket map', () => {
+    const sp = buildBlogSystemPrompt({ editorialMd: 'EDITORIAL CONTENT', isDerivative: false })
+    expect(sp).toContain('EDITORIAL CONTENT')
+    expect(sp).toContain('Leadership')
+    expect(sp).toContain('Engineering')
+  })
+
+  it('adds derivative instructions when isDerivative=true', () => {
+    const sp = buildBlogSystemPrompt({
+      editorialMd: 'x',
+      isDerivative: true,
+      sourceVideoUrl: 'https://youtu.be/abc',
+    })
+    expect(sp).toContain('<Youtube id="abc" />')
+  })
+})
+
+describe('buildBlogUserPrompt', () => {
+  it('embeds title, hint, source URLs, and commit context', () => {
+    const up = buildBlogUserPrompt({
+      title: 'A post',
+      hint: 'angle here',
+      sourceUrls: ['https://x.com'],
+      tags: ['ai'],
+      commits: [
+        {
+          repo: 'shariqh/lognote',
+          sha: 'abc',
+          message: 'feat: add logging',
+          date: '2026-06-01T00:00:00Z',
+          filesChanged: ['src/log.ts'],
+          url: 'https://github.com/shariqh/lognote/commit/abc',
+        },
+      ],
+    })
+    expect(up).toContain('A post')
+    expect(up).toContain('angle here')
+    expect(up).toContain('https://x.com')
+    expect(up).toContain('feat: add logging')
+    expect(up).toContain('src/log.ts')
+  })
+})
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+```bash
+npx vitest run scripts/agent/tests/draft-blog.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `draft-blog.ts`**
+
+````typescript
+// scripts/agent/lib/draft-blog.ts
+import { BUCKETS } from './bucket'
+import type { CommitInfo } from './types'
+
+export function slugify(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+}
+
+export interface BlogSystemPromptInput {
+  editorialMd: string
+  isDerivative: boolean
+  sourceVideoUrl?: string
+}
+
+export function buildBlogSystemPrompt(input: BlogSystemPromptInput): string {
+  const bucketSummary = Object.entries(BUCKETS)
+    .map(
+      ([key, b]) =>
+        `- **${b.label}** (key: \`${key}\`) — tags: ${b.tags.join(', ') || '(catch-all)'}`
+    )
+    .join('\n')
+
+  const derivativeBlock = input.isDerivative
+    ? `
+
+## DERIVATIVE POST FROM YOUTUBE
+
+This post derives from a YouTube video. Open the MDX with the video embedded at the very top via:
+
+\`\`\`mdx
+<Youtube id="${extractYoutubeId(input.sourceVideoUrl ?? '')}" />
+\`\`\`
+
+After the embed, write what you couldn't fit in 60 seconds — context, longer demos, gotchas, where it fits in the broader stack.
+`
+    : ''
+
+  return `You are the drafting agent for shariq.dev. Your job is to produce one MDX file ready to publish, following the editorial guide below verbatim.
+
+OUTPUT: Just the MDX file contents. No prose explanation, no markdown fences around the file. Start with the YAML frontmatter, end with the body.
+
+# Buckets
+
+Posts are categorized by tags into one of five buckets:
+
+${bucketSummary}
+
+Pick tags appropriate for the post. The bucket resolver in src/lib/buckets.ts will assign the visual treatment automatically.
+
+# Editorial guide (verbatim — follow these rules)
+
+${input.editorialMd}
+${derivativeBlock}`
+}
+
+function extractYoutubeId(url: string): string {
+  const m = url.match(/(?:youtu\.be\/|v=)([A-Za-z0-9_-]{11})/)
+  return m?.[1] ?? ''
+}
+
+export interface BlogUserPromptInput {
+  title: string
+  hint: string
+  sourceUrls: string[]
+  tags: string[]
+  commits: CommitInfo[]
+  sourceVideoUrl?: string
+  sourceScript?: string
+}
+
+export function buildBlogUserPrompt(input: BlogUserPromptInput): string {
+  const lines: string[] = []
+  lines.push(`# Draft this post`)
+  lines.push('')
+  lines.push(`**Working title:** ${input.title}`)
+  lines.push(`**Angle:** ${input.hint || '(none provided — derive from sources)'}`)
+  if (input.tags.length) lines.push(`**Suggested tags:** ${input.tags.join(', ')}`)
+  lines.push('')
+
+  if (input.sourceVideoUrl) {
+    lines.push('## Source video')
+    lines.push(input.sourceVideoUrl)
+    lines.push('')
+  }
+  if (input.sourceScript) {
+    lines.push('## Original YouTube script (basis to expand from)')
+    lines.push('```')
+    lines.push(input.sourceScript)
+    lines.push('```')
+    lines.push('')
+  }
+  if (input.sourceUrls.length) {
+    lines.push('## Source URLs')
+    for (const u of input.sourceUrls) lines.push(`- ${u}`)
+    lines.push('')
+  }
+  if (input.commits.length) {
+    lines.push('## Recent commits (context)')
+    for (const c of input.commits) {
+      lines.push(
+        `- \`${c.repo}@${c.sha.slice(0, 7)}\` (${c.date.slice(0, 10)}) — ${c.message.split('\n')[0]}`
+      )
+      if (c.filesChanged.length) lines.push(`  files: ${c.filesChanged.slice(0, 5).join(', ')}`)
+    }
+    lines.push('')
+  }
+
+  lines.push(`Today's date: ${new Date().toISOString().slice(0, 10)}`)
+  lines.push('')
+  lines.push('Write the MDX now. Frontmatter first, body second.')
+
+  return lines.join('\n')
+}
+````
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+```bash
+npx vitest run scripts/agent/tests/draft-blog.test.ts
+```
+
+Expected: PASS — all 7 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/agent/lib/draft-blog.ts scripts/agent/tests/draft-blog.test.ts
+git commit -m "add blog-drafting prompt builders + slugify"
+```
+
+### Task 4.2: Write `scripts/agent/draft.ts` (blog branch only, YT stubbed)
+
+**Files:**
+
+- Create: `scripts/agent/draft.ts`
+
+- [ ] **Step 1: Write the script**
+
+```typescript
+// scripts/agent/draft.ts
+import { writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { CONFIG } from './lib/config'
+import { runPrompt } from './lib/claude'
+import { queryContentRows, updateContentRow, addPageComment } from './lib/notion'
+import { recentCommits } from './lib/git-scan'
+import { loadEditorialGuide } from './lib/editorial'
+import { buildBlogSystemPrompt, buildBlogUserPrompt, slugify } from './lib/draft-blog'
+import { validateMdxFrontmatter, runVale, formatValeReport } from './lib/validate'
+import { createBranchAndPr } from './lib/pr'
+import type { ContentRow, CommitInfo } from './lib/types'
+
+const READY_FILTER = {
+  property: 'Stage',
+  select: { equals: 'Ready' },
+}
+
+async function main(): Promise<void> {
+  const rows = await queryContentRows(READY_FILTER)
+  console.log(`Found ${rows.length} Ready row(s).`)
+  if (rows.length === 0) return
+
+  // Fetch shared context once
+  const allCommits = await recentCommits(7)
+  const editorialMd = loadEditorialGuide()
+
+  let succeeded = 0
+  let failed = 0
+  for (const row of rows) {
+    try {
+      if (row.kind === 'blog') {
+        await draftBlogRow(row, allCommits, editorialMd)
+        succeeded++
+      } else if (row.kind === 'YT short' || row.kind === 'YT long') {
+        // Stubbed — implemented in Phase 5
+        console.log(`Skipping YT row (Phase 5 not yet implemented): ${row.title}`)
+      } else {
+        console.log(`Skipping unsupported Kind=${row.kind}: ${row.title}`)
+      }
+    } catch (err) {
+      failed++
+      const msg = (err as Error).message
+      console.error(`Row ${row.id} (${row.title}) failed: ${msg}`)
+      try {
+        await addPageComment(row.id, `Agent drafting failed: ${msg}`)
+      } catch (commentErr) {
+        console.error(`Also failed to post Notion comment: ${(commentErr as Error).message}`)
+      }
+    }
+  }
+  console.log(`Done. Succeeded: ${succeeded}, Failed: ${failed}`)
+}
+
+async function draftBlogRow(
+  row: ContentRow,
+  allCommits: CommitInfo[],
+  editorialMd: string
+): Promise<void> {
+  // Filter commits relevant to this row (mentioned by SHA in Source URLs)
+  const relevantShas = new Set(
+    row.sourceUrls.map((u) => u.match(/\/commit\/([a-f0-9]+)/)?.[1]).filter((x): x is string => !!x)
+  )
+  const commits = allCommits.filter((c) => relevantShas.has(c.sha))
+
+  const isDerivative = row.origin === 'Derivative'
+  const sourceVideoUrl = isDerivative
+    ? row.sourceUrls.find((u) => /youtu\.be|youtube\.com/.test(u))
+    : undefined
+
+  const systemPrompt = buildBlogSystemPrompt({
+    editorialMd,
+    isDerivative,
+    sourceVideoUrl,
+  })
+
+  const userPrompt = buildBlogUserPrompt({
+    title: row.title,
+    hint: row.hint,
+    sourceUrls: row.sourceUrls,
+    tags: row.tags,
+    commits,
+    sourceVideoUrl,
+    sourceScript: undefined, // populated below in YT-derivative case if we add it later
+  })
+
+  console.log(`Calling Claude for: ${row.title}`)
+  const mdx = await runPrompt({ systemPrompt, userPrompt })
+
+  // Validate
+  const valid = validateMdxFrontmatter(mdx)
+  if (!valid.ok) {
+    throw new Error(`Frontmatter validation failed: ${valid.error}`)
+  }
+
+  // Write file
+  const slug = slugify(row.title)
+  const filePath = join('src', 'content', 'writing', `${slug}.mdx`)
+  writeFileSync(filePath, mdx)
+
+  // Vale
+  const findings = runVale(filePath)
+  const valeReport = formatValeReport(findings)
+
+  // Stage the file
+  const { spawnSync } = await import('node:child_process')
+  const stageRes = spawnSync('git', ['add', filePath], { encoding: 'utf8' })
+  if (stageRes.status !== 0) throw new Error(`git add failed: ${stageRes.stderr}`)
+
+  // Create branch + PR
+  const branchName = `agent/draft/${slug}`
+  const commitMsg = `draft: ${row.title} (proposed by agent)`
+  const prBody = renderPrBody(row, valeReport)
+  const { prUrl } = createBranchAndPr({
+    branchName,
+    commitMessage: commitMsg,
+    prTitle: commitMsg,
+    prBody,
+  })
+
+  // Update Notion
+  await updateContentRow(row.id, { stage: 'Drafted', draftUrl: prUrl })
+
+  // Return to main branch so the next iteration starts clean
+  spawnSync('git', ['checkout', '-'], { encoding: 'utf8' })
+
+  console.log(`✓ Drafted ${row.title} → ${prUrl}`)
+}
+
+function renderPrBody(row: ContentRow, valeReport: string): string {
+  return `## AI-drafted post
+
+Drafted by the Plan B agent from Notion row [\`${row.title}\`](https://www.notion.so/${row.id.replace(/-/g, '')}).
+
+### Source
+- Hint: ${row.hint || '_(none)_'}
+- Tags: ${row.tags.join(', ') || '_(none)_'}
+- Source URLs: ${row.sourceUrls.length ? row.sourceUrls.join(', ') : '_(none)_'}
+
+### Pre-publish checklist (from docs/EDITORIAL.md)
+
+- [ ] Voice check — sounds like me, not a press release
+- [ ] Accuracy — every claim reflects something I actually did/saw/built
+- [ ] AI-tell sweep (read it out loud)
+- [ ] Length matches bucket
+- [ ] Frontmatter complete
+- [ ] Cloudflare preview reviewed (mobile too)
+
+### Vale report
+
+${valeReport}
+
+---
+
+_When this PR merges to main, please update the Notion row's Published URL to the live shariq.dev URL._
+`
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add scripts/agent/draft.ts
+git commit -m "add draft.ts entry (blog branch implemented, YT stubbed)"
+```
+
+### Task 4.3: Write `.github/workflows/agent-draft.yml`
+
+**Files:**
+
+- Create: `.github/workflows/agent-draft.yml`
+
+- [ ] **Step 1: Write the workflow**
+
+```yaml
+name: Agent — draft
+
+on:
+  schedule:
+    - cron: '0 2 * * *' # Daily 02:00 UTC
+  workflow_dispatch:
+
+jobs:
+  draft:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.AGENT_GH_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Install Vale
+        run: |
+          curl -fsSL -o vale.tar.gz https://github.com/errata-ai/vale/releases/download/v3.9.1/vale_3.9.1_Linux_64-bit.tar.gz
+          tar -xzf vale.tar.gz vale
+          sudo mv vale /usr/local/bin/
+
+      - name: Configure git
+        run: |
+          git config user.name "shariq-dev-agent"
+          git config user.email "agent@shariq.dev"
+
+      - name: Run drafting
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          NOTION_CONTENT_DB_ID: ${{ vars.NOTION_CONTENT_DB_ID }}
+          YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
+          YOUTUBE_CHANNEL_ID: ${{ vars.YOUTUBE_CHANNEL_ID }}
+          AGENT_GH_TOKEN: ${{ secrets.AGENT_GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.AGENT_GH_TOKEN }}
+          SCAN_REPO_ORG: ${{ vars.SCAN_REPO_ORG }}
+          SCAN_REPO_INCLUDE: ${{ vars.SCAN_REPO_INCLUDE }}
+          SCAN_REPO_ACTIVE_DAYS: ${{ vars.SCAN_REPO_ACTIVE_DAYS }}
+        run: npm run agent:draft
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .github/workflows/agent-draft.yml
+git commit -m "add agent-draft GH Actions workflow"
+```
+
+### Task 4.4: Smoke-test the blog drafting flow
+
+**This is a human-action task.**
+
+- [ ] **Step 1: Add required secrets and variables to GH**
+
+```bash
+gh secret set CLAUDE_CODE_OAUTH_TOKEN --body "$(cat ~/.config/claude/auth.json | jq -r .oauth_token)" # adjust to actual location
+gh secret set NOTION_TOKEN --body "<your notion token>"
+gh secret set YOUTUBE_API_KEY --body "<your YT key>"
+gh secret set AGENT_GH_TOKEN --body "<your fine-grained PAT>"
+
+gh variable set NOTION_CONTENT_DB_ID --body "<content db id>"
+gh variable set YOUTUBE_CHANNEL_ID --body "<your channel id>"
+gh variable set SCAN_REPO_ORG --body "shariqh"
+gh variable set SCAN_REPO_INCLUDE --body "blog-site,lognote"
+gh variable set SCAN_REPO_ACTIVE_DAYS --body "30"
+```
+
+- [ ] **Step 2: Manually set a Content row to Stage=Ready**
+
+In Notion, pick a Content row with Kind=blog. Set Stage=Ready.
+
+- [ ] **Step 3: Trigger the workflow manually**
+
+```bash
+gh workflow run agent-draft.yml
+gh run watch
+```
+
+Expected: workflow runs, calls Claude, writes MDX, opens a PR. The PR should appear in `gh pr list`.
+
+- [ ] **Step 4: Verify outputs**
+
+- PR exists with correct title/body
+- Notion row Stage=Drafted, Draft URL points at the PR
+- Cloudflare Pages preview deploys successfully on the PR
+
+---
+
+## Phase 5: Drafting — YT branch
+
+### Task 5.1: Write YT script-to-Notion-blocks renderer + tests
+
+**Files:**
+
+- Create: `scripts/agent/lib/draft-yt.ts`
+- Test: `scripts/agent/tests/draft-yt.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// scripts/agent/tests/draft-yt.test.ts
+import { describe, it, expect } from 'vitest'
+import { buildYtSystemPrompt, buildYtUserPrompt, renderYtScriptToBlocks } from '../lib/draft-yt'
+import type { YTScriptBlocks } from '../lib/types'
+
+const sample: YTScriptBlocks = {
+  hook: 'Cursor rewrote my git config.',
+  script: 'Here is what happened…',
+  onScreenText: [{ timestampSeconds: 2, text: 'WAIT' }],
+  bRoll: [{ timestampSeconds: 5, description: 'screen recording of git config diff' }],
+  thumbnailPrompt: 'Terminal with red diff, calm face',
+  titleVariants: ['Cursor broke my git', 'Heads up on Cursor', 'A weird thing Cursor did'],
+  hashtags: ['ai', 'cursor', 'developer', 'cli'],
+}
+
+describe('renderYtScriptToBlocks', () => {
+  it('renders all 7 sections as Notion blocks', () => {
+    const blocks = renderYtScriptToBlocks(sample)
+    const headings = blocks.filter((b: { type?: string }) => b.type === 'heading_2')
+    expect(headings).toHaveLength(7)
+  })
+
+  it('preserves timestamps in on-screen-text bullets', () => {
+    const blocks = renderYtScriptToBlocks(sample)
+    const serialized = JSON.stringify(blocks)
+    expect(serialized).toContain('2s — WAIT')
+  })
+})
+
+describe('buildYtSystemPrompt', () => {
+  it('includes SHORTS-STYLE guide and tools', () => {
+    const sp = buildYtSystemPrompt({
+      shortsStyleMd: 'SHORTS GUIDE',
+      kind: 'YT short',
+      tools: ['claude-code'],
+    })
+    expect(sp).toContain('SHORTS GUIDE')
+    expect(sp).toContain('claude-code')
+  })
+})
+
+describe('buildYtUserPrompt', () => {
+  it('embeds title, hint, source URLs, and YT performance signal', () => {
+    const up = buildYtUserPrompt({
+      title: 'A short',
+      hint: 'angle',
+      sourceUrls: ['https://x.com'],
+      tools: ['claude-code'],
+      perfSignal: 'Past videos on claude-code averaged 4k views',
+    })
+    expect(up).toContain('A short')
+    expect(up).toContain('claude-code')
+    expect(up).toContain('4k views')
+  })
+})
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+```bash
+npx vitest run scripts/agent/tests/draft-yt.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `draft-yt.ts`**
+
+```typescript
+// scripts/agent/lib/draft-yt.ts
+import type { YTScriptBlocks, Kind } from './types'
+
+export interface YtSystemPromptInput {
+  shortsStyleMd: string
+  kind: Kind
+  tools: string[]
+}
+
+export function buildYtSystemPrompt(input: YtSystemPromptInput): string {
+  return `You are the drafting agent for the shariq.dev YouTube channel. Produce one script in the structured JSON format below, following the style guide verbatim.
+
+OUTPUT: Valid JSON only. No markdown fences, no commentary, no preamble.
+
+# Kind
+${input.kind}
+
+# Tools covered
+${input.tools.length ? input.tools.join(', ') : '(none specified — infer from sources)'}
+
+# Style guide
+
+${input.shortsStyleMd}
+
+# Output schema
+
+\`\`\`json
+{
+  "hook": "string (≤3s of dialogue)",
+  "script": "string (full body, ~50s for short, ~5min for long)",
+  "on_screen_text": [{"timestamp_seconds": number, "text": "string ≤6 words"}],
+  "b_roll": [{"timestamp_seconds": number, "description": "string"}],
+  "thumbnail_prompt": "string (one sentence)",
+  "title_variants": ["string", "string", "string"],
+  "hashtags": ["string", "string", "..."]
+}
+\`\`\`
+`
+}
+
+export interface YtUserPromptInput {
+  title: string
+  hint: string
+  sourceUrls: string[]
+  tools: string[]
+  perfSignal?: string
+}
+
+export function buildYtUserPrompt(input: YtUserPromptInput): string {
+  const lines: string[] = []
+  lines.push(`# Write this script`)
+  lines.push('')
+  lines.push(`**Working title:** ${input.title}`)
+  lines.push(`**Angle:** ${input.hint || '(none — derive)'}`)
+  if (input.tools.length) lines.push(`**Tools:** ${input.tools.join(', ')}`)
+  if (input.sourceUrls.length) {
+    lines.push('')
+    lines.push('## Source URLs')
+    for (const u of input.sourceUrls) lines.push(`- ${u}`)
+  }
+  if (input.perfSignal) {
+    lines.push('')
+    lines.push('## Performance signal')
+    lines.push(input.perfSignal)
+  }
+  lines.push('')
+  lines.push('Return the JSON now.')
+  return lines.join('\n')
+}
+
+interface NotionBlock {
+  object?: 'block'
+  type: string
+  [k: string]: unknown
+}
+
+function rtText(content: string): unknown[] {
+  return [{ type: 'text', text: { content } }]
+}
+
+function heading2(text: string): NotionBlock {
+  return { object: 'block', type: 'heading_2', heading_2: { rich_text: rtText(text) } }
+}
+
+function paragraph(text: string): NotionBlock {
+  return { object: 'block', type: 'paragraph', paragraph: { rich_text: rtText(text) } }
+}
+
+function bullet(text: string): NotionBlock {
+  return {
+    object: 'block',
+    type: 'bulleted_list_item',
+    bulleted_list_item: { rich_text: rtText(text) },
+  }
+}
+
+export function renderYtScriptToBlocks(s: YTScriptBlocks): NotionBlock[] {
+  const blocks: NotionBlock[] = []
+
+  blocks.push(heading2('Hook'))
+  blocks.push(paragraph(s.hook))
+
+  blocks.push(heading2('Script'))
+  for (const para of s.script.split(/\n\s*\n/)) blocks.push(paragraph(para))
+
+  blocks.push(heading2('On-screen text'))
+  for (const ost of s.onScreenText) blocks.push(bullet(`${ost.timestampSeconds}s — ${ost.text}`))
+
+  blocks.push(heading2('B-roll'))
+  for (const b of s.bRoll) blocks.push(bullet(`${b.timestampSeconds}s — ${b.description}`))
+
+  blocks.push(heading2('Thumbnail'))
+  blocks.push(paragraph(s.thumbnailPrompt))
+
+  blocks.push(heading2('Title variants'))
+  for (const t of s.titleVariants) blocks.push(bullet(t))
+
+  blocks.push(heading2('Hashtags'))
+  blocks.push(paragraph(s.hashtags.map((h) => `#${h}`).join(' ')))
+
+  return blocks
+}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+```bash
+npx vitest run scripts/agent/tests/draft-yt.test.ts
+```
+
+Expected: PASS — all 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/agent/lib/draft-yt.ts scripts/agent/tests/draft-yt.test.ts
+git commit -m "add YT drafting: prompt builders + Notion block renderer"
+```
+
+### Task 5.2: Wire YT branch into `draft.ts`
+
+**Files:**
+
+- Modify: `scripts/agent/draft.ts`
+
+- [ ] **Step 1: Add YT imports and branch**
+
+In `scripts/agent/draft.ts`, replace the existing YT stub section with a real implementation. Update imports at top:
+
+```typescript
+import { loadShortsStyleGuide } from './lib/editorial'
+import { buildYtSystemPrompt, buildYtUserPrompt, renderYtScriptToBlocks } from './lib/draft-yt'
+import { recentChannelStats } from './lib/youtube'
+import { parseJsonResponse } from './lib/claude'
+import { replacePageBody } from './lib/notion'
+import type { YTScriptBlocks } from './lib/types'
+```
+
+Replace the YT branch in `main()`:
+
+```typescript
+} else if (row.kind === 'YT short' || row.kind === 'YT long') {
+  await draftYtRow(row)
+  succeeded++
+```
+
+Add the function below `draftBlogRow`:
+
+```typescript
+async function draftYtRow(row: ContentRow): Promise<void> {
+  const shortsStyleMd = loadShortsStyleGuide()
+  const stats = await recentChannelStats(30)
+  const perfSignal = buildPerfSignal(row.tools, stats)
+
+  const systemPrompt = buildYtSystemPrompt({
+    shortsStyleMd,
+    kind: row.kind,
+    tools: row.tools,
+  })
+  const userPrompt = buildYtUserPrompt({
+    title: row.title,
+    hint: row.hint,
+    sourceUrls: row.sourceUrls,
+    tools: row.tools,
+    perfSignal,
+  })
+
+  console.log(`Calling Claude for YT: ${row.title}`)
+  const json = await runPrompt({ systemPrompt, userPrompt })
+  const parsed = parseJsonResponse<RawYtScript>(json)
+  const blocks: YTScriptBlocks = {
+    hook: parsed.hook,
+    script: parsed.script,
+    onScreenText: parsed.on_screen_text.map((o) => ({
+      timestampSeconds: o.timestamp_seconds,
+      text: o.text,
+    })),
+    bRoll: parsed.b_roll.map((b) => ({
+      timestampSeconds: b.timestamp_seconds,
+      description: b.description,
+    })),
+    thumbnailPrompt: parsed.thumbnail_prompt,
+    titleVariants: parsed.title_variants,
+    hashtags: parsed.hashtags,
+  }
+  const notionBlocks = renderYtScriptToBlocks(blocks)
+  await replacePageBody(row.id, notionBlocks)
+  await updateContentRow(row.id, { stage: 'Drafted' })
+
+  console.log(`✓ YT script drafted for ${row.title}`)
+}
+
+interface RawYtScript {
+  hook: string
+  script: string
+  on_screen_text: Array<{ timestamp_seconds: number; text: string }>
+  b_roll: Array<{ timestamp_seconds: number; description: string }>
+  thumbnail_prompt: string
+  title_variants: string[]
+  hashtags: string[]
+}
+
+function buildPerfSignal(tools: string[], stats: { title: string; views: number }[]): string {
+  if (stats.length === 0) return 'No recent video stats available.'
+  const lines: string[] = ['Recent video performance (last 30 days):']
+  for (const s of stats.slice(0, 10)) {
+    lines.push(`- "${s.title}" — ${s.views} views`)
+  }
+  if (tools.length > 0) {
+    lines.push('')
+    lines.push(`Tools this script covers: ${tools.join(', ')}.`)
+  }
+  return lines.join('\n')
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add scripts/agent/draft.ts
+git commit -m "wire YT drafting branch into draft.ts"
+```
+
+### Task 5.3: Smoke-test the YT drafting flow
+
+**This is a human-action task.**
+
+- [ ] **Step 1: Set a Content row Kind=YT short Stage=Ready in Notion**
+
+- [ ] **Step 2: Trigger workflow_dispatch and watch**
+
+```bash
+gh workflow run agent-draft.yml
+gh run watch
+```
+
+- [ ] **Step 3: Verify outputs**
+
+- Notion row Stage=Drafted, body replaced with the structured script (7 H2 sections)
+- No PR created (correct — YT lives in Notion)
+
+---
+
+## Phase 6: Discovery workflow
+
+### Task 6.1: Write discovery script
+
+**Files:**
+
+- Create: `scripts/agent/discover.ts`
+
+- [ ] **Step 1: Write the script**
+
+```typescript
+// scripts/agent/discover.ts
+import { CONFIG } from './lib/config'
+import { runPrompt, parseJsonResponse } from './lib/claude'
+import { queryContentRows, createContentRow } from './lib/notion'
+import { recentCommits } from './lib/git-scan'
+import { fetchTrending } from './lib/trending'
+import { recentChannelStats } from './lib/youtube'
+import { loadEditorialGuide, loadShortsStyleGuide } from './lib/editorial'
+import { isTitleDuplicate, hasFullToolsOverlap } from './lib/dedupe'
+import type { ContentRow, Candidate, DiscoveryOutput } from './lib/types'
+
+async function main(): Promise<void> {
+  console.log('Discovery: gathering source material...')
+  const [ideaRows, allRows, commits, trending, ytStats] = await Promise.all([
+    queryContentRows({ property: 'Stage', select: { equals: 'Idea' } }),
+    queryContentRows({
+      and: [{ property: 'Stage', select: { does_not_equal: 'Abandoned' } }],
+    }),
+    recentCommits(7),
+    fetchTrending(
+      extractKnownTools(
+        await queryContentRows({ property: 'Tools', multi_select: { is_not_empty: true } })
+      )
+    ),
+    recentChannelStats(30),
+  ])
+
+  const publishedYtRows = allRows.filter(
+    (r) => r.stage === 'Published' && (r.kind === 'YT short' || r.kind === 'YT long')
+  )
+
+  console.log(
+    `Sources: ${ideaRows.length} ideas, ${commits.length} commits, ${trending.length} trending, ${ytStats.length} YT stats`
+  )
+
+  const editorialMd = loadEditorialGuide()
+  const shortsStyleMd = loadShortsStyleGuide()
+
+  const systemPrompt = `You are the discovery agent for shariq.dev. Propose up to 3 new blog candidates and up to 3 new YouTube short candidates that are worth drafting.
+
+Empty arrays are fine — do not propose mediocre candidates to fill slots.
+
+OUTPUT: Valid JSON only, matching this schema:
+
+\`\`\`json
+{
+  "blog_candidates": [
+    {"title": "string", "hint": "string", "tags": ["string"], "source_urls": ["string"], "rationale": "string"}
+  ],
+  "yt_candidates": [
+    {"title": "string", "hint": "string", "tools": ["string"], "source_urls": ["string"], "rationale": "string"}
+  ]
+}
+\`\`\`
+
+# Editorial guide (for blog candidates)
+
+${editorialMd}
+
+# Shorts style (for YT candidates)
+
+${shortsStyleMd}
+`
+
+  const userPrompt = buildDiscoveryUserPrompt({
+    ideaRows,
+    publishedYtRows,
+    commits,
+    trending,
+    ytStats,
+  })
+
+  console.log('Calling Claude for ranking...')
+  const raw = await runPrompt({ systemPrompt, userPrompt })
+  const out = parseJsonResponse<{
+    blog_candidates: Candidate[]
+    yt_candidates: Candidate[]
+  }>(raw)
+
+  // Dedupe + upsert
+  const recentTitles = allRows
+    .filter((r) => Date.now() - new Date(r.createdAt).getTime() < 60 * 86_400_000)
+    .map((r) => r.title)
+
+  let blogCreated = 0
+  for (const c of out.blog_candidates) {
+    if (isTitleDuplicate(c.title, recentTitles)) {
+      console.log(`Skipping blog dupe: ${c.title}`)
+      continue
+    }
+    await createCandidateRow(c, 'blog')
+    blogCreated++
+  }
+
+  const publishedYtToolsByRow = publishedYtRows.map((r) => r.tools)
+  let ytCreated = 0
+  for (const c of out.yt_candidates) {
+    if (isTitleDuplicate(c.title, recentTitles)) {
+      console.log(`Skipping YT dupe (title): ${c.title}`)
+      continue
+    }
+    if (c.tools && hasFullToolsOverlap(c.tools, publishedYtToolsByRow)) {
+      console.log(`Skipping YT dupe (tools covered): ${c.title}`)
+      continue
+    }
+    await createCandidateRow(c, 'YT short')
+    ytCreated++
+  }
+
+  console.log(`Discovery done. Created ${blogCreated} blog + ${ytCreated} YT candidate rows.`)
+}
+
+function extractKnownTools(rowsWithTools: ContentRow[]): string[] {
+  const set = new Set<string>()
+  for (const r of rowsWithTools) for (const t of r.tools) set.add(t.toLowerCase())
+  return [...set]
+}
+
+interface DiscoveryUserPromptInput {
+  ideaRows: ContentRow[]
+  publishedYtRows: ContentRow[]
+  commits: {
+    repo: string
+    sha: string
+    message: string
+    date: string
+    filesChanged: string[]
+    url: string
+  }[]
+  trending: { source: string; title: string; url: string; hint?: string }[]
+  ytStats: { title: string; views: number; likes: number; publishedAt: string }[]
+}
+
+function buildDiscoveryUserPrompt(input: DiscoveryUserPromptInput): string {
+  const lines: string[] = []
+  lines.push(`# Source material for discovery`)
+  lines.push('')
+
+  lines.push('## Existing ideas in Notion (not yet drafted)')
+  if (input.ideaRows.length === 0) lines.push('(none)')
+  for (const r of input.ideaRows.slice(0, 20)) {
+    lines.push(
+      `- **${r.title}** (Kind: ${r.kind}; tags: ${r.tags.join(',') || '–'}) — ${r.hint || ''}`
+    )
+  }
+  lines.push('')
+
+  lines.push('## Recent commits (last 7 days, across active repos)')
+  if (input.commits.length === 0) lines.push('(none)')
+  for (const c of input.commits.slice(0, 40)) {
+    const first = c.message.split('\n')[0]
+    lines.push(
+      `- \`${c.repo}@${c.sha.slice(0, 7)}\` — ${first} (${c.filesChanged.slice(0, 3).join(', ')})`
+    )
+  }
+  lines.push('')
+
+  lines.push('## Trending (GH + HN, AI/dev tool keywords)')
+  if (input.trending.length === 0) lines.push('(none)')
+  for (const t of input.trending.slice(0, 20)) {
+    lines.push(`- [${t.source}] **${t.title}** — ${t.url}${t.hint ? ` (${t.hint})` : ''}`)
+  }
+  lines.push('')
+
+  lines.push('## YouTube performance (channel, last 30 days)')
+  if (input.ytStats.length === 0) lines.push('(no recent uploads)')
+  for (const s of input.ytStats.slice(0, 20)) {
+    lines.push(
+      `- "${s.title}" — ${s.views} views, ${s.likes} likes (${s.publishedAt.slice(0, 10)})`
+    )
+  }
+  lines.push('')
+
+  lines.push(`Today's date: ${new Date().toISOString().slice(0, 10)}`)
+  lines.push('')
+  lines.push('Propose candidates now. Return JSON only.')
+
+  return lines.join('\n')
+}
+
+async function createCandidateRow(c: Candidate, kind: 'blog' | 'YT short'): Promise<void> {
+  await createContentRow({
+    title: c.title,
+    kind,
+    stage: 'Proposed',
+    origin: 'Agent Proposed',
+    tags: c.tags ?? [],
+    tools: c.tools ?? [],
+    hint: c.hint,
+    sourceUrls: c.sourceUrls,
+  })
+  console.log(`+ ${kind}: ${c.title}`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add scripts/agent/discover.ts
+git commit -m "add discovery script"
+```
+
+### Task 6.2: Write `.github/workflows/agent-discover.yml`
+
+**Files:**
+
+- Create: `.github/workflows/agent-discover.yml`
+
+- [ ] **Step 1: Write the workflow**
+
+```yaml
+name: Agent — discover
+
+on:
+  schedule:
+    - cron: '0 3 * * 0' # Sunday 03:00 UTC
+  workflow_dispatch:
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Run discovery
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          NOTION_CONTENT_DB_ID: ${{ vars.NOTION_CONTENT_DB_ID }}
+          YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
+          YOUTUBE_CHANNEL_ID: ${{ vars.YOUTUBE_CHANNEL_ID }}
+          AGENT_GH_TOKEN: ${{ secrets.AGENT_GH_TOKEN }}
+          SCAN_REPO_ORG: ${{ vars.SCAN_REPO_ORG }}
+          SCAN_REPO_INCLUDE: ${{ vars.SCAN_REPO_INCLUDE }}
+          SCAN_REPO_ACTIVE_DAYS: ${{ vars.SCAN_REPO_ACTIVE_DAYS }}
+        run: npm run agent:discover
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .github/workflows/agent-discover.yml
+git commit -m "add agent-discover GH Actions workflow"
+```
+
+### Task 6.3: Smoke-test discovery
+
+**Human-action task.**
+
+- [ ] **Step 1: Trigger manually**
+
+```bash
+gh workflow run agent-discover.yml
+gh run watch
+```
+
+- [ ] **Step 2: Verify candidates in Notion**
+
+Open the `Triage` view. New rows with `Stage=Proposed Origin=Agent Proposed` should appear (up to 3 blog + 3 YT). Each should have a title, hint, source URLs, and tags/tools.
+
+If no candidates created, check workflow logs — could be that no sources had material, which is a valid outcome.
+
+---
+
+## Phase 7: Promotion workflow
+
+### Task 7.1: Write promotion script + tests
+
+**Files:**
+
+- Create: `scripts/agent/promote.ts`
+- Create: `scripts/agent/lib/promote.ts` (pure logic)
+- Test: `scripts/agent/tests/promote.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// scripts/agent/tests/promote.test.ts
+import { describe, it, expect } from 'vitest'
+import { selectRowsNeedingPromotion, buildDerivativeRowInput } from '../lib/promote'
+import type { ContentRow } from '../lib/types'
+
+const baseRow: ContentRow = {
+  id: 'row-1',
+  title: 'A short',
+  kind: 'YT short',
+  stage: 'Published',
+  origin: 'OC',
+  crossPostTargets: ['blog'],
+  tags: ['ai'],
+  tools: ['claude-code'],
+  hint: '',
+  sourceUrls: [],
+  publishedUrl: 'https://youtu.be/abc12345678',
+  createdAt: '2026-06-01T00:00:00Z',
+  updatedAt: '2026-06-02T00:00:00Z',
+}
+
+describe('selectRowsNeedingPromotion', () => {
+  it('selects published YT rows with blog target and no existing derivative', () => {
+    const out = selectRowsNeedingPromotion([baseRow], [])
+    expect(out).toHaveLength(1)
+  })
+
+  it('skips rows without blog target', () => {
+    const r = { ...baseRow, crossPostTargets: [] }
+    expect(selectRowsNeedingPromotion([r], [])).toHaveLength(0)
+  })
+
+  it('skips rows that already have a derivative', () => {
+    const derivative: ContentRow = {
+      ...baseRow,
+      id: 'row-2',
+      kind: 'blog',
+      origin: 'Derivative',
+      sourceRowId: 'row-1',
+    }
+    expect(selectRowsNeedingPromotion([baseRow], [derivative])).toHaveLength(0)
+  })
+
+  it('skips non-published YT rows', () => {
+    const r = { ...baseRow, stage: 'Drafted' as const }
+    expect(selectRowsNeedingPromotion([r], [])).toHaveLength(0)
+  })
+
+  it('skips non-YT rows even if they have blog target', () => {
+    const r = { ...baseRow, kind: 'blog' as const }
+    expect(selectRowsNeedingPromotion([r], [])).toHaveLength(0)
+  })
+})
+
+describe('buildDerivativeRowInput', () => {
+  it('mints a blog derivative carrying tags, tools, and YT URL forward', () => {
+    const out = buildDerivativeRowInput(baseRow)
+    expect(out.kind).toBe('blog')
+    expect(out.stage).toBe('Proposed')
+    expect(out.origin).toBe('Derivative')
+    expect(out.sourceRowId).toBe('row-1')
+    expect(out.tags).toEqual(['ai'])
+    expect(out.tools).toEqual(['claude-code'])
+    expect(out.sourceUrls).toContain('https://youtu.be/abc12345678')
+    expect(out.hint).toContain('Blog-length treatment')
+  })
+})
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+```bash
+npx vitest run scripts/agent/tests/promote.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `lib/promote.ts`**
+
+```typescript
+// scripts/agent/lib/promote.ts
+import type { ContentRow } from './types'
+import type { CreateRowInput } from './notion'
+
+export function selectRowsNeedingPromotion(
+  allRows: ContentRow[],
+  existingDerivatives: ContentRow[]
+): ContentRow[] {
+  const promotedSourceIds = new Set(
+    existingDerivatives
+      .filter((r) => r.origin === 'Derivative' && r.kind === 'blog' && r.sourceRowId)
+      .map((r) => r.sourceRowId as string)
+  )
+  return allRows.filter(
+    (r) =>
+      (r.kind === 'YT short' || r.kind === 'YT long') &&
+      r.stage === 'Published' &&
+      r.crossPostTargets.includes('blog') &&
+      !promotedSourceIds.has(r.id)
+  )
+}
+
+export function buildDerivativeRowInput(source: ContentRow): CreateRowInput {
+  const ytUrl = source.publishedUrl ?? ''
+  const sourceUrls = [...source.sourceUrls]
+  if (ytUrl && !sourceUrls.includes(ytUrl)) sourceUrls.unshift(ytUrl)
+
+  return {
+    title: source.title,
+    kind: 'blog',
+    stage: 'Proposed',
+    origin: 'Derivative',
+    sourceRowId: source.id,
+    tags: source.tags,
+    tools: source.tools,
+    hint: `Blog-length treatment of YT video ${ytUrl}. Expand on: setup, full demo, what surprised me, where this fits.`,
+    sourceUrls,
+  }
+}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+```bash
+npx vitest run scripts/agent/tests/promote.test.ts
+```
+
+Expected: PASS — all 6 tests.
+
+- [ ] **Step 5: Write `scripts/agent/promote.ts`**
+
+```typescript
+// scripts/agent/promote.ts
+import { queryContentRows, createContentRow, addPageComment } from './lib/notion'
+import { selectRowsNeedingPromotion, buildDerivativeRowInput } from './lib/promote'
+
+async function main(): Promise<void> {
+  const allRows = await queryContentRows({
+    property: 'Stage',
+    select: { does_not_equal: 'Abandoned' },
+  })
+  const toPromote = selectRowsNeedingPromotion(allRows, allRows)
+  if (toPromote.length === 0) {
+    console.log('Nothing to promote.')
+    return
+  }
+  console.log(`Promoting ${toPromote.length} row(s)...`)
+  for (const source of toPromote) {
+    try {
+      const input = buildDerivativeRowInput(source)
+      const newId = await createContentRow(input)
+      const newUrl = `https://www.notion.so/${newId.replace(/-/g, '')}`
+      await addPageComment(source.id, `Created derivative blog row: ${newUrl}`)
+      console.log(`✓ ${source.title} → ${newUrl}`)
+    } catch (err) {
+      console.error(`Failed to promote ${source.title}: ${(err as Error).message}`)
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/agent/lib/promote.ts scripts/agent/promote.ts scripts/agent/tests/promote.test.ts
+git commit -m "add promotion: lib (TDD'd) + entry script"
+```
+
+### Task 7.2: Write `.github/workflows/agent-promote.yml`
+
+**Files:**
+
+- Create: `.github/workflows/agent-promote.yml`
+
+- [ ] **Step 1: Write the workflow**
+
+```yaml
+name: Agent — promote
+
+on:
+  schedule:
+    - cron: '0 4 * * *' # Daily 04:00 UTC (2h after draft)
+  workflow_dispatch:
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Run promotion
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          NOTION_CONTENT_DB_ID: ${{ vars.NOTION_CONTENT_DB_ID }}
+          # The rest are unused but required by config.ts:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
+          YOUTUBE_CHANNEL_ID: ${{ vars.YOUTUBE_CHANNEL_ID }}
+          AGENT_GH_TOKEN: ${{ secrets.AGENT_GH_TOKEN }}
+        run: npm run agent:promote
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .github/workflows/agent-promote.yml
+git commit -m "add agent-promote GH Actions workflow"
+```
+
+### Task 7.3: Smoke-test promotion
+
+**Human-action task.**
+
+- [ ] **Step 1: Set up test scenario**
+
+In Notion: pick (or create) a Content row with Kind=YT short, Stage=Published, Cross-post Targets=blog. Confirm no existing derivative row points at it.
+
+- [ ] **Step 2: Trigger workflow**
+
+```bash
+gh workflow run agent-promote.yml
+gh run watch
+```
+
+- [ ] **Step 3: Verify**
+
+- New row in Notion with Kind=blog, Stage=Proposed, Origin=Derivative, Source Row pointing at the YT row
+- Comment posted on the YT row linking to the new derivative
+
+---
+
+## Phase 8: Cutover
+
+### Task 8.1: Update CLAUDE.md with agent docs
+
+**Files:**
+
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Add a new section before `## Deploy`**
+
+In `CLAUDE.md`, add this section between `## Writing posts` and `## Deploy`:
+
+````markdown
+## AI drafting agent (Plan B)
+
+Three GHA workflows under `.github/workflows/agent-*.yml` run on cron:
+
+- **agent-discover** — Sunday 03:00 UTC: scans Notion ideas, recent commits, GH trending, HN, and YT performance; proposes up to 3 blog + 3 YT candidates as Notion rows.
+- **agent-draft** — Daily 02:00 UTC: picks up Content rows with `Stage=Ready`. Blog rows → MDX file + PR. YT rows → script blocks written to the Notion row body.
+- **agent-promote** — Daily 04:00 UTC: for published YT rows with `Cross-post Targets` includes `blog`, mints a linked blog derivative row in `Stage=Proposed`.
+
+Source of truth for content: Notion DB `Content` (see `docs/superpowers/specs/2026-06-02-plan-b-ai-drafting-agent-design.md`).
+
+Local invocation (for prompt iteration without burning CI):
+
+```sh
+npm run agent:discover
+npm run agent:draft
+npm run agent:promote
+```
+````
+
+Each reads `.env.local` (see `.env.local.example`).
+
+Style contracts:
+
+- Blog: `docs/EDITORIAL.md`
+- YouTube: `docs/SHORTS-STYLE.md`
+
+````
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "document AI drafting agent in CLAUDE.md"
+````
+
+### Task 8.2: Update README with agent section
+
+**Files:**
+
+- Modify: `README.md`
+
+- [ ] **Step 1: Append a short section**
+
+Add to `README.md` (location: near the end, after deploy section):
+
+```markdown
+## Drafting pipeline
+
+Posts and YouTube scripts are drafted by a Claude-based agent that reads from a Notion DB of ideas + my recent commits + AI/dev tool trends. The agent never publishes — every blog post goes through PR review on Cloudflare Pages preview; every YouTube script lives in Notion for me to record manually.
+
+See [`docs/superpowers/specs/2026-06-02-plan-b-ai-drafting-agent-design.md`](docs/superpowers/specs/2026-06-02-plan-b-ai-drafting-agent-design.md) for the design.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "add drafting pipeline section to README"
+```
+
+### Task 8.3: Final smoke + crons enabled
+
+The crons defined in the workflow files run automatically once merged to `main`. After merge, monitor the first scheduled run:
+
+- [ ] **Step 1: Merge agent PR to main**
+
+After review:
+
+```bash
+gh pr merge --squash <pr-number>
+```
+
+- [ ] **Step 2: Wait for first scheduled discover run (next Sunday 03:00 UTC)**
+
+Or trigger manually for confidence:
+
+```bash
+gh workflow run agent-discover.yml
+gh workflow run agent-draft.yml
+gh workflow run agent-promote.yml
+```
+
+- [ ] **Step 3: Update Solo todo**
+
+Mark Solo todo #37 (Plan B) complete.
+
+```bash
+# Or via Solo MCP
+```
+
+---
+
+## Done
+
+The agent is live. Going forward:
+
+- Drop ideas in Notion `Content` DB with `Kind`, `Stage=Idea`
+- Each Sunday morning, check the `Triage` view for new candidates
+- Flip `Stage=Ready` on anything you want drafted
+- Wake up Monday to a PR (blog) or filled-in script (YT) waiting for you
+- After publishing a YT short, set `Cross-post Targets=blog` to auto-mint a blog derivative
+
+---
+
+## Open follow-ups (out of scope for v1, tracked in spec's "Open questions")
+
+- Tools registry as separate DB (if the multi-select grows past ~30 entries)
+- YT performance window tuning
+- PR auto-labeling beyond `agent-draft`
+- Blog → YT script derivative direction
+- Hero image generation
+- Notion webhook for sub-minute draft trigger

--- a/docs/superpowers/plans/2026-06-02-plan-b-ai-drafting-agent.md
+++ b/docs/superpowers/plans/2026-06-02-plan-b-ai-drafting-agent.md
@@ -624,6 +624,12 @@ To the existing `Origin` property, add: `Agent Proposed`, `Derivative`. Keep `OC
 - `Hint` — Text
 - `Draft URL` — URL
 
+- [ ] **Step 6.5: (Recommended) Add a `Site` property for future multi-site support**
+
+- Type: Select (single)
+- Options: `shariq.dev` (set as default for all existing rows)
+- Cost today: ~10 seconds in the UI; cost later: trivial agent filter when a second site (e.g., lognote) joins. The agent doesn't read this property in v1, but adding it now means future multi-site is a drop-in instead of a schema-migration project. Skip if you're sure no other sites will publish through this DB.
+
 - [ ] **Step 7: Optionally rename `Published Link` → `Published URL`**
 
 Cosmetic. The migration script reads either name.

--- a/docs/superpowers/plans/2026-06-02-plan-b-ai-drafting-agent.md
+++ b/docs/superpowers/plans/2026-06-02-plan-b-ai-drafting-agent.md
@@ -6,7 +6,7 @@
 
 **Architecture:** Three TypeScript scripts under `scripts/agent/` invoked by separate GitHub Actions workflows on cron + manual dispatch. All call the Claude Agent SDK via subscription OAuth (no per-token billing). Notion is HTTP, GitHub PRs are `gh` CLI. No MCP servers spawned in CI. A new `Content` Notion DB replaces the existing `CMS` DB via a one-shot migration script.
 
-**Tech Stack:** Node 22, TypeScript strict, `@anthropic-ai/claude-agent-sdk`, `tsx` (TS runner), Vitest, native `fetch`, `gh` CLI, Vale, Notion HTTP API v2025-09-03, YouTube Data API v3, Hacker News Firebase API.
+**Tech Stack:** Node 24 (current LTS), TypeScript strict, `@anthropic-ai/claude-agent-sdk` (latest), `tsx` (TS runner), Vitest, native `fetch`, `gh` CLI, Vale 3.14.2, Notion HTTP API v2025-09-03, YouTube Data API v3, Hacker News Firebase API.
 
 **Out of scope (deferred to v2):** hero image generation; Notion webhooks (replaces hourly poll); blog→YT derivative direction; podcast/presentation/IG-reel drafting (schema reserves Kind slots but no per-Kind drafting code).
 
@@ -207,6 +207,90 @@ git commit -m "add SHORTS-STYLE.md for YT script generation"
 ---
 
 ## Phase 1: Scaffolding, deps, config
+
+### Task 1.0: Bump project to Node 24 LTS
+
+The existing site is pinned to Node 22. Bring the whole project to the current Active LTS (Node 24) so the agent and the site share one runtime. Node 22 stays in maintenance until April 2027 but Node 24 has been LTS since October 2025 — no reason to lag.
+
+**Files:**
+
+- Modify: `package.json` (engines field)
+- Modify: `.github/workflows/deploy.yml`
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Bump `engines.node` in `package.json`**
+
+In `package.json`, find:
+
+```json
+"engines": {
+  "node": ">=22.12.0"
+}
+```
+
+Replace with:
+
+```json
+"engines": {
+  "node": ">=24"
+}
+```
+
+- [ ] **Step 2: Bump deploy workflow**
+
+In `.github/workflows/deploy.yml`, find:
+
+```yaml
+node-version: '22'
+```
+
+Replace with:
+
+```yaml
+node-version: '24'
+```
+
+- [ ] **Step 3: Bump CI workflow**
+
+In `.github/workflows/ci.yml`, find:
+
+```yaml
+node-version: '22'
+```
+
+Replace with:
+
+```yaml
+node-version: '24'
+```
+
+- [ ] **Step 4: Verify locally**
+
+Run:
+
+```bash
+node --version
+```
+
+If you're on Node < 24, install via `nvm` / `fnm` / your version manager.
+
+Then verify the full build + tests still pass:
+
+```bash
+npm ci
+npm run astro check
+npm test
+npm run build
+```
+
+Expected: all PASS. If anything breaks on Node 24, fix before continuing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add package.json .github/workflows/deploy.yml .github/workflows/ci.yml
+git commit -m "bump project to Node 24 LTS (was 22)"
+```
 
 ### Task 1.1: Install dependencies
 
@@ -2884,14 +2968,14 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
 
       - run: npm ci
 
       - name: Install Vale
         run: |
-          curl -fsSL -o vale.tar.gz https://github.com/errata-ai/vale/releases/download/v3.9.1/vale_3.9.1_Linux_64-bit.tar.gz
+          curl -fsSL -o vale.tar.gz https://github.com/errata-ai/vale/releases/download/v3.14.2/vale_3.14.2_Linux_64-bit.tar.gz
           tar -xzf vale.tar.gz vale
           sudo mv vale /usr/local/bin/
 
@@ -3549,7 +3633,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
 
       - run: npm ci
@@ -3806,7 +3890,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
 
       - run: npm ci

--- a/docs/superpowers/plans/2026-06-02-plan-b-ai-drafting-agent.md
+++ b/docs/superpowers/plans/2026-06-02-plan-b-ai-drafting-agent.md
@@ -4,7 +4,7 @@
 
 **Goal:** Ship the v1 AI drafting agent as designed in [2026-06-02-plan-b-ai-drafting-agent-design.md](../specs/2026-06-02-plan-b-ai-drafting-agent-design.md). End state: three GitHub Actions workflows that propose, draft, and promote blog posts + YouTube scripts based on Notion ideas and recent commits, with all output reviewed by the user before publishing.
 
-**Architecture:** Three TypeScript scripts under `scripts/agent/` invoked by separate GitHub Actions workflows on cron + manual dispatch. All call the Claude Agent SDK via subscription OAuth (no per-token billing). Notion is HTTP, GitHub PRs are `gh` CLI. No MCP servers spawned in CI. A new `Content` Notion DB replaces the existing `CMS` DB via a one-shot migration script.
+**Architecture:** Three TypeScript scripts under `scripts/agent/` invoked by separate GitHub Actions workflows on cron + manual dispatch. All call the Claude Agent SDK via subscription OAuth (no per-token billing). Notion is HTTP, GitHub PRs are `gh` CLI. No MCP servers spawned in CI. The existing CMS Notion DB is restructured in place via a one-shot migration script.
 
 **Tech Stack:** Node 24 (current LTS), TypeScript strict, `@anthropic-ai/claude-agent-sdk` (latest), `tsx` (TS runner), Vitest, native `fetch`, `gh` CLI, Vale 3.14.2, Notion HTTP API v2025-09-03, YouTube Data API v3, Hacker News Firebase API.
 
@@ -363,7 +363,7 @@ git commit -m "add agent + migration npm scripts"
 CLAUDE_CODE_OAUTH_TOKEN=
 
 # Notion integration token — create at https://www.notion.so/profile/integrations
-# Share the Content DB with the integration after creating it.
+# Share the CMS DB with the integration after creating it.
 NOTION_TOKEN=
 
 # YouTube Data API v3 key — create at https://console.cloud.google.com/apis/credentials
@@ -374,7 +374,7 @@ YOUTUBE_API_KEY=
 AGENT_GH_TOKEN=
 
 # Config (also settable as GH repo variables in CI)
-NOTION_CONTENT_DB_ID=
+NOTION_CMS_DB_ID=d25e9f1c0a3345589592fce32f7bc02b
 YOUTUBE_CHANNEL_ID=
 SCAN_REPO_ORG=shariqh
 SCAN_REPO_INCLUDE=blog-site,lognote
@@ -423,7 +423,7 @@ function optional(key: string, fallback: string): string {
 export const CONFIG = {
   claudeOauthToken: required('CLAUDE_CODE_OAUTH_TOKEN'),
   notionToken: required('NOTION_TOKEN'),
-  notionContentDbId: required('NOTION_CONTENT_DB_ID'),
+  notionCmsDbId: required('NOTION_CMS_DB_ID'),
   youtubeApiKey: required('YOUTUBE_API_KEY'),
   youtubeChannelId: required('YOUTUBE_CHANNEL_ID'),
   agentGhToken: required('AGENT_GH_TOKEN'),
@@ -431,9 +431,6 @@ export const CONFIG = {
   scanRepoOrg: optional('SCAN_REPO_ORG', 'shariqh'),
   scanRepoInclude: optional('SCAN_REPO_INCLUDE', 'blog-site,lognote').split(','),
   scanRepoActiveDays: parseInt(optional('SCAN_REPO_ACTIVE_DAYS', '30'), 10),
-
-  // Set by `npm run migrate:cms` — old DB to read from once before deprecation.
-  notionLegacyCmsDbId: process.env.NOTION_LEGACY_CMS_DB_ID,
 } as const
 
 export type Config = typeof CONFIG
@@ -444,7 +441,7 @@ export type Config = typeof CONFIG
 Run:
 
 ```bash
-NOTION_TOKEN=x NOTION_CONTENT_DB_ID=x CLAUDE_CODE_OAUTH_TOKEN=x YOUTUBE_API_KEY=x YOUTUBE_CHANNEL_ID=x AGENT_GH_TOKEN=x npx tsx -e "import('./scripts/agent/lib/config.ts').then(m => console.log(Object.keys(m.CONFIG)))"
+NOTION_TOKEN=x NOTION_CMS_DB_ID=x CLAUDE_CODE_OAUTH_TOKEN=x YOUTUBE_API_KEY=x YOUTUBE_CHANNEL_ID=x AGENT_GH_TOKEN=x npx tsx -e "import('./scripts/agent/lib/config.ts').then(m => console.log(Object.keys(m.CONFIG)))"
 ```
 
 Expected: prints the array of config keys.
@@ -580,67 +577,72 @@ git commit -m "add agent shared types"
 
 ## Phase 2: Notion redesign + migration
 
-### Task 2.1: Hand-create the `Content` Notion DB
+### Task 2.1: Restructure the CMS Notion DB schema in place
 
-**This is a manual user action.** Pause for the user to do this before any agent code runs.
+**This is a manual user action in the Notion UI.** Pause for the user to do this before the migration script (Task 2.6) runs.
 
-- [ ] **Step 1: Create the DB**
+The existing CMS DB stays — same ID, same rows, same URLs. We restructure the schema instead of cloning to a new DB.
 
-In Notion:
+- [ ] **Step 1: Rename `Status` → `Stage`**
 
-1. Open your workspace, click `+ New Page`
-2. Select `Database — Full page`
-3. Title it `Content`
-4. Delete the default Name property → keep `Title` (Notion forces a title field; rename if needed)
+In Notion, on the CMS DB:
 
-- [ ] **Step 2: Add properties in this exact order with these exact options**
+- Click the Status property header → ⋯ → Edit property → rename to `Stage`
+- Notion preserves all existing row values automatically
 
-| Property             | Type         | Options                                                                                |
-| -------------------- | ------------ | -------------------------------------------------------------------------------------- |
-| `Kind`               | Select       | `blog`, `YT short`, `YT long`, `podcast`, `presentation`, `IG reel`, `stand up`        |
-| `Stage`              | Select       | `Idea`, `Proposed`, `Ready`, `Drafted`, `Recorded`, `Edited`, `Published`, `Abandoned` |
-| `Origin`             | Select       | `OC`, `Agent Proposed`, `Derivative`                                                   |
-| `Source Row`         | Relation     | Target: this same `Content` DB. Show on related: yes. Limit: 1.                        |
-| `Cross-post Targets` | Multi-select | `blog`, `YT short`, `YT long`                                                          |
-| `Tags`               | Multi-select | (leave empty — agent + you add over time)                                              |
-| `Tools`              | Multi-select | (leave empty)                                                                          |
-| `Hint`               | Text         |                                                                                        |
-| `Source URLs`        | Text         |                                                                                        |
-| `Draft URL`          | URL          |                                                                                        |
-| `Published URL`      | URL          |                                                                                        |
-| `Publishing`         | Date         |                                                                                        |
+- [ ] **Step 2: Rename Status options to new Stage values**
 
-Notion adds `Created` and `Updated` automatically. Don't add `Created time` / `Last edited time` manually.
+For each existing option, edit and rename:
 
-- [ ] **Step 3: Share with Claude Code MCP integration**
+- `Prepping` → `Idea`
+- `Ready To Record` → `Ready`
+- `Recording` → `Recorded`
+- `Post-Processing` → `Edited`
+- `Published` stays `Published`
+- `Abandoned` stays `Abandoned`
+- `✅` → re-tag any rows using ✅ to `Published`, then delete the ✅ option
 
-Top-right `...` → `Connections` → add `Claude Code MCP`. Same integration you connected to the legacy CMS DB.
+- [ ] **Step 3: Add new Stage options**
 
-- [ ] **Step 4: Copy DB ID for env config**
+Add: `Proposed`, `Drafted`. These are agent states that don't exist yet.
 
-Copy the URL of the Content DB page. The DB ID is the 32-char hex segment before `?v=`. Example: `https://www.notion.so/<DB_ID>?v=...`
+- [ ] **Step 4: Add a new property `Kind`**
+
+- Type: Select (single)
+- Options: `blog`, `YT short`, `YT long`, `podcast`, `presentation`, `IG reel`, `stand up`
+- Leave empty — migration will backfill from Medium.
+
+- [ ] **Step 5: Add Origin options**
+
+To the existing `Origin` property, add: `Agent Proposed`, `Derivative`. Keep `OC`, `x-post:bundle`, `x-post:blog`.
+
+- [ ] **Step 6: Add 5 new properties**
+
+- `Source Row` — Relation, target: this same CMS DB, limit 1
+- `Cross-post Targets` — Multi-select, options: `blog`, `YT short`, `YT long`
+- `Tools` — Multi-select (empty pool)
+- `Hint` — Text
+- `Draft URL` — URL
+
+- [ ] **Step 7: Optionally rename `Published Link` → `Published URL`**
+
+Cosmetic. The migration script reads either name.
+
+- [ ] **Step 8: Capture the DB ID**
+
+The CMS DB URL contains the ID — `https://www.notion.so/<DB_ID>?v=...`. It's `d25e9f1c0a3345589592fce32f7bc02b` if you haven't moved the page.
 
 Add to your local `.env.local`:
 
 ```
-NOTION_CONTENT_DB_ID=<that-id>
+NOTION_CMS_DB_ID=d25e9f1c0a3345589592fce32f7bc02b
 ```
 
-Also set in GitHub repo variables (next phase will use it; can do now or later):
+And in GitHub:
 
 ```bash
-gh variable set NOTION_CONTENT_DB_ID --body "<that-id>"
+gh variable set NOTION_CMS_DB_ID --body "d25e9f1c0a3345589592fce32f7bc02b"
 ```
-
-- [ ] **Step 5: Note legacy CMS DB ID**
-
-In `.env.local` add:
-
-```
-NOTION_LEGACY_CMS_DB_ID=d25e9f1c0a3345589592fce32f7bc02b
-```
-
-This is only used by the migration script.
 
 ### Task 2.2: TDD `scripts/agent/lib/dedupe.ts`
 
@@ -1015,7 +1017,7 @@ export function pageToContentRow(page: NotionPage): ContentRow {
 // ---------- Public DB ops ----------
 
 export async function queryContentRows(filter: object, sorts?: object[]): Promise<ContentRow[]> {
-  const dataSourceId = await getDataSourceIdForDb(CONFIG.notionContentDbId)
+  const dataSourceId = await getDataSourceIdForDb(CONFIG.notionCmsDbId)
   const rows: ContentRow[] = []
   let cursor: string | undefined
   do {
@@ -1056,7 +1058,7 @@ export interface CreateRowInput {
 }
 
 export async function createContentRow(input: CreateRowInput): Promise<string> {
-  const dataSourceId = await getDataSourceIdForDb(CONFIG.notionContentDbId)
+  const dataSourceId = await getDataSourceIdForDb(CONFIG.notionCmsDbId)
   const body = {
     parent: { type: 'data_source_id', data_source_id: dataSourceId },
     properties: buildPropertiesPayload(input),
@@ -1451,240 +1453,23 @@ git add scripts/agent/lib/migrate-mapping.ts scripts/agent/lib/types.ts scripts/
 git commit -m "add CMS-to-Content row mapping with tests"
 ```
 
-### Task 2.5: Write `migrate-cms.ts` (dry-run mode)
+### Task 2.5: Write `migrate-cms.ts` (in-place rewrite)
 
 **Files:**
 
-- Create: `scripts/agent/migrate-cms.ts`
+- Create/modify: `scripts/agent/migrate-cms.ts`
+
+The script is an in-place migration: source and destination are the same CMS DB. See the file itself for inline comments on the algorithm. Key points:
+
+- Reads `CONFIG.notionCmsDbId` (was `notionContentDbId`)
+- Idempotent: rows where `Kind` is already set are skipped
+- Single-Medium rows: PATCH the existing page with Kind, Hint, Source URLs
+- Multi-Medium rows: PATCH the primary + CREATE sibling pages with `Origin=Derivative` and `Source Row` → primary's page ID
+- `x-post:blog` rows get `Origin` upgraded to `Derivative`
 
 - [ ] **Step 1: Write the script**
 
-```typescript
-// scripts/agent/migrate-cms.ts
-import { CONFIG } from './lib/config'
-import { mapCmsRowToContentRows } from './lib/migrate-mapping'
-import { createContentRow } from './lib/notion'
-import type { CmsRow, MappedRow, LegacyMedium, LegacyStatus, LegacyOrigin } from './lib/types'
-
-const DRY_RUN = process.argv.includes('--dry-run')
-const EXECUTE = process.argv.includes('--execute')
-
-if (!DRY_RUN && !EXECUTE) {
-  console.error('Usage: npm run migrate:cms -- (--dry-run | --execute)')
-  process.exit(1)
-}
-
-const NOTION_VERSION = '2025-09-03'
-
-async function fetchLegacyCmsRows(legacyDbId: string): Promise<CmsRow[]> {
-  // Get data source for legacy DB
-  const dbRes = await fetch(`https://api.notion.com/v1/databases/${legacyDbId}`, {
-    headers: {
-      Authorization: `Bearer ${CONFIG.notionToken}`,
-      'Notion-Version': NOTION_VERSION,
-    },
-  })
-  if (!dbRes.ok) throw new Error(`Failed to fetch legacy DB: ${dbRes.status}`)
-  const db = (await dbRes.json()) as { data_sources: Array<{ id: string }> }
-  const ds = db.data_sources[0]?.id
-  if (!ds) throw new Error('No data source on legacy CMS DB')
-
-  const rows: CmsRow[] = []
-  let cursor: string | undefined
-  do {
-    const body = JSON.stringify({ start_cursor: cursor, page_size: 100 })
-    const res = await fetch(`https://api.notion.com/v1/data_sources/${ds}/query`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${CONFIG.notionToken}`,
-        'Notion-Version': NOTION_VERSION,
-        'Content-Type': 'application/json',
-      },
-      body,
-    })
-    if (!res.ok) throw new Error(`Legacy query failed: ${res.status} ${await res.text()}`)
-    const data = (await res.json()) as {
-      results: Array<{ id: string; properties: Record<string, unknown> }>
-      has_more: boolean
-      next_cursor?: string
-    }
-    for (const p of data.results) {
-      rows.push(extractCmsRow(p))
-    }
-    cursor = data.has_more ? data.next_cursor : undefined
-  } while (cursor)
-  return rows
-}
-
-function extractCmsRow(page: { id: string; properties: Record<string, unknown> }): CmsRow {
-  const p = page.properties as Record<string, { type: string; [k: string]: unknown }>
-  const text = (prop: { type: string; [k: string]: unknown } | undefined): string => {
-    if (!prop) return ''
-    if (prop.type === 'title')
-      return ((prop as { title: Array<{ plain_text: string }> }).title ?? [])
-        .map((t) => t.plain_text)
-        .join('')
-    if (prop.type === 'rich_text')
-      return ((prop as { rich_text: Array<{ plain_text: string }> }).rich_text ?? [])
-        .map((t) => t.plain_text)
-        .join('')
-    return ''
-  }
-  const select = <T extends string>(
-    prop: { type: string; [k: string]: unknown } | undefined
-  ): T | undefined => {
-    if (!prop || prop.type !== 'select') return undefined
-    const sel = (prop as { select: { name: string } | null }).select
-    return sel ? (sel.name as T) : undefined
-  }
-  const multi = <T extends string>(
-    prop: { type: string; [k: string]: unknown } | undefined
-  ): T[] => {
-    if (!prop || prop.type !== 'multi_select') return []
-    return ((prop as { multi_select: Array<{ name: string }> }).multi_select ?? []).map(
-      (m) => m.name as T
-    )
-  }
-  const url = (prop: { type: string; [k: string]: unknown } | undefined): string | undefined => {
-    if (!prop || prop.type !== 'url') return undefined
-    return (prop as { url: string | null }).url ?? undefined
-  }
-  const date = (prop: { type: string; [k: string]: unknown } | undefined): string | undefined => {
-    if (!prop || prop.type !== 'date') return undefined
-    return (prop as { date: { start: string } | null }).date?.start
-  }
-  const num = (prop: { type: string; [k: string]: unknown } | undefined): number | undefined => {
-    if (!prop || prop.type !== 'number') return undefined
-    return (prop as { number: number | null }).number ?? undefined
-  }
-  return {
-    id: page.id,
-    title: text(p['Title']),
-    status: select<LegacyStatus>(p['Status']),
-    medium: multi<LegacyMedium>(p['Medium']),
-    origin: select<LegacyOrigin>(p['Origin']),
-    tags: multi<string>(p['Tags']),
-    type: select<string>(p['Type']),
-    keywords: text(p['Keywords']),
-    sources: text(p['Source(s)']),
-    publishedLink: url(p['Published Link']),
-    publishing: date(p['Publishing']),
-    no: num(p['No.']),
-  }
-}
-
-async function main(): Promise<void> {
-  const legacyId = CONFIG.notionLegacyCmsDbId
-  if (!legacyId) {
-    console.error('Set NOTION_LEGACY_CMS_DB_ID in .env.local')
-    process.exit(1)
-  }
-  console.log(`Fetching legacy CMS rows from ${legacyId}...`)
-  const rows = await fetchLegacyCmsRows(legacyId)
-  console.log(`Fetched ${rows.length} legacy rows.`)
-
-  const mapped: Array<{ source: CmsRow; out: MappedRow[] }> = rows.map((r) => ({
-    source: r,
-    out: mapCmsRowToContentRows(r),
-  }))
-
-  // Report
-  const splits = mapped.filter((m) => m.out.length > 1)
-  const totalOutRows = mapped.reduce((s, m) => s + m.out.length, 0)
-
-  console.log('\n=== Migration report ===')
-  console.log(`Input rows:      ${rows.length}`)
-  console.log(`Output rows:     ${totalOutRows}`)
-  console.log(`Rows being split:${splits.length}`)
-  console.log(
-    `New rows created:${totalOutRows - rows.length} (from splits; primary rows reuse original page ID)`
-  )
-
-  if (splits.length > 0) {
-    console.log('\nSplit rows:')
-    for (const s of splits) {
-      console.log(
-        `  ${s.source.title}: ${s.source.medium.join(',')} → ${s.out.map((o) => o.kind).join(',')}`
-      )
-    }
-  }
-
-  if (DRY_RUN) {
-    console.log('\n[dry-run] No writes performed. Re-run with --execute to apply.')
-    return
-  }
-
-  // Execute mode — refuse if Content DB has any rows
-  console.log('\nChecking destination DB is empty...')
-  const dest = await fetch(
-    `https://api.notion.com/v1/data_sources/${await getDataSourceId(CONFIG.notionContentDbId)}/query`,
-    {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${CONFIG.notionToken}`,
-        'Notion-Version': NOTION_VERSION,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ page_size: 1 }),
-    }
-  )
-  if (!dest.ok) throw new Error(`Destination check failed: ${dest.status}`)
-  const destData = (await dest.json()) as { results: unknown[] }
-  if (destData.results.length > 0) {
-    console.error('Destination Content DB is not empty. Aborting to avoid double-import.')
-    process.exit(1)
-  }
-
-  console.log('Executing migration...')
-  let created = 0
-  for (const m of mapped) {
-    // Create primary first; capture its new ID so derivatives in this group
-    // can link to it directly. This avoids the title-collision risk of a
-    // post-hoc title-based linking pass.
-    const newIdsByOriginalPageId = new Map<string, string>()
-    let primaryNewId: string | null = null
-    for (const out of m.out) {
-      const sourceRowId = out.sourceRowOriginalPageId && primaryNewId ? primaryNewId : undefined
-      const id = await createContentRow({
-        title: out.title,
-        kind: out.kind,
-        stage: out.stage,
-        origin: out.origin,
-        crossPostTargets: out.crossPostTargets,
-        tags: out.tags,
-        tools: out.tools,
-        hint: out.hint,
-        sourceUrls: out.sourceUrls,
-        publishedUrl: out.publishedUrl,
-        publishingDate: out.publishingDate,
-        sourceRowId,
-      })
-      if (!out.sourceRowOriginalPageId) primaryNewId = id
-      newIdsByOriginalPageId.set(m.source.id, id)
-      created++
-      if (created % 10 === 0) console.log(`  created ${created} rows...`)
-    }
-  }
-
-  console.log(`Done. Created ${created} rows.`)
-}
-
-async function getDataSourceId(dbId: string): Promise<string> {
-  const dbRes = await fetch(`https://api.notion.com/v1/databases/${dbId}`, {
-    headers: {
-      Authorization: `Bearer ${CONFIG.notionToken}`,
-      'Notion-Version': NOTION_VERSION,
-    },
-  })
-  const db = (await dbRes.json()) as { data_sources: Array<{ id: string }> }
-  return db.data_sources[0].id
-}
-
-main().catch((err) => {
-  console.error(err)
-  process.exit(1)
-})
-```
+See `scripts/agent/migrate-cms.ts` — the file reflects the current (in-place) implementation.
 
 - [ ] **Step 2: Test dry-run mode locally**
 
@@ -1694,20 +1479,18 @@ Run:
 npm run migrate:cms -- --dry-run
 ```
 
-Expected: prints `Migration report` with input count, output count, split rows. No Notion writes.
+Expected: prints `=== Migration plan ===` with total rows, already-migrated count, rows to PATCH, siblings to CREATE. No Notion writes.
 
 - [ ] **Step 3: Commit**
 
 ```bash
 git add scripts/agent/migrate-cms.ts
-git commit -m "add CMS-to-Content migration script with dry-run + execute modes"
+git commit -m "refactor migrate-cms.ts: in-place CMS rewrite (patch existing rows, create siblings)"
 ```
 
 ### Task 2.6: Run the migration (one-time human action)
 
-**This task is for the human, not the agent.**
-
-- [ ] **Step 1: Run dry-run, review output**
+- [ ] **Step 1: Dry-run, review output**
 
 ```bash
 npm run migrate:cms -- --dry-run
@@ -1715,37 +1498,38 @@ npm run migrate:cms -- --dry-run
 
 Confirm:
 
-- Input row count matches what you see in Notion
-- Split rows make sense (multi-medium rows split as expected)
-- No rows missing
+- "Total rows in CMS" matches your row count
+- "Already migrated" is 0 (first run) or non-zero if you've already partially migrated
+- Splits make sense (e.g., a multi-Medium row shows the primary Kind and the sibling Kinds you'd expect)
 
-- [ ] **Step 2: Run execute mode**
+- [ ] **Step 2: Execute**
 
 ```bash
 npm run migrate:cms -- --execute
 ```
 
-Expected: prints "Created N rows. Done." Refuses if Content DB has any rows already.
+Expected: prints "Patched N rows, created M sibling rows."
 
 - [ ] **Step 3: Spot-check in Notion**
 
-Open the `Content` DB. Verify:
+In the CMS DB:
 
-- All rows present with expected Kind/Stage/Origin
-- Split rows show up as separate rows with Source Row relation populated on the derivatives
-- Old `CMS` DB untouched
+- Every row should now have `Kind` populated
+- A multi-Medium row's primary should have `Cross-post Targets` listing the other Mediums
+- New sibling rows should have `Origin=Derivative` and `Source Row` linking to the primary
+- Stage values should match the renamed options
+- Legacy properties (Medium, Type, Keywords, Source(s)) are still present on rows — they're not deleted
 
-- [ ] **Step 4: Build the recommended views in Notion**
+- [ ] **Step 4: Build new agent-facing views**
 
-Manually create these views (Notion UI):
+These views don't replace your existing CMS views; they augment for the agent workflow:
 
-| View               | Filter                                      | Sort                        |
-| ------------------ | ------------------------------------------- | --------------------------- |
-| Triage             | Stage in [Proposed, Ready]                  | Created desc                |
-| In flight          | Stage in [Ready, Drafted, Recorded, Edited] | Updated desc                |
-| Recently published | Stage = Published                           | Publishing desc             |
-| Ideas inbox        | Stage = Idea                                | Created desc                |
-| By Kind            | (no filter)                                 | grouped by Kind, then Stage |
+| View        | Filter                                      | Sort                        |
+| ----------- | ------------------------------------------- | --------------------------- |
+| Triage      | Stage in [Proposed, Ready]                  | Created desc                |
+| In flight   | Stage in [Ready, Drafted, Recorded, Edited] | Updated desc                |
+| Ideas inbox | Stage = Idea                                | Created desc                |
+| By Kind     | (no filter)                                 | grouped by Kind, then Stage |
 
 ---
 
@@ -2988,7 +2772,7 @@ jobs:
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
-          NOTION_CONTENT_DB_ID: ${{ vars.NOTION_CONTENT_DB_ID }}
+          NOTION_CMS_DB_ID: ${{ vars.NOTION_CMS_DB_ID }}
           YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
           YOUTUBE_CHANNEL_ID: ${{ vars.YOUTUBE_CHANNEL_ID }}
           AGENT_GH_TOKEN: ${{ secrets.AGENT_GH_TOKEN }}
@@ -3018,16 +2802,16 @@ gh secret set NOTION_TOKEN --body "<your notion token>"
 gh secret set YOUTUBE_API_KEY --body "<your YT key>"
 gh secret set AGENT_GH_TOKEN --body "<your fine-grained PAT>"
 
-gh variable set NOTION_CONTENT_DB_ID --body "<content db id>"
+gh variable set NOTION_CMS_DB_ID --body "d25e9f1c0a3345589592fce32f7bc02b"
 gh variable set YOUTUBE_CHANNEL_ID --body "<your channel id>"
 gh variable set SCAN_REPO_ORG --body "shariqh"
 gh variable set SCAN_REPO_INCLUDE --body "blog-site,lognote"
 gh variable set SCAN_REPO_ACTIVE_DAYS --body "30"
 ```
 
-- [ ] **Step 2: Manually set a Content row to Stage=Ready**
+- [ ] **Step 2: Manually set a CMS row to Stage=Ready**
 
-In Notion, pick a Content row with Kind=blog. Set Stage=Ready.
+In Notion, pick a CMS row with Kind=blog. Set Stage=Ready.
 
 - [ ] **Step 3: Trigger the workflow manually**
 
@@ -3373,7 +3157,7 @@ git commit -m "wire YT drafting branch into draft.ts"
 
 **This is a human-action task.**
 
-- [ ] **Step 1: Set a Content row Kind=YT short Stage=Ready in Notion**
+- [ ] **Step 1: Set a CMS row Kind=YT short Stage=Ready in Notion**
 
 - [ ] **Step 2: Trigger workflow_dispatch and watch**
 
@@ -3642,7 +3426,7 @@ jobs:
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
-          NOTION_CONTENT_DB_ID: ${{ vars.NOTION_CONTENT_DB_ID }}
+          NOTION_CMS_DB_ID: ${{ vars.NOTION_CMS_DB_ID }}
           YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
           YOUTUBE_CHANNEL_ID: ${{ vars.YOUTUBE_CHANNEL_ID }}
           AGENT_GH_TOKEN: ${{ secrets.AGENT_GH_TOKEN }}
@@ -3898,7 +3682,7 @@ jobs:
       - name: Run promotion
         env:
           NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
-          NOTION_CONTENT_DB_ID: ${{ vars.NOTION_CONTENT_DB_ID }}
+          NOTION_CMS_DB_ID: ${{ vars.NOTION_CMS_DB_ID }}
           # The rest are unused but required by config.ts:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
@@ -3920,7 +3704,7 @@ git commit -m "add agent-promote GH Actions workflow"
 
 - [ ] **Step 1: Set up test scenario**
 
-In Notion: pick (or create) a Content row with Kind=YT short, Stage=Published, Cross-post Targets=blog. Confirm no existing derivative row points at it.
+In Notion: pick (or create) a CMS row with Kind=YT short, Stage=Published, Cross-post Targets=blog. Confirm no existing derivative row points at it.
 
 - [ ] **Step 2: Trigger workflow**
 
@@ -3954,10 +3738,10 @@ In `CLAUDE.md`, add this section between `## Writing posts` and `## Deploy`:
 Three GHA workflows under `.github/workflows/agent-*.yml` run on cron:
 
 - **agent-discover** — Sunday 03:00 UTC: scans Notion ideas, recent commits, GH trending, HN, and YT performance; proposes up to 3 blog + 3 YT candidates as Notion rows.
-- **agent-draft** — Daily 02:00 UTC: picks up Content rows with `Stage=Ready`. Blog rows → MDX file + PR. YT rows → script blocks written to the Notion row body.
+- **agent-draft** — Daily 02:00 UTC: picks up CMS rows with `Stage=Ready`. Blog rows → MDX file + PR. YT rows → script blocks written to the Notion row body.
 - **agent-promote** — Daily 04:00 UTC: for published YT rows with `Cross-post Targets` includes `blog`, mints a linked blog derivative row in `Stage=Proposed`.
 
-Source of truth for content: Notion DB `Content` (see `docs/superpowers/specs/2026-06-02-plan-b-ai-drafting-agent-design.md`).
+Source of truth for content: Notion CMS DB (see `docs/superpowers/specs/2026-06-02-plan-b-ai-drafting-agent-design.md`).
 
 Local invocation (for prompt iteration without burning CI):
 
@@ -4045,7 +3829,7 @@ Mark Solo todo #37 (Plan B) complete.
 
 The agent is live. Going forward:
 
-- Drop ideas in Notion `Content` DB with `Kind`, `Stage=Idea`
+- Drop ideas in the Notion CMS DB with `Kind`, `Stage=Idea`
 - Each Sunday morning, check the `Triage` view for new candidates
 - Flip `Stage=Ready` on anything you want drafted
 - Wake up Monday to a PR (blog) or filled-in script (YT) waiting for you

--- a/docs/superpowers/specs/2026-06-02-plan-b-ai-drafting-agent-design.md
+++ b/docs/superpowers/specs/2026-06-02-plan-b-ai-drafting-agent-design.md
@@ -28,7 +28,7 @@ The agent never publishes anything. Every blog post still flows through your PR 
 
 ```
                   ┌───────────────────────────────────────────┐
-                  │  Notion Content DB                        │
+                  │  Notion CMS DB (restructured in place)    │
                   │   Kind ∈ {blog, YT short, YT long, ...}   │
                   │   Stage = workflow state                  │
                   └───────────────────────────────────────────┘
@@ -82,11 +82,11 @@ drafting shells out to `gh` for PR creation. No MCP servers are spawned in CI.
 
 ## Notion DB redesign
 
-The existing `CMS` database is replaced by a new database called `Content`. The current schema conflates production stage with workflow state and uses a multi-select `Medium` that doesn't compose with the per-artifact lifecycle the agent needs. A cleaner schema saves us from per-Kind branching at every read.
+We restructure the existing `CMS` database **in place** rather than create a parallel `Content` DB. Same row IDs, same DB ID, same Notion views URL — but with cleaner properties for the agent loop. One source of truth, no archive DB to maintain.
 
-**The old `CMS` DB stays around as archive — nothing deletes it.** We just stop writing to it after migration.
+The transformation is split between manual Notion-UI changes (rename property, rename options, add new properties) and a migration script that backfills the new properties on every existing row.
 
-### New schema: `Content`
+### Target schema (after restructure)
 
 | Property           | Type            | Notes                                                                                              |
 | ------------------ | --------------- | -------------------------------------------------------------------------------------------------- |
@@ -120,9 +120,9 @@ The existing `CMS` database is replaced by a new database called `Content`. The 
 
 Blog skips Recorded/Edited; YT uses them. Stage is single-select, so there's no ambiguity at any moment.
 
-### Recommended views to rebuild after migration
+### Recommended views to add (existing views keep working)
 
-Existing Notion views on `CMS` don't migrate. After cutover, recreate manually in `Content`:
+Because we restructure the same DB, your current Notion views on CMS continue working — they reference the same DB ID and the same properties (where renamed, Notion updates view references automatically). Add these new agent-oriented views alongside what you already have:
 
 | View               | Filter                                        | Sort                        |
 | ------------------ | --------------------------------------------- | --------------------------- |
@@ -132,9 +132,36 @@ Existing Notion views on `CMS` don't migrate. After cutover, recreate manually i
 | Ideas inbox        | `Stage = Idea`                                | Created desc                |
 | By Kind            | (no filter)                                   | grouped by Kind, then Stage |
 
-### Migration
+### Manual Notion-UI restructure (one-time, human action)
 
-One-shot script `scripts/agent/migrate-cms.ts`. Two modes:
+Before the migration script runs, restructure the CMS DB schema in Notion's UI:
+
+1. **Rename `Status` → `Stage`.** Notion preserves all existing values automatically.
+2. **Rename Status options to new Stage values:**
+   - `Prepping` → `Idea`
+   - `Ready To Record` → `Ready`
+   - `Recording` → `Recorded`
+   - `Post-Processing` → `Edited`
+   - `Published` stays `Published`
+   - `Abandoned` stays `Abandoned`
+   - `✅` → merge into `Published` (re-tag any rows using ✅, then delete the ✅ option)
+3. **Add new Stage options:** `Proposed`, `Drafted`. These are agent states that don't exist yet.
+4. **Add new property `Kind`** (single-select) with options: `blog`, `YT short`, `YT long`, `podcast`, `presentation`, `IG reel`, `stand up`. Empty initially — migration backfills from Medium.
+5. **Add Origin options:** `Agent Proposed`, `Derivative`. Keep existing `OC`, `x-post:bundle`, `x-post:blog`.
+6. **Add new properties:**
+   - `Source Row` — relation to self (this same DB)
+   - `Cross-post Targets` — multi-select with options `blog`, `YT short`, `YT long`
+   - `Tools` — multi-select (empty pool initially)
+   - `Hint` — text
+   - `Draft URL` — URL
+7. **Optionally rename** `Published Link` → `Published URL` for consistency. Notion preserves values.
+8. **Keep as-is (legacy, agent ignores):** `Medium`, `Type`, `Keywords`, `Source(s)`, `No.`, `Files & Media`. The migration reads these and populates the new properties, but they're not deleted — your historical data stays intact.
+
+After this, share the DB with the `Claude Code MCP` integration (already done, no action needed).
+
+### Migration script
+
+One-shot, in-place: updates existing pages, creates sibling pages only for multi-Medium splits.
 
 ```sh
 npm run migrate:cms -- --dry-run    # transformation report, no writes
@@ -143,35 +170,17 @@ npm run migrate:cms -- --execute    # performs migration after you approve
 
 Transformation rules:
 
-1. **Split multi-Medium rows.** A row with `Medium=[blog, YT short]` becomes two `Content` rows — one per Kind, linked by `Source Row` (the first holds the original page ID; the second is freshly created). The first becomes `Origin=OC` with `Cross-post Targets` populated to the other Kind(s). The second becomes `Origin=Derivative` with `Source Row` pointing back.
-2. **Status → Stage.**
-
-   | Old Status      | New Stage |
-   | --------------- | --------- |
-   | Prepping        | Idea      |
-   | Ready To Record | Ready     |
-   | Recording       | Recorded  |
-   | Post-Processing | Edited    |
-   | Published       | Published |
-   | ✅              | Published |
-   | Abandoned       | Abandoned |
-
-3. **Medium → Kind** (1:1 after splitting).
-4. **Origin → Origin.**
-   - `OC` → `OC`
-   - `x-post:bundle` → `OC` with `Cross-post Targets` populated from the row's Medium
-   - `x-post:blog` → `Derivative`; try title-match within ±60 days to find a likely Source Row
-5. **Carry forward.** Title, Tags, Source(s)→Source URLs, Published Link→Published URL, Keywords→appended to Hint, Publishing→Publishing.
-6. **Drop.** Type (mapped into Tags if a value is set), No., Files & Media.
+1. **Single-Medium rows:** PATCH the existing page. Set `Kind` from the first Medium value, populate `Source URLs` from `Source(s)`, append `Keywords` to `Hint`. (Stage is already correct because Notion renamed it during the UI restructure.) Set Origin if mapping: `x-post:blog` → `Derivative`; everything else unchanged.
+2. **Multi-Medium rows:** PATCH the existing page (becomes primary; `Kind` = first Medium, `Cross-post Targets` = other Mediums). CREATE one new sibling page per additional Medium with `Origin=Derivative` and `Source Row` linking back to the primary.
+3. **`x-post:bundle`** → keep as `OC` but populate `Cross-post Targets` from the other Mediums (for both single and multi rows).
+4. **Drop nothing.** Legacy properties (Medium, Type, Keywords, etc.) remain on rows; the agent just doesn't read them after migration.
 
 The dry-run report flags:
 
-- Rows that will be split (and what each new row will look like)
-- Rows where `x-post:blog` couldn't find a Source Row match (you decide: leave unlinked or skip)
-- Rows where Keywords don't fit cleanly into Hint
-- Any rows that won't migrate at all
+- How many rows will be PATCHed vs how many sibling pages will be CREATED (from multi-Medium splits)
+- Rows where `x-post:blog` would mark Origin=Derivative but no Source Row link can be inferred (left unlinked)
 
-Migration is not idempotent in the strict sense, but it's safe to re-run dry-run as many times as needed; execute mode refuses if `Content` already has rows.
+Execute mode is idempotent against already-migrated rows: it skips PATCH on rows where `Kind` is already populated. Splits are NOT re-run for rows that already have derivative siblings (detected via `Source Row` back-references).
 
 ## Discovery workflow
 
@@ -387,13 +396,13 @@ The agent never invents style rules — it follows what's documented. Updates to
 ### Secrets (`.github/workflows/*.yml` env)
 
 - `CLAUDE_CODE_OAUTH_TOKEN` — subscription auth, obtained via `claude setup-token`
-- `NOTION_TOKEN` — internal Notion integration token, scoped to the new `Content` DB
+- `NOTION_TOKEN` — internal Notion integration token, scoped to the restructured CMS DB
 - `AGENT_GH_TOKEN` — fine-grained PAT with `contents:write` + `pull-requests:write` on this repo (the default `GITHUB_TOKEN` from a cron workflow can't trigger downstream workflows like deploy/Vale CI; a separate PAT can)
 - `YOUTUBE_API_KEY` — YT Data API v3 key for public stats
 
 ### Repo variables
 
-- `NOTION_CONTENT_DB_ID` — set after the new DB is created and the integration is shared
+- `NOTION_CMS_DB_ID` — the existing CMS DB ID (`d25e9f1c0a3345589592fce32f7bc02b`)
 - `YOUTUBE_CHANNEL_ID` — your channel ID
 - `SCAN_REPO_ORG=shariqh`
 - `SCAN_REPO_INCLUDE=blog-site,lognote` — always-on repos
@@ -441,7 +450,7 @@ Observability in v1 = GH Actions run logs + Notion row comments. Both are easy t
 **Integration (manual, gated):**
 
 - Migration dry-run against the real CMS DB; inspect transformation report
-- Migration execute; verify Content DB looks right; verify CMS DB unchanged
+- Migration execute; verify CMS DB rows now have Kind/Stage/Origin/etc populated; spot-check a split row's sibling
 - `workflow_dispatch` discovery once; verify candidates land in Notion
 - Manually flip one Content row to Stage=Ready; `workflow_dispatch` draft; verify either PR opens (blog) or script blocks appear in row body (YT)
 - Enable crons
@@ -451,7 +460,7 @@ Observability in v1 = GH Actions run logs + Notion row comments. Both are easy t
 The implementation plan (next phase, via the writing-plans skill) will sequence these. Rough shape:
 
 1. Write `docs/SHORTS-STYLE.md`
-2. Notion redesign: create `Content` DB by hand in Notion, capture its ID
+2. Notion redesign: manually restructure CMS DB schema (rename Status→Stage with new options, add Kind + 5 new properties, add Origin options)
 3. Migration script: dry-run mode → review → execute mode
 4. Shared lib: `sources/notion.ts`, `sources/git.ts`, `sources/trending.ts`, `sources/youtube.ts`
 5. Drafting: blog branch (MDX + PR) — narrowest path, most existing primitives

--- a/docs/superpowers/specs/2026-06-02-plan-b-ai-drafting-agent-design.md
+++ b/docs/superpowers/specs/2026-06-02-plan-b-ai-drafting-agent-design.md
@@ -1,0 +1,470 @@
+# Plan B — AI Drafting Agent — Design Spec
+
+**Date:** 2026-06-02
+**Status:** Approved, ready for implementation planning
+**Extends:** [2026-05-27-blog-modernization-design.md](./2026-05-27-blog-modernization-design.md)
+
+## Goal
+
+A nightly Claude-based agent that watches your real work — Notion ideas, recent commits across active repos, public AI/dev tool releases — and proposes content to publish in two formats: blog posts and YouTube shorts. You triage candidates in Notion. The agent then drafts each in the right shape:
+
+- **Blog** → an MDX file in a PR against this repo, reviewed via the Cloudflare Pages preview.
+- **YouTube short / long** → a structured script written directly into the Notion row body, ready for you to record.
+
+When a published YT short turns out to be worth a long-form treatment, a separate promotion workflow mints a linked blog-derivative row carrying the video forward. You triage that the same way.
+
+The agent never publishes anything. Every blog post still flows through your PR review; every video still gets you behind the camera. Git is the database for blog content; Notion is the database for video scripts and for the workflow state of everything.
+
+## Non-goals (v1, explicit)
+
+- Hero image generation for blog posts (deferred — you add images at PR review)
+- Notion webhooks for sub-minute draft trigger (nightly cron is fine for content)
+- Blog → YT script derivative direction (only YT → blog in v1)
+- Video editing, thumbnail rendering, or upload automation
+- Auto-merge or auto-publish of any kind
+- Real-time tool-discovery beyond Notion + GH trending + HN
+
+## System overview
+
+```
+                  ┌───────────────────────────────────────────┐
+                  │  Notion Content DB                        │
+                  │   Kind ∈ {blog, YT short, YT long, ...}   │
+                  │   Stage = workflow state                  │
+                  └───────────────────────────────────────────┘
+                       ▲                              ▲
+            proposes   │                              │   writes script blocks / PR link
+            new        │                              │
+            candidate  │                              │
+            rows       │                              │
+                       │                              │
+        ┌──────────────┴──────────────┐  ┌────────────┴─────────────────┐
+        │ agent-discover.yml          │  │ agent-draft.yml              │
+        │ Sun 03:00 UTC + manual      │  │ Daily 02:00 UTC + manual     │
+        │                             │  │                              │
+        │ Reads:                      │  │ Reads: Stage=Ready rows      │
+        │  • Notion Stage=Idea rows   │  │ Per row, branches on Kind:   │
+        │  • Git commits (active 30d) │  │   blog → MDX + PR            │
+        │  • GH trending + HN feed    │  │   YT*  → script in row body  │
+        │  • Past YT perf (YT API)    │  │ Flips Stage=Drafted          │
+        │ Writes: candidate rows      │  │                              │
+        └─────────────────────────────┘  └──────────────────────────────┘
+
+                       ┌─────────────────────────────────────────────┐
+                       │ agent-promote.yml                            │
+                       │ Daily 04:00 UTC + manual                     │
+                       │                                              │
+                       │ Reads: Kind=YT* rows now Stage=Published     │
+                       │   with Cross-post Targets includes 'blog'    │
+                       │   AND no derivative row exists yet           │
+                       │ Mints: linked derivative blog row            │
+                       │   Stage=Proposed, Origin=Derivative          │
+                       └──────────────────────────────────────────────┘
+
+Discovery and drafting call Claude via subscription OAuth (CLAUDE_CODE_OAUTH_TOKEN);
+promotion is metadata-only (no model call). All three use the Notion HTTP API, and
+drafting shells out to `gh` for PR creation. No MCP servers are spawned in CI.
+```
+
+## Stack
+
+| Layer          | Choice                                                  | Why                                                                                 |
+| -------------- | ------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| Runtime        | Node 22 (matches site CI)                               | Same toolchain as the rest of the repo                                              |
+| Language       | TypeScript strict                                       | Matches the rest of the repo; types end-to-end on Notion + Claude payloads          |
+| Model          | Claude via Agent SDK (`@anthropic-ai/claude-agent-sdk`) | Supports subscription OAuth auth (raw `@anthropic-ai/sdk` requires API-key billing) |
+| Auth           | `CLAUDE_CODE_OAUTH_TOKEN` (your subscription)           | Runs against your subscription quota, not per-token billing                         |
+| Notion         | Raw HTTP via `fetch` (Notion API v2025-09-03)           | No MCP server in CI; HTTP is enough for the operations we need                      |
+| GitHub PRs     | `gh` CLI (already on GHA runners)                       | Familiar; handles PR body via heredoc cleanly                                       |
+| YouTube        | YT Data API v3 via `fetch`                              | Free, no OAuth (public stats only)                                                  |
+| Trending feeds | HN Firebase API + GH trending scrape                    | HN has an official API; GH trending doesn't (acceptable for v1)                     |
+| Orchestration  | GitHub Actions (cron + workflow_dispatch)               | Same infra as the deploy workflow                                                   |
+
+## Notion DB redesign
+
+The existing `CMS` database is replaced by a new database called `Content`. The current schema conflates production stage with workflow state and uses a multi-select `Medium` that doesn't compose with the per-artifact lifecycle the agent needs. A cleaner schema saves us from per-Kind branching at every read.
+
+**The old `CMS` DB stays around as archive — nothing deletes it.** We just stop writing to it after migration.
+
+### New schema: `Content`
+
+| Property           | Type            | Notes                                                                                              |
+| ------------------ | --------------- | -------------------------------------------------------------------------------------------------- |
+| Title              | title           | Working title                                                                                      |
+| Kind               | select (single) | `blog`, `YT short`, `YT long`, `podcast`, `presentation`, `IG reel`, `stand up`. One Kind per row. |
+| Stage              | select          | `Idea`, `Proposed`, `Ready`, `Drafted`, `Recorded`, `Edited`, `Published`, `Abandoned`             |
+| Origin             | select          | `OC` (you), `Agent Proposed` (discovery wrote it), `Derivative` (promotion minted it)              |
+| Source Row         | relation (self) | For derivatives — links back to the parent row                                                     |
+| Cross-post Targets | multi-select    | `blog`, `YT short`, `YT long`. Promotion workflow reads this.                                      |
+| Tags               | multi-select    | Free-form pool. Display bucket for blog still resolved by `src/lib/buckets.ts`.                    |
+| Tools              | multi-select    | AI/dev tools the piece covers; powers YT dedupe                                                    |
+| Hint               | rich_text       | One-line angle / take (agent writes this on proposal)                                              |
+| Source URLs        | rich_text       | Commit SHAs, HN links, tool homepages                                                              |
+| Draft URL          | url             | PR URL for blog; null for YT (script lives in row body)                                            |
+| Published URL      | url             | Final live URL                                                                                     |
+| Publishing         | date            | Target / actual publish date                                                                       |
+| Created / Updated  | auto            |                                                                                                    |
+
+### Stage lifecycle by Kind
+
+| Stage     | blog | YT short / YT long | Notes                                                   |
+| --------- | ---- | ------------------ | ------------------------------------------------------- |
+| Idea      | ✓    | ✓                  | Seed state — your raw notes; never touched by the agent |
+| Proposed  | ✓    | ✓                  | Discovery wrote this row OR you upgraded an Idea        |
+| Ready     | ✓    | ✓                  | You flipped this; drafting picks it up overnight        |
+| Drafted   | ✓    | ✓                  | Blog: PR opened. YT: script blocks in row body.         |
+| Recorded  | —    | ✓                  | You shot the video                                      |
+| Edited    | —    | ✓                  | Video edit done                                         |
+| Published | ✓    | ✓                  | Live (you set this)                                     |
+| Abandoned | ✓    | ✓                  | Dead end, any stage                                     |
+
+Blog skips Recorded/Edited; YT uses them. Stage is single-select, so there's no ambiguity at any moment.
+
+### Recommended views to rebuild after migration
+
+Existing Notion views on `CMS` don't migrate. After cutover, recreate manually in `Content`:
+
+| View               | Filter                                        | Sort                        |
+| ------------------ | --------------------------------------------- | --------------------------- |
+| Triage             | `Stage in [Proposed, Ready]`                  | Created desc                |
+| In flight          | `Stage in [Ready, Drafted, Recorded, Edited]` | Updated desc                |
+| Recently published | `Stage = Published`                           | Publishing desc             |
+| Ideas inbox        | `Stage = Idea`                                | Created desc                |
+| By Kind            | (no filter)                                   | grouped by Kind, then Stage |
+
+### Migration
+
+One-shot script `scripts/agent/migrate-cms.ts`. Two modes:
+
+```sh
+npm run migrate:cms -- --dry-run    # transformation report, no writes
+npm run migrate:cms -- --execute    # performs migration after you approve
+```
+
+Transformation rules:
+
+1. **Split multi-Medium rows.** A row with `Medium=[blog, YT short]` becomes two `Content` rows — one per Kind, linked by `Source Row` (the first holds the original page ID; the second is freshly created). The first becomes `Origin=OC` with `Cross-post Targets` populated to the other Kind(s). The second becomes `Origin=Derivative` with `Source Row` pointing back.
+2. **Status → Stage.**
+
+   | Old Status      | New Stage |
+   | --------------- | --------- |
+   | Prepping        | Idea      |
+   | Ready To Record | Ready     |
+   | Recording       | Recorded  |
+   | Post-Processing | Edited    |
+   | Published       | Published |
+   | ✅              | Published |
+   | Abandoned       | Abandoned |
+
+3. **Medium → Kind** (1:1 after splitting).
+4. **Origin → Origin.**
+   - `OC` → `OC`
+   - `x-post:bundle` → `OC` with `Cross-post Targets` populated from the row's Medium
+   - `x-post:blog` → `Derivative`; try title-match within ±60 days to find a likely Source Row
+5. **Carry forward.** Title, Tags, Source(s)→Source URLs, Published Link→Published URL, Keywords→appended to Hint, Publishing→Publishing.
+6. **Drop.** Type (mapped into Tags if a value is set), No., Files & Media.
+
+The dry-run report flags:
+
+- Rows that will be split (and what each new row will look like)
+- Rows where `x-post:blog` couldn't find a Source Row match (you decide: leave unlinked or skip)
+- Rows where Keywords don't fit cleanly into Hint
+- Any rows that won't migrate at all
+
+Migration is not idempotent in the strict sense, but it's safe to re-run dry-run as many times as needed; execute mode refuses if `Content` already has rows.
+
+## Discovery workflow
+
+Path: `.github/workflows/agent-discover.yml`. Schedule: `cron: '0 3 * * 0'` (Sunday 03:00 UTC) + `workflow_dispatch`.
+
+Entry: `scripts/agent/discover.ts`.
+
+```
+discover.ts
+├─ sources/
+│  ├─ notion.ts    – existing Stage=Idea rows for both blog + YT
+│  ├─ git.ts       – commits last 7d across active repos
+│  ├─ trending.ts  – GH trending (ai-tools topic) + HN Show HN feed
+│  └─ youtube.ts   – last 30d of own video stats via YT Data API v3
+├─ rank.ts         – calls Claude with structured-output prompt
+└─ upsert.ts       – writes new candidate rows to Notion
+```
+
+### Source-reader rules
+
+**`notion.ts`** — query `Stage=Idea` rows. Pass title + Tags + Tools + body excerpt to the ranker.
+
+**`git.ts`** — for each repo in scope:
+
+- Always: `blog-site`, `lognote`
+- Opportunistic: every public repo under `shariqh` with a push in the last 30 days
+
+Use the GH REST API (`/repos/{owner}/{repo}/commits?since=<date>`). Pull commit messages + first ~10 changed files per commit. Cap at the last 50 commits per repo per run.
+
+**`trending.ts`** — two feeds:
+
+- GH trending: scrape `github.com/trending/typescript?since=weekly` and `python`, `rust`, plus `github.com/topics/ai-tools`. No official API; cache the HTML for the run. If scraping fails, log and continue without it.
+- HN: official Firebase API (`https://hacker-news.firebaseio.com/v0/topstories.json`). Filter to titles matching `cli`, `agent`, `claude`, `gemini`, `copilot`, `codex`, plus tool-names already in the `Tools` registry.
+
+**`youtube.ts`** — YouTube Data API v3 `videos.list` filtered to your channel. Pull title + view count + like count for the last 30 days. Compute per-tool average performance via the matching row's `Tools` field.
+
+### Ranking prompt
+
+Single Claude call. System prompt loads `docs/EDITORIAL.md` and `docs/SHORTS-STYLE.md`. User message contains all source data, requests structured JSON output:
+
+```jsonc
+{
+  "blog_candidates": [
+    {
+      "title": "...",
+      "hint": "...",
+      "tags": ["..."],
+      "source_urls": ["..."],
+      "rationale": "...",
+    },
+  ],
+  "yt_candidates": [
+    {
+      "title": "...",
+      "hint": "...",
+      "tools": ["..."],
+      "source_urls": ["..."],
+      "rationale": "...",
+    },
+  ],
+}
+```
+
+Up to 3 candidates per track. Empty arrays if nothing meets the bar (no spam runs).
+
+### Upsert rules
+
+For each candidate from the model:
+
+- **Dedupe by title similarity** (case-insensitive normalized Levenshtein distance ≤ 0.2 — i.e., titles ≥80% similar count as duplicates) against existing rows in the last 60 days. Skip if a near-match exists.
+- **YT-only dedupe by Tools overlap**: if every tool in the proposed candidate appears in an existing `Stage=Published Kind=YT*` row, skip.
+- Create row with: `Kind=<blog|YT short>`, `Stage=Proposed`, `Origin=Agent Proposed`, Tags/Tools/Hint/Source URLs from the model, body containing the rationale.
+
+## Drafting workflow
+
+Path: `.github/workflows/agent-draft.yml`. Schedule: `cron: '0 2 * * *'` (daily 02:00 UTC) + `workflow_dispatch`.
+
+Entry: `scripts/agent/draft.ts`. Queries Notion for rows where `Stage=Ready`. For each row, branches on `Kind`.
+
+### Blog branch
+
+```
+1. Gather context:
+   - Notion row body + Hint + Source URLs
+   - For each commit SHA in Source URLs: fetch full diff via GH API
+
+2. Load system prompt:
+   - SITE.author voice (from src/lib/site.ts)
+   - docs/EDITORIAL.md (verbatim)
+   - Bucket map from src/lib/buckets.ts
+   - For Origin=Derivative rows: include the source YT script + URL,
+     and instruct the model to embed the video at the top via
+     <Youtube id="..." />
+
+3. Claude call: write the full MDX file. Output is the file contents.
+
+4. Validate:
+   - Parse frontmatter, run through the Zod schema from src/content.config.ts
+   - If invalid: post a comment on the Notion row with the error,
+     leave Stage=Ready, abort this row
+
+5. Run Vale:
+   - vale src/content/writing/<slug>.mdx
+   - Errors block (current Vale config triggers errors only on broken frontmatter)
+   - Warnings collected for PR description, do not block
+
+6. Git ops:
+   - Branch: agent/draft/<slug>
+   - Commit: "draft: <title> (proposed by agent)"
+   - Push
+
+7. PR via gh CLI:
+   - Title: same as commit
+   - Body: Notion source link + EDITORIAL pre-publish checklist
+     + Vale warning report + "this was AI-drafted, please review"
+
+8. Update Notion row: Stage=Drafted, Draft URL=<PR URL>
+```
+
+### YT short / YT long branch
+
+```
+1. Gather context (same as blog).
+
+2. Load system prompt:
+   - SITE.author voice (from src/lib/site.ts)
+   - docs/SHORTS-STYLE.md (verbatim)
+   - The row's Tools field for tool-specific framing
+
+3. Claude call: structured output with these fields:
+   - hook            (≤3 seconds of dialogue, sentence by sentence)
+   - script          (full body, ~50s for short, ~5min for long)
+   - on_screen_text  [{timestamp_seconds, text}]
+   - b_roll          [{timestamp_seconds, description}]
+   - thumbnail_prompt (string)
+   - title_variants  (array of 3)
+   - hashtags        (array of 5-8)
+
+4. Render as Notion blocks; replace row body via the Notion blocks API:
+   - H2 Hook                → paragraph
+   - H2 Script              → paragraphs
+   - H2 On-screen text      → bulleted list "{time}s — {text}"
+   - H2 B-roll              → bulleted list "{time}s — {description}"
+   - H2 Thumbnail           → paragraph with the prompt
+   - H2 Title variants      → bulleted list
+   - H2 Hashtags            → paragraph (space-joined)
+
+5. Update Notion row: Stage=Drafted. Draft URL stays null —
+   the script is in the row body.
+```
+
+### Per-row error isolation
+
+Try/catch around each row. Any failure leaves Stage=Ready, posts a Notion page comment with the error, and continues to the next row. The whole workflow exits 0 unless something catastrophic happens (Notion API completely down, OAuth invalid, etc.) — those exit 1 and trigger GH's email notification.
+
+## Promotion workflow
+
+Path: `.github/workflows/agent-promote.yml`. Schedule: `cron: '0 4 * * *'` (daily 04:00 UTC) + `workflow_dispatch`.
+
+Runs two hours after drafting so rows that just got drafted earlier in the same night don't trigger spurious promotions.
+
+Entry: `scripts/agent/promote.ts`.
+
+```
+1. Query Notion: rows where
+   - Kind in [YT short, YT long]
+   - Stage = Published
+   - Cross-post Targets includes 'blog'
+   - No existing row has this row as Source Row (no derivative yet)
+
+2. For each such row, create a new Content row:
+   - Kind = blog
+   - Stage = Proposed
+   - Origin = Derivative
+   - Source Row = <published YT row's page ID>
+   - Title = <YT title, adapted toward blog convention>
+   - Tags = inherited from source
+   - Tools = inherited from source
+   - Hint = "Blog-length treatment of YT video <YT URL>. Expand on: ..."
+   - Source URLs = source row's Source URLs + the published YT URL
+   - Body: pre-filled with the YT script as a starting point
+           + a static expansion-outline template (Setup / Demo / What surprised me / Where this fits)
+
+3. Post a Notion comment on the source row: "Created derivative blog row: <link>"
+```
+
+Important: promotion only creates the row in `Proposed`. The agent **never** auto-promotes to `Ready` — you triage every derivative the same as any other candidate.
+
+Promotion does not call Claude. The adapted title is a literal copy of the source title, the body is templated. When you later flip the derivative row to `Ready`, the drafting workflow's blog branch handles all the model-driven work — and because `Origin=Derivative`, that prompt includes the source video URL and script context.
+
+## Style contracts
+
+### `docs/EDITORIAL.md` (existing)
+
+The agent loads this verbatim into the system prompt for the blog branch. No changes needed for v1.
+
+### `docs/SHORTS-STYLE.md` (new, to be drafted during implementation)
+
+Captures:
+
+- Hook discipline (first 3 seconds promise a payoff)
+- 60s pacing for shorts, ~5min for YT long
+- Vertical framing assumed
+- Tone: peer-to-peer; no influencer voice; no "what's up guys"
+- Tool framing: what's this for / what's surprising / what's it replace
+- Title formula guidelines: punchy without clickbait
+- Hashtag conventions (5–8 per video, lowercase, mix of broad + tool-specific)
+
+The agent never invents style rules — it follows what's documented. Updates to either style doc require no code changes; the agent re-reads on every run.
+
+## Secrets and config
+
+### Secrets (`.github/workflows/*.yml` env)
+
+- `CLAUDE_CODE_OAUTH_TOKEN` — subscription auth, obtained via `claude setup-token`
+- `NOTION_TOKEN` — internal Notion integration token, scoped to the new `Content` DB
+- `AGENT_GH_TOKEN` — fine-grained PAT with `contents:write` + `pull-requests:write` on this repo (the default `GITHUB_TOKEN` from a cron workflow can't trigger downstream workflows like deploy/Vale CI; a separate PAT can)
+- `YOUTUBE_API_KEY` — YT Data API v3 key for public stats
+
+### Repo variables
+
+- `NOTION_CONTENT_DB_ID` — set after the new DB is created and the integration is shared
+- `YOUTUBE_CHANNEL_ID` — your channel ID
+- `SCAN_REPO_ORG=shariqh`
+- `SCAN_REPO_INCLUDE=blog-site,lognote` — always-on repos
+- `SCAN_REPO_ACTIVE_DAYS=30` — gate for opportunistic public repos
+
+## Local development
+
+All three scripts runnable locally:
+
+```sh
+npm run agent:discover
+npm run agent:draft
+npm run agent:promote
+```
+
+Each reads from a gitignored `.env.local` mirroring CI secrets. Useful for prompt iteration without burning a subscription window in CI.
+
+The migration script (`migrate:cms`) is local-only — it never runs in CI.
+
+## Error handling and observability
+
+| Failure mode                    | Behavior                                                            |
+| ------------------------------- | ------------------------------------------------------------------- |
+| Subscription rate limit (429)   | Log, exit 0. Cron retries next slot.                                |
+| Notion API outage               | Exit 1 → GH email notification                                      |
+| Per-row drafting error          | Try/catch isolates; Notion comment on the row; continue to next row |
+| Frontmatter Zod validation fail | Row stays Ready; Notion comment with the validation error           |
+| Vale errors                     | Currently only fire on broken frontmatter — same handling as above  |
+| Vale warnings                   | Collected; surfaced in PR description; never block                  |
+| `gh pr create` failure          | Row stays Ready; Notion comment                                     |
+| YouTube API quota exhausted     | Discovery proceeds without perf signal; logged                      |
+| GH trending scrape failure      | Discovery proceeds without trending signal; logged                  |
+
+Observability in v1 = GH Actions run logs + Notion row comments. Both are easy to inspect from where you already are.
+
+## Testing
+
+**Unit (Vitest):**
+
+- Notion row mapper: old CMS shape → new Content shape (both directions, for migration verification)
+- Bucket consumption from agent output
+- Frontmatter validator using `src/content.config.ts`'s schema
+- Dedupe logic: title-similarity threshold, Tools overlap
+
+**Integration (manual, gated):**
+
+- Migration dry-run against the real CMS DB; inspect transformation report
+- Migration execute; verify Content DB looks right; verify CMS DB unchanged
+- `workflow_dispatch` discovery once; verify candidates land in Notion
+- Manually flip one Content row to Stage=Ready; `workflow_dispatch` draft; verify either PR opens (blog) or script blocks appear in row body (YT)
+- Enable crons
+
+## Implementation order (high-level)
+
+The implementation plan (next phase, via the writing-plans skill) will sequence these. Rough shape:
+
+1. Write `docs/SHORTS-STYLE.md`
+2. Notion redesign: create `Content` DB by hand in Notion, capture its ID
+3. Migration script: dry-run mode → review → execute mode
+4. Shared lib: `sources/notion.ts`, `sources/git.ts`, `sources/trending.ts`, `sources/youtube.ts`
+5. Drafting: blog branch (MDX + PR) — narrowest path, most existing primitives
+6. Drafting: YT branch (script blocks into Notion)
+7. Discovery script + workflow
+8. Promotion workflow
+9. Vitest coverage on lib units
+10. End-to-end smoke via workflow_dispatch
+11. Enable crons
+
+## Open questions (deferred, not blocking)
+
+- **Tools registry as separate DB.** v1 uses the `Tools` multi-select on `Content`. If the list grows past ~30 entries, a separate `Tools` DB with status (Untested/Covered/Deprioritized) may earn its keep. Re-evaluate after 3 months.
+- **YT performance window.** v1 uses last 30d. Some videos pop late; the window may need tuning. Adjustable via a repo variable.
+- **PR auto-labeling.** Could tag draft PRs with `agent-draft`, `bucket-<key>` for filtering. Cheap; saving for v2 unless filtering becomes annoying.
+- **Blog → YT script derivative.** Symmetric to the YT → blog flow. Less common per the original framing. Add later if the need shows up.

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,17 +29,193 @@
         "tailwindcss": "^4.3.0"
       },
       "devDependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.3.161",
         "@astrojs/check": "^0.9.9",
         "@playwright/test": "^1.60.0",
         "@types/react": "^19.2.15",
         "@types/react-dom": "^19.2.3",
+        "dotenv": "^17.4.2",
+        "gray-matter": "^4.0.3",
         "prettier": "^3.8.3",
         "prettier-plugin-astro": "^0.14.1",
+        "tsx": "^4.22.4",
         "typescript": "^6.0.3",
         "vitest": "^4.1.7"
       },
       "engines": {
-        "node": ">=22.12.0"
+        "node": ">=24"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.3.161",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.161.tgz",
+      "integrity": "sha512-TWVFmPsGePXPNnNuWAAuKagQai9kNj99tuu2KLo8FN3oWF5r82OnWTNpQ3IubpWYPyO1vC0+kQu2GfqoEme/hA==",
+      "dev": true,
+      "license": "SEE LICENSE IN README.md",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.161",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.161",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.161",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.161",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.161",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.161",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.161",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.161"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.93.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+      "version": "0.3.161",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.161.tgz",
+      "integrity": "sha512-KwDpi1O2P++uAskFt454K/sShPmhHSYhSbBxaap2KLFoVFti1pttDcEqDPfmKCk2XzKTwlpnVSI1IwTiawPJTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+      "version": "0.3.161",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.161.tgz",
+      "integrity": "sha512-VoLz1BfKDc6UOYL+UhRKNSFA1k4l6kvOUrWqkHJ34V5zI5/7VzQilaGl7hU5JECE1TleXMzrWpDrLZO7akApJA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+      "version": "0.3.161",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.161.tgz",
+      "integrity": "sha512-QQbGTJ+2AFeP6+vsZQtafqeGZGX72jaHOjOyrhEcMk1T2DSrJV05J0xnkZT4yIOsByGosntTcY6963EfkuwuTg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+      "version": "0.3.161",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.161.tgz",
+      "integrity": "sha512-y+RPkQ6ZFje6LP0WyGvM4yHp7IQAaxAbcKSP9QVzKtT9yWiDeqWSnPzdP2Rp3B+6Kd12MuhwIMAbiKS4onAusA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+      "version": "0.3.161",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.161.tgz",
+      "integrity": "sha512-gq4tvNRRcfSf8o35mLWKN351I6FowQa2n28YiZJBvZU1glQ3HKQM4srrXzjwLwv1VcndyWBfLxoaDB1I9BS++w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+      "version": "0.3.161",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.161.tgz",
+      "integrity": "sha512-ev0eJhypbyatvSL+Cl2LqOos5+XZbgBMV6MJk7jIh/9dirMLwDj2JFlLlOnHdmIpFcznESZ/Z2wgMtqmOMUCHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+      "version": "0.3.161",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.161.tgz",
+      "integrity": "sha512-toJhVo/7RKyPc/IEGvgIcN/mPmGs38gnuDOrdtdxXoPR7WRkHcHfwprD5S9zV/pZAhuLhj/cznhno3G7b4Pnkg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+      "version": "0.3.161",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.161.tgz",
+      "integrity": "sha512-QmYFeX/P7bt4diCZhXgazkmzLxL+uK1zwPaCSL2sIQyYGWAXiUulZ41TVLQbHglCBlKzUzVP9kwEXaAZye7LPA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.100.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.100.1.tgz",
+      "integrity": "sha512-RANcEe7LpiLczkKGOwoXOTuFdPhuubS0i4xaAKOMpcqc55YO0mukgxppV7eygx3DXNjxWT6RYOLPyOy0aIAmwg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@astrojs/check": {
@@ -536,6 +712,17 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1136,6 +1323,20 @@
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/@img/colour": {
@@ -1743,6 +1944,48 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/@nodable/entities": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
@@ -2268,6 +2511,14 @@
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -2969,6 +3220,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -3015,6 +3281,25 @@
       "license": "MIT",
       "peerDependencies": {
         "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
       },
       "peerDependenciesMeta": {
         "ajv": {
@@ -3232,6 +3517,32 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -3269,6 +3580,50 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/caniuse-lite": {
@@ -3463,6 +3818,32 @@
         "node": ">= 18"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -3487,6 +3868,52 @@
       "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
       "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
       "license": "MIT"
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/crossws": {
       "version": "0.3.5",
@@ -3613,6 +4040,17 @@
       "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "license": "MIT"
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -3732,6 +4170,19 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dset": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
@@ -3740,6 +4191,30 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.362",
@@ -3771,6 +4246,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.0.tgz",
@@ -3796,11 +4282,47 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esast-util-from-estree": {
       "version": "2.0.0",
@@ -3884,6 +4406,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/escape-string-regexp": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
@@ -3894,6 +4424,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/estree-util-attach-comments": {
@@ -3993,11 +4537,47 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -4009,11 +4589,100 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4021,6 +4690,14 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "dev": true,
+      "license": "Unlicense",
+      "peer": true
     },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
@@ -4118,6 +4795,29 @@
         }
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/flattie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flattie/-/flattie-1.1.1.tgz",
@@ -4148,6 +4848,28 @@
         "node": ">=20"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4160,6 +4882,17 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/gensync": {
@@ -4179,6 +4912,47 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-tsconfig": {
@@ -4202,11 +4976,65 @@
       "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
       "license": "ISC"
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/h3": {
       "version": "1.15.11",
@@ -4223,6 +5051,34 @@
         "radix3": "^1.1.2",
         "ufo": "^1.6.3",
         "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/hast-util-from-dom": {
@@ -4514,6 +5370,17 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
@@ -4536,11 +5403,81 @@
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "license": "MIT"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/iron-webcrypto": {
       "version": "1.2.1",
@@ -4598,6 +5535,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -4665,6 +5612,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/is-wsl": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
@@ -4680,6 +5635,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
     "node_modules/jiti": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
@@ -4687,6 +5650,17 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {
@@ -4719,12 +5693,35 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -4767,6 +5764,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/kleur": {
@@ -5101,6 +6108,17 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/mdast-util-definitions": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-6.0.0.tgz",
@@ -5427,6 +6445,31 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "license": "CC0-1.0"
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/micromark": {
       "version": "4.0.2",
@@ -6189,6 +7232,35 @@
       ],
       "license": "MIT"
     },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -6227,6 +7299,17 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/neotraverse": {
@@ -6293,6 +7376,31 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -6319,6 +7427,31 @@
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
       "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
     "node_modules/oniguruma-parser": {
       "version": "0.12.2",
@@ -6441,6 +7574,17 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -6461,6 +7605,29 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pathe": {
@@ -6492,6 +7659,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/playwright": {
@@ -6626,11 +7804,71 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/radix3": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
       "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/react": {
       "version": "19.2.6",
@@ -7185,12 +8423,38 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "license": "MIT"
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/s.color": {
       "version": "0.0.15",
       "resolved": "https://registry.npmjs.org/s.color/-/s.color-0.0.15.tgz",
       "integrity": "sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/sass-formatter": {
       "version": "0.7.9",
@@ -7217,6 +8481,20 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/semver": {
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
@@ -7228,6 +8506,63 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/sharp": {
       "version": "0.34.5",
@@ -7274,6 +8609,31 @@
         "@img/sharp-win32-x64": "0.34.5"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/shiki": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.1.0.tgz",
@@ -7291,6 +8651,86 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -7365,12 +8805,42 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "4.1.0",
@@ -7425,6 +8895,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/strnum": {
@@ -7568,6 +9048,17 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -7588,12 +9079,532 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/typesafe-path": {
       "version": "0.2.2",
@@ -7816,6 +9827,17 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/unstorage": {
       "version": "1.17.5",
       "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.5.tgz",
@@ -7940,6 +9962,17 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/vfile": {
@@ -8425,6 +10458,23 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/which-pm-runs": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
@@ -8468,6 +10518,14 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/xml-naming": {
       "version": "0.1.0",
@@ -8622,6 +10680,17 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "version": "0.0.1",
   "engines": {
-    "node": ">=22.12.0"
+    "node": ">=24"
   },
   "scripts": {
     "dev": "astro dev",

--- a/package.json
+++ b/package.json
@@ -36,12 +36,16 @@
     "tailwindcss": "^4.3.0"
   },
   "devDependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.3.161",
     "@astrojs/check": "^0.9.9",
     "@playwright/test": "^1.60.0",
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
+    "dotenv": "^17.4.2",
+    "gray-matter": "^4.0.3",
     "prettier": "^3.8.3",
     "prettier-plugin-astro": "^0.14.1",
+    "tsx": "^4.22.4",
     "typescript": "^6.0.3",
     "vitest": "^4.1.7"
   }

--- a/package.json
+++ b/package.json
@@ -6,13 +6,17 @@
     "node": ">=24"
   },
   "scripts": {
-    "dev": "astro dev",
-    "build": "astro build",
-    "preview": "astro preview",
+    "agent:discover": "tsx scripts/agent/discover.ts",
+    "agent:draft": "tsx scripts/agent/draft.ts",
+    "agent:promote": "tsx scripts/agent/promote.ts",
     "astro": "astro",
+    "build": "astro build",
+    "dev": "astro dev",
+    "migrate:cms": "tsx scripts/agent/migrate-cms.ts",
+    "preview": "astro preview",
     "test": "vitest run",
-    "test:watch": "vitest",
-    "test:smoke": "playwright test"
+    "test:smoke": "playwright test",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@astrojs/mdx": "^5.0.6",

--- a/scripts/agent/discover.ts
+++ b/scripts/agent/discover.ts
@@ -1,0 +1,195 @@
+// scripts/agent/discover.ts
+import { runPrompt, parseJsonResponse } from './lib/claude'
+import { queryContentRows, createContentRow } from './lib/notion'
+import { recentCommits } from './lib/git-scan'
+import { fetchTrending } from './lib/trending'
+import { recentChannelStats } from './lib/youtube'
+import { loadEditorialGuide, loadShortsStyleGuide } from './lib/editorial'
+import { isTitleDuplicate, hasFullToolsOverlap } from './lib/dedupe'
+import type { ContentRow, Candidate } from './lib/types'
+
+async function main(): Promise<void> {
+  console.log('Discovery: gathering source material...')
+  const [ideaRows, allRows, commits, ytStats] = await Promise.all([
+    queryContentRows({ property: 'Stage', select: { equals: 'Idea' } }),
+    queryContentRows({
+      and: [{ property: 'Stage', select: { does_not_equal: 'Abandoned' } }],
+    }),
+    recentCommits(7),
+    recentChannelStats(30),
+  ])
+
+  const toolsRegistry = extractKnownTools(allRows)
+  const trending = await fetchTrending(toolsRegistry)
+
+  const publishedYtRows = allRows.filter(
+    (r) => r.stage === 'Published' && (r.kind === 'YT short' || r.kind === 'YT long')
+  )
+
+  console.log(
+    `Sources: ${ideaRows.length} ideas, ${commits.length} commits, ${trending.length} trending, ${ytStats.length} YT stats`
+  )
+
+  const editorialMd = loadEditorialGuide()
+  const shortsStyleMd = loadShortsStyleGuide()
+
+  const systemPrompt = `You are the discovery agent for shariq.dev. Propose up to 3 new blog candidates and up to 3 new YouTube short candidates that are worth drafting.
+
+Empty arrays are fine — do not propose mediocre candidates to fill slots.
+
+OUTPUT: Valid JSON only, matching this schema:
+
+\`\`\`json
+{
+  "blog_candidates": [
+    {"title": "string", "hint": "string", "tags": ["string"], "source_urls": ["string"], "rationale": "string"}
+  ],
+  "yt_candidates": [
+    {"title": "string", "hint": "string", "tools": ["string"], "source_urls": ["string"], "rationale": "string"}
+  ]
+}
+\`\`\`
+
+# Editorial guide (for blog candidates)
+
+${editorialMd}
+
+# Shorts style (for YT candidates)
+
+${shortsStyleMd}
+`
+
+  const userPrompt = buildDiscoveryUserPrompt({
+    ideaRows,
+    publishedYtRows,
+    commits,
+    trending,
+    ytStats,
+  })
+
+  console.log('Calling Claude for ranking...')
+  const raw = await runPrompt({ systemPrompt, userPrompt })
+  const out = parseJsonResponse<{
+    blog_candidates: Candidate[]
+    yt_candidates: Candidate[]
+  }>(raw)
+
+  // Dedupe + upsert
+  const recentTitles = allRows
+    .filter((r) => Date.now() - new Date(r.createdAt).getTime() < 60 * 86_400_000)
+    .map((r) => r.title)
+
+  let blogCreated = 0
+  for (const c of out.blog_candidates) {
+    if (isTitleDuplicate(c.title, recentTitles)) {
+      console.log(`Skipping blog dupe: ${c.title}`)
+      continue
+    }
+    await createCandidateRow(c, 'blog')
+    blogCreated++
+  }
+
+  const publishedYtToolsByRow = publishedYtRows.map((r) => r.tools)
+  let ytCreated = 0
+  for (const c of out.yt_candidates) {
+    if (isTitleDuplicate(c.title, recentTitles)) {
+      console.log(`Skipping YT dupe (title): ${c.title}`)
+      continue
+    }
+    if (c.tools && hasFullToolsOverlap(c.tools, publishedYtToolsByRow)) {
+      console.log(`Skipping YT dupe (tools covered): ${c.title}`)
+      continue
+    }
+    await createCandidateRow(c, 'YT short')
+    ytCreated++
+  }
+
+  console.log(`Discovery done. Created ${blogCreated} blog + ${ytCreated} YT candidate rows.`)
+}
+
+function extractKnownTools(rows: ContentRow[]): string[] {
+  const set = new Set<string>()
+  for (const r of rows) for (const t of r.tools) set.add(t.toLowerCase())
+  return [...set]
+}
+
+interface DiscoveryUserPromptInput {
+  ideaRows: ContentRow[]
+  publishedYtRows: ContentRow[]
+  commits: {
+    repo: string
+    sha: string
+    message: string
+    date: string
+    filesChanged: string[]
+    url: string
+  }[]
+  trending: { source: string; title: string; url: string; hint?: string }[]
+  ytStats: { title: string; views: number; likes: number; publishedAt: string }[]
+}
+
+function buildDiscoveryUserPrompt(input: DiscoveryUserPromptInput): string {
+  const lines: string[] = []
+  lines.push(`# Source material for discovery`)
+  lines.push('')
+
+  lines.push('## Existing ideas in Notion (not yet drafted)')
+  if (input.ideaRows.length === 0) lines.push('(none)')
+  for (const r of input.ideaRows.slice(0, 20)) {
+    lines.push(
+      `- **${r.title}** (Kind: ${r.kind}; tags: ${r.tags.join(',') || '–'}) — ${r.hint || ''}`
+    )
+  }
+  lines.push('')
+
+  lines.push('## Recent commits (last 7 days, across active repos)')
+  if (input.commits.length === 0) lines.push('(none)')
+  for (const c of input.commits.slice(0, 40)) {
+    const first = c.message.split('\n')[0]
+    lines.push(
+      `- \`${c.repo}@${c.sha.slice(0, 7)}\` — ${first} (${c.filesChanged.slice(0, 3).join(', ')})`
+    )
+  }
+  lines.push('')
+
+  lines.push('## Trending (GH + HN, AI/dev tool keywords)')
+  if (input.trending.length === 0) lines.push('(none)')
+  for (const t of input.trending.slice(0, 20)) {
+    lines.push(`- [${t.source}] **${t.title}** — ${t.url}${t.hint ? ` (${t.hint})` : ''}`)
+  }
+  lines.push('')
+
+  lines.push('## YouTube performance (channel, last 30 days)')
+  if (input.ytStats.length === 0) lines.push('(no recent uploads)')
+  for (const s of input.ytStats.slice(0, 20)) {
+    lines.push(
+      `- "${s.title}" — ${s.views} views, ${s.likes} likes (${s.publishedAt.slice(0, 10)})`
+    )
+  }
+  lines.push('')
+
+  lines.push(`Today's date: ${new Date().toISOString().slice(0, 10)}`)
+  lines.push('')
+  lines.push('Propose candidates now. Return JSON only.')
+
+  return lines.join('\n')
+}
+
+async function createCandidateRow(c: Candidate, kind: 'blog' | 'YT short'): Promise<void> {
+  await createContentRow({
+    title: c.title,
+    kind,
+    stage: 'Proposed',
+    origin: 'Agent Proposed',
+    tags: c.tags ?? [],
+    tools: c.tools ?? [],
+    hint: c.hint,
+    sourceUrls: c.sourceUrls,
+  })
+  console.log(`+ ${kind}: ${c.title}`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/agent/discover.ts
+++ b/scripts/agent/discover.ts
@@ -1,12 +1,21 @@
 // scripts/agent/discover.ts
 import { runPrompt, parseJsonResponse } from './lib/claude'
-import { queryContentRows, createContentRow } from './lib/notion'
+import { queryContentRows, createContentRow, appendBlocks } from './lib/notion'
 import { recentCommits } from './lib/git-scan'
 import { fetchTrending } from './lib/trending'
 import { recentChannelStats } from './lib/youtube'
 import { loadEditorialGuide, loadShortsStyleGuide } from './lib/editorial'
 import { isTitleDuplicate, hasFullToolsOverlap } from './lib/dedupe'
-import type { ContentRow, Candidate } from './lib/types'
+import type { ContentRow } from './lib/types'
+
+interface RawCandidate {
+  title: string
+  hint: string
+  tags?: string[]
+  tools?: string[]
+  source_urls: string[]
+  rationale: string
+}
 
 async function main(): Promise<void> {
   console.log('Discovery: gathering source material...')
@@ -70,8 +79,8 @@ ${shortsStyleMd}
   console.log('Calling Claude for ranking...')
   const raw = await runPrompt({ systemPrompt, userPrompt })
   const out = parseJsonResponse<{
-    blog_candidates: Candidate[]
-    yt_candidates: Candidate[]
+    blog_candidates: RawCandidate[]
+    yt_candidates: RawCandidate[]
   }>(raw)
 
   // Dedupe + upsert
@@ -175,8 +184,8 @@ function buildDiscoveryUserPrompt(input: DiscoveryUserPromptInput): string {
   return lines.join('\n')
 }
 
-async function createCandidateRow(c: Candidate, kind: 'blog' | 'YT short'): Promise<void> {
-  await createContentRow({
+async function createCandidateRow(c: RawCandidate, kind: 'blog' | 'YT short'): Promise<void> {
+  const newId = await createContentRow({
     title: c.title,
     kind,
     stage: 'Proposed',
@@ -184,8 +193,17 @@ async function createCandidateRow(c: Candidate, kind: 'blog' | 'YT short'): Prom
     tags: c.tags ?? [],
     tools: c.tools ?? [],
     hint: c.hint,
-    sourceUrls: c.sourceUrls,
+    sourceUrls: c.source_urls,
   })
+  if (c.rationale) {
+    await appendBlocks(newId, [
+      {
+        object: 'block',
+        type: 'paragraph',
+        paragraph: { rich_text: [{ type: 'text', text: { content: c.rationale } }] },
+      },
+    ])
+  }
   console.log(`+ ${kind}: ${c.title}`)
 }
 

--- a/scripts/agent/draft.ts
+++ b/scripts/agent/draft.ts
@@ -1,14 +1,16 @@
 // scripts/agent/draft.ts
 import { writeFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { runPrompt } from './lib/claude'
-import { queryContentRows, updateContentRow, addPageComment } from './lib/notion'
+import { runPrompt, parseJsonResponse } from './lib/claude'
+import { queryContentRows, updateContentRow, addPageComment, replacePageBody } from './lib/notion'
 import { recentCommits } from './lib/git-scan'
-import { loadEditorialGuide } from './lib/editorial'
+import { loadEditorialGuide, loadShortsStyleGuide } from './lib/editorial'
 import { buildBlogSystemPrompt, buildBlogUserPrompt, slugify } from './lib/draft-blog'
+import { buildYtSystemPrompt, buildYtUserPrompt, renderYtScriptToBlocks } from './lib/draft-yt'
+import { recentChannelStats } from './lib/youtube'
 import { validateMdxFrontmatter, runVale, formatValeReport } from './lib/validate'
 import { createBranchAndPr } from './lib/pr'
-import type { ContentRow, CommitInfo } from './lib/types'
+import type { ContentRow, CommitInfo, YTScriptBlocks, YouTubeStat } from './lib/types'
 
 const READY_FILTER = {
   property: 'Stage',
@@ -32,8 +34,8 @@ async function main(): Promise<void> {
         await draftBlogRow(row, allCommits, editorialMd)
         succeeded++
       } else if (row.kind === 'YT short' || row.kind === 'YT long') {
-        // Stubbed — implemented in Phase 5
-        console.log(`Skipping YT row (Phase 5 not yet implemented): ${row.title}`)
+        await draftYtRow(row)
+        succeeded++
       } else {
         console.log(`Skipping unsupported Kind=${row.kind}: ${row.title}`)
       }
@@ -124,6 +126,72 @@ async function draftBlogRow(
   spawnSync('git', ['checkout', '-'], { encoding: 'utf8' })
 
   console.log(`✓ Drafted ${row.title} → ${prUrl}`)
+}
+
+async function draftYtRow(row: ContentRow): Promise<void> {
+  const shortsStyleMd = loadShortsStyleGuide()
+  const stats = await recentChannelStats(30)
+  const perfSignal = buildPerfSignal(row.tools, stats)
+
+  const systemPrompt = buildYtSystemPrompt({
+    shortsStyleMd,
+    kind: row.kind,
+    tools: row.tools,
+  })
+  const userPrompt = buildYtUserPrompt({
+    title: row.title,
+    hint: row.hint,
+    sourceUrls: row.sourceUrls,
+    tools: row.tools,
+    perfSignal,
+  })
+
+  console.log(`Calling Claude for YT: ${row.title}`)
+  const json = await runPrompt({ systemPrompt, userPrompt })
+  const parsed = parseJsonResponse<RawYtScript>(json)
+  const blocks: YTScriptBlocks = {
+    hook: parsed.hook,
+    script: parsed.script,
+    onScreenText: parsed.on_screen_text.map((o) => ({
+      timestampSeconds: o.timestamp_seconds,
+      text: o.text,
+    })),
+    bRoll: parsed.b_roll.map((b) => ({
+      timestampSeconds: b.timestamp_seconds,
+      description: b.description,
+    })),
+    thumbnailPrompt: parsed.thumbnail_prompt,
+    titleVariants: parsed.title_variants,
+    hashtags: parsed.hashtags,
+  }
+  const notionBlocks = renderYtScriptToBlocks(blocks)
+  await replacePageBody(row.id, notionBlocks)
+  await updateContentRow(row.id, { stage: 'Drafted' })
+
+  console.log(`✓ YT script drafted for ${row.title}`)
+}
+
+interface RawYtScript {
+  hook: string
+  script: string
+  on_screen_text: Array<{ timestamp_seconds: number; text: string }>
+  b_roll: Array<{ timestamp_seconds: number; description: string }>
+  thumbnail_prompt: string
+  title_variants: string[]
+  hashtags: string[]
+}
+
+function buildPerfSignal(tools: string[], stats: YouTubeStat[]): string {
+  if (stats.length === 0) return 'No recent video stats available.'
+  const lines: string[] = ['Recent video performance (last 30 days):']
+  for (const s of stats.slice(0, 10)) {
+    lines.push(`- "${s.title}" — ${s.views} views`)
+  }
+  if (tools.length > 0) {
+    lines.push('')
+    lines.push(`Tools this script covers: ${tools.join(', ')}.`)
+  }
+  return lines.join('\n')
 }
 
 function renderPrBody(row: ContentRow, valeReport: string): string {

--- a/scripts/agent/draft.ts
+++ b/scripts/agent/draft.ts
@@ -108,22 +108,27 @@ async function draftBlogRow(
   const stageRes = spawnSync('git', ['add', filePath], { encoding: 'utf8' })
   if (stageRes.status !== 0) throw new Error(`git add failed: ${stageRes.stderr}`)
 
-  // Create branch + PR
+  // Create branch + PR, always returning to the originating branch afterwards
   const branchName = `agent/draft/${slug}`
   const commitMsg = `draft: ${row.title} (proposed by agent)`
   const prBody = renderPrBody(row, valeReport)
-  const { prUrl } = createBranchAndPr({
-    branchName,
-    commitMessage: commitMsg,
-    prTitle: commitMsg,
-    prBody,
-  })
 
-  // Update Notion
+  let prUrl: string
+  try {
+    const result = createBranchAndPr({
+      branchName,
+      commitMessage: commitMsg,
+      prTitle: commitMsg,
+      prBody,
+    })
+    prUrl = result.prUrl
+  } finally {
+    // Always return to the originating branch so the next row starts clean
+    spawnSync('git', ['checkout', '-'], { encoding: 'utf8' })
+  }
+
+  // Update Notion (only reached if PR creation succeeded)
   await updateContentRow(row.id, { stage: 'Drafted', draftUrl: prUrl })
-
-  // Return to main branch so the next iteration starts clean
-  spawnSync('git', ['checkout', '-'], { encoding: 'utf8' })
 
   console.log(`✓ Drafted ${row.title} → ${prUrl}`)
 }

--- a/scripts/agent/draft.ts
+++ b/scripts/agent/draft.ts
@@ -1,0 +1,163 @@
+// scripts/agent/draft.ts
+import { writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { runPrompt } from './lib/claude'
+import { queryContentRows, updateContentRow, addPageComment } from './lib/notion'
+import { recentCommits } from './lib/git-scan'
+import { loadEditorialGuide } from './lib/editorial'
+import { buildBlogSystemPrompt, buildBlogUserPrompt, slugify } from './lib/draft-blog'
+import { validateMdxFrontmatter, runVale, formatValeReport } from './lib/validate'
+import { createBranchAndPr } from './lib/pr'
+import type { ContentRow, CommitInfo } from './lib/types'
+
+const READY_FILTER = {
+  property: 'Stage',
+  select: { equals: 'Ready' },
+}
+
+async function main(): Promise<void> {
+  const rows = await queryContentRows(READY_FILTER)
+  console.log(`Found ${rows.length} Ready row(s).`)
+  if (rows.length === 0) return
+
+  // Fetch shared context once
+  const allCommits = await recentCommits(7)
+  const editorialMd = loadEditorialGuide()
+
+  let succeeded = 0
+  let failed = 0
+  for (const row of rows) {
+    try {
+      if (row.kind === 'blog') {
+        await draftBlogRow(row, allCommits, editorialMd)
+        succeeded++
+      } else if (row.kind === 'YT short' || row.kind === 'YT long') {
+        // Stubbed — implemented in Phase 5
+        console.log(`Skipping YT row (Phase 5 not yet implemented): ${row.title}`)
+      } else {
+        console.log(`Skipping unsupported Kind=${row.kind}: ${row.title}`)
+      }
+    } catch (err) {
+      failed++
+      const msg = (err as Error).message
+      console.error(`Row ${row.id} (${row.title}) failed: ${msg}`)
+      try {
+        await addPageComment(row.id, `Agent drafting failed: ${msg}`)
+      } catch (commentErr) {
+        console.error(`Also failed to post Notion comment: ${(commentErr as Error).message}`)
+      }
+    }
+  }
+  console.log(`Done. Succeeded: ${succeeded}, Failed: ${failed}`)
+}
+
+async function draftBlogRow(
+  row: ContentRow,
+  allCommits: CommitInfo[],
+  editorialMd: string
+): Promise<void> {
+  // Filter commits relevant to this row (mentioned by SHA in Source URLs)
+  const relevantShas = new Set(
+    row.sourceUrls.map((u) => u.match(/\/commit\/([a-f0-9]+)/)?.[1]).filter((x): x is string => !!x)
+  )
+  const commits = allCommits.filter((c) => relevantShas.has(c.sha))
+
+  const isDerivative = row.origin === 'Derivative'
+  const sourceVideoUrl = isDerivative
+    ? row.sourceUrls.find((u) => /youtu\.be|youtube\.com/.test(u))
+    : undefined
+
+  const systemPrompt = buildBlogSystemPrompt({
+    editorialMd,
+    isDerivative,
+    sourceVideoUrl,
+  })
+
+  const userPrompt = buildBlogUserPrompt({
+    title: row.title,
+    hint: row.hint,
+    sourceUrls: row.sourceUrls,
+    tags: row.tags,
+    commits,
+    sourceVideoUrl,
+    sourceScript: undefined, // populated below in YT-derivative case if we add it later
+  })
+
+  console.log(`Calling Claude for: ${row.title}`)
+  const mdx = await runPrompt({ systemPrompt, userPrompt })
+
+  // Validate
+  const valid = validateMdxFrontmatter(mdx)
+  if (!valid.ok) {
+    throw new Error(`Frontmatter validation failed: ${valid.error}`)
+  }
+
+  // Write file
+  const slug = slugify(row.title)
+  const filePath = join('src', 'content', 'writing', `${slug}.mdx`)
+  writeFileSync(filePath, mdx)
+
+  // Vale
+  const findings = runVale(filePath)
+  const valeReport = formatValeReport(findings)
+
+  // Stage the file
+  const { spawnSync } = await import('node:child_process')
+  const stageRes = spawnSync('git', ['add', filePath], { encoding: 'utf8' })
+  if (stageRes.status !== 0) throw new Error(`git add failed: ${stageRes.stderr}`)
+
+  // Create branch + PR
+  const branchName = `agent/draft/${slug}`
+  const commitMsg = `draft: ${row.title} (proposed by agent)`
+  const prBody = renderPrBody(row, valeReport)
+  const { prUrl } = createBranchAndPr({
+    branchName,
+    commitMessage: commitMsg,
+    prTitle: commitMsg,
+    prBody,
+  })
+
+  // Update Notion
+  await updateContentRow(row.id, { stage: 'Drafted', draftUrl: prUrl })
+
+  // Return to main branch so the next iteration starts clean
+  spawnSync('git', ['checkout', '-'], { encoding: 'utf8' })
+
+  console.log(`✓ Drafted ${row.title} → ${prUrl}`)
+}
+
+function renderPrBody(row: ContentRow, valeReport: string): string {
+  return `## AI-drafted post
+
+Drafted by the Plan B agent from Notion row [\`${
+    row.title
+  }\`](https://www.notion.so/${row.id.replace(/-/g, '')}).
+
+### Source
+- Hint: ${row.hint || '_(none)_'}
+- Tags: ${row.tags.join(', ') || '_(none)_'}
+- Source URLs: ${row.sourceUrls.length ? row.sourceUrls.join(', ') : '_(none)_'}
+
+### Pre-publish checklist (from docs/EDITORIAL.md)
+
+- [ ] Voice check — sounds like me, not a press release
+- [ ] Accuracy — every claim reflects something I actually did/saw/built
+- [ ] AI-tell sweep (read it out loud)
+- [ ] Length matches bucket
+- [ ] Frontmatter complete
+- [ ] Cloudflare preview reviewed (mobile too)
+
+### Vale report
+
+${valeReport}
+
+---
+
+_When this PR merges to main, please update the Notion row's Published URL to the live shariq.dev URL._
+`
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/agent/lib/bucket.ts
+++ b/scripts/agent/lib/bucket.ts
@@ -1,0 +1,2 @@
+export { resolveBucket, BUCKETS } from '../../../src/lib/buckets'
+export type { Bucket, BucketKey } from '../../../src/lib/buckets'

--- a/scripts/agent/lib/claude.ts
+++ b/scripts/agent/lib/claude.ts
@@ -1,0 +1,49 @@
+// scripts/agent/lib/claude.ts
+import { query } from '@anthropic-ai/claude-agent-sdk'
+
+export interface PromptOptions {
+  systemPrompt: string
+  userPrompt: string
+  model?: string
+  maxTurns?: number
+}
+
+/**
+ * Runs a one-shot Claude prompt via the Agent SDK using subscription OAuth.
+ * Returns the assistant's full text response.
+ *
+ * Auth: reads CLAUDE_CODE_OAUTH_TOKEN from env (set by config import side effect
+ * via 'dotenv/config' in callers' lib/config.ts).
+ */
+export async function runPrompt(opts: PromptOptions): Promise<string> {
+  const result = query({
+    prompt: opts.userPrompt,
+    options: {
+      systemPrompt: opts.systemPrompt,
+      model: opts.model ?? 'claude-sonnet-4-6',
+      // Disable all built-in tools — we feed all context in the prompt.
+      tools: [],
+      maxTurns: opts.maxTurns ?? 1,
+    },
+  })
+
+  let text = ''
+  for await (const message of result) {
+    if (message.type === 'assistant' && Array.isArray(message.message.content)) {
+      for (const block of message.message.content) {
+        if (block.type === 'text') text += block.text
+      }
+    }
+  }
+  return text.trim()
+}
+
+/**
+ * Parses a Claude response we expect to be JSON. The model often wraps JSON in
+ * markdown code fences; this strips those before parsing.
+ */
+export function parseJsonResponse<T>(text: string): T {
+  const fenced = text.match(/```(?:json)?\s*([\s\S]+?)```/)
+  const raw = fenced ? fenced[1] : text
+  return JSON.parse(raw.trim()) as T
+}

--- a/scripts/agent/lib/config.ts
+++ b/scripts/agent/lib/config.ts
@@ -14,7 +14,7 @@ function optional(key: string, fallback: string): string {
 export const CONFIG = {
   claudeOauthToken: required('CLAUDE_CODE_OAUTH_TOKEN'),
   notionToken: required('NOTION_TOKEN'),
-  notionContentDbId: required('NOTION_CONTENT_DB_ID'),
+  notionCmsDbId: required('NOTION_CMS_DB_ID'),
   youtubeApiKey: required('YOUTUBE_API_KEY'),
   youtubeChannelId: required('YOUTUBE_CHANNEL_ID'),
   agentGhToken: required('AGENT_GH_TOKEN'),
@@ -22,9 +22,6 @@ export const CONFIG = {
   scanRepoOrg: optional('SCAN_REPO_ORG', 'shariqh'),
   scanRepoInclude: optional('SCAN_REPO_INCLUDE', 'blog-site,lognote').split(','),
   scanRepoActiveDays: parseInt(optional('SCAN_REPO_ACTIVE_DAYS', '30'), 10),
-
-  // Set by `npm run migrate:cms` — old DB to read from once before deprecation.
-  notionLegacyCmsDbId: process.env.NOTION_LEGACY_CMS_DB_ID,
 } as const
 
 export type Config = typeof CONFIG

--- a/scripts/agent/lib/config.ts
+++ b/scripts/agent/lib/config.ts
@@ -1,0 +1,30 @@
+// scripts/agent/lib/config.ts
+import 'dotenv/config'
+
+function required(key: string): string {
+  const val = process.env[key]
+  if (!val) throw new Error(`Missing required env var: ${key}`)
+  return val
+}
+
+function optional(key: string, fallback: string): string {
+  return process.env[key] ?? fallback
+}
+
+export const CONFIG = {
+  claudeOauthToken: required('CLAUDE_CODE_OAUTH_TOKEN'),
+  notionToken: required('NOTION_TOKEN'),
+  notionContentDbId: required('NOTION_CONTENT_DB_ID'),
+  youtubeApiKey: required('YOUTUBE_API_KEY'),
+  youtubeChannelId: required('YOUTUBE_CHANNEL_ID'),
+  agentGhToken: required('AGENT_GH_TOKEN'),
+
+  scanRepoOrg: optional('SCAN_REPO_ORG', 'shariqh'),
+  scanRepoInclude: optional('SCAN_REPO_INCLUDE', 'blog-site,lognote').split(','),
+  scanRepoActiveDays: parseInt(optional('SCAN_REPO_ACTIVE_DAYS', '30'), 10),
+
+  // Set by `npm run migrate:cms` — old DB to read from once before deprecation.
+  notionLegacyCmsDbId: process.env.NOTION_LEGACY_CMS_DB_ID,
+} as const
+
+export type Config = typeof CONFIG

--- a/scripts/agent/lib/dedupe.ts
+++ b/scripts/agent/lib/dedupe.ts
@@ -1,0 +1,61 @@
+// scripts/agent/lib/dedupe.ts
+
+function levenshtein(a: string, b: string): number {
+  const m = a.length
+  const n = b.length
+  if (m === 0) return n
+  if (n === 0) return m
+  const dp = Array.from({ length: m + 1 }, () => new Array<number>(n + 1).fill(0))
+  for (let i = 0; i <= m; i++) dp[i][0] = i
+  for (let j = 0; j <= n; j++) dp[0][j] = j
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1
+      dp[i][j] = Math.min(dp[i - 1][j] + 1, dp[i][j - 1] + 1, dp[i - 1][j - 1] + cost)
+    }
+  }
+  return dp[m][n]
+}
+
+function normalize(s: string): string {
+  return s.trim().toLowerCase().replace(/\s+/g, ' ')
+}
+
+/**
+ * Returns true if `candidate` is within 20% normalized edit distance of any
+ * title in `existing`. Used to skip re-proposing similar candidates.
+ */
+export function isTitleDuplicate(candidate: string, existing: string[]): boolean {
+  if (existing.length === 0) return false
+  const cand = normalize(candidate)
+  for (const ex of existing) {
+    const a = cand
+    const b = normalize(ex)
+    const maxLen = Math.max(a.length, b.length)
+    if (maxLen === 0) continue
+    const ratio = levenshtein(a, b) / maxLen
+    if (ratio <= 0.2) return true
+  }
+  return false
+}
+
+/**
+ * Returns true if every tool in `proposed` is contained in at least one row's
+ * tool list in `existingRows`. (One row must cover the whole proposed set.)
+ */
+export function hasFullToolsOverlap(proposed: string[], existingRows: string[][]): boolean {
+  if (proposed.length === 0) return false
+  const propSet = new Set(proposed.map((t) => t.toLowerCase()))
+  for (const row of existingRows) {
+    const rowSet = new Set(row.map((t) => t.toLowerCase()))
+    let allIn = true
+    for (const t of propSet) {
+      if (!rowSet.has(t)) {
+        allIn = false
+        break
+      }
+    }
+    if (allIn) return true
+  }
+  return false
+}

--- a/scripts/agent/lib/draft-blog.ts
+++ b/scripts/agent/lib/draft-blog.ts
@@ -1,0 +1,121 @@
+import { BUCKETS } from './bucket'
+import type { CommitInfo } from './types'
+
+export function slugify(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+}
+
+export interface BlogSystemPromptInput {
+  editorialMd: string
+  isDerivative: boolean
+  sourceVideoUrl?: string
+}
+
+export function buildBlogSystemPrompt(input: BlogSystemPromptInput): string {
+  const bucketSummary = Object.entries(BUCKETS)
+    .map(
+      ([key, b]) =>
+        `- **${b.label}** (key: \`${key}\`) — tags: ${
+          b.tags.length ? b.tags.join(', ') : '(catch-all)'
+        }`
+    )
+    .join('\n')
+
+  const derivativeBlock = input.isDerivative
+    ? `
+
+## DERIVATIVE POST FROM YOUTUBE
+
+This post derives from a YouTube video. Open the MDX with the video embedded at the very top via:
+
+\`\`\`mdx
+<Youtube id="${extractYoutubeId(input.sourceVideoUrl ?? '')}" />
+\`\`\`
+
+After the embed, write what you couldn't fit in 60 seconds — context, longer demos, gotchas, where it fits in the broader stack.
+`
+    : ''
+
+  return `You are the drafting agent for shariq.dev. Your job is to produce one MDX file ready to publish, following the editorial guide below verbatim.
+
+OUTPUT: Just the MDX file contents. No prose explanation, no markdown fences around the file. Start with the YAML frontmatter, end with the body.
+
+# Buckets
+
+Posts are categorized by tags into one of five buckets:
+
+${bucketSummary}
+
+Pick tags appropriate for the post. The bucket resolver in src/lib/buckets.ts will assign the visual treatment automatically.
+
+# Editorial guide (verbatim — follow these rules)
+
+${input.editorialMd}
+${derivativeBlock}`
+}
+
+function extractYoutubeId(url: string): string {
+  const m = url.match(/(?:youtu\.be\/|v=)([A-Za-z0-9_-]{11})/)
+  return m?.[1] ?? ''
+}
+
+export interface BlogUserPromptInput {
+  title: string
+  hint: string
+  sourceUrls: string[]
+  tags: string[]
+  commits: CommitInfo[]
+  sourceVideoUrl?: string
+  sourceScript?: string
+}
+
+export function buildBlogUserPrompt(input: BlogUserPromptInput): string {
+  const lines: string[] = []
+  lines.push(`# Draft this post`)
+  lines.push('')
+  lines.push(`**Working title:** ${input.title}`)
+  lines.push(`**Angle:** ${input.hint || '(none provided — derive from sources)'}`)
+  if (input.tags.length) lines.push(`**Suggested tags:** ${input.tags.join(', ')}`)
+  lines.push('')
+
+  if (input.sourceVideoUrl) {
+    lines.push('## Source video')
+    lines.push(input.sourceVideoUrl)
+    lines.push('')
+  }
+  if (input.sourceScript) {
+    lines.push('## Original YouTube script (basis to expand from)')
+    lines.push('```')
+    lines.push(input.sourceScript)
+    lines.push('```')
+    lines.push('')
+  }
+  if (input.sourceUrls.length) {
+    lines.push('## Source URLs')
+    for (const u of input.sourceUrls) lines.push(`- ${u}`)
+    lines.push('')
+  }
+  if (input.commits.length) {
+    lines.push('## Recent commits (context)')
+    for (const c of input.commits) {
+      lines.push(
+        `- \`${c.repo}@${c.sha.slice(0, 7)}\` (${c.date.slice(0, 10)}) — ${
+          c.message.split('\n')[0]
+        }`
+      )
+      if (c.filesChanged.length) lines.push(`  files: ${c.filesChanged.slice(0, 5).join(', ')}`)
+    }
+    lines.push('')
+  }
+
+  lines.push(`Today's date: ${new Date().toISOString().slice(0, 10)}`)
+  lines.push('')
+  lines.push('Write the MDX now. Frontmatter first, body second.')
+
+  return lines.join('\n')
+}

--- a/scripts/agent/lib/draft-yt.ts
+++ b/scripts/agent/lib/draft-yt.ts
@@ -1,0 +1,122 @@
+// scripts/agent/lib/draft-yt.ts
+import type { YTScriptBlocks, Kind } from './types'
+
+export interface YtSystemPromptInput {
+  shortsStyleMd: string
+  kind: Kind
+  tools: string[]
+}
+
+export function buildYtSystemPrompt(input: YtSystemPromptInput): string {
+  return `You are the drafting agent for the shariq.dev YouTube channel. Produce one script in the structured JSON format below, following the style guide verbatim.
+
+OUTPUT: Valid JSON only. No markdown fences, no commentary, no preamble.
+
+# Kind
+${input.kind}
+
+# Tools covered
+${input.tools.length ? input.tools.join(', ') : '(none specified — infer from sources)'}
+
+# Style guide
+
+${input.shortsStyleMd}
+
+# Output schema
+
+\`\`\`json
+{
+  "hook": "string (≤3s of dialogue)",
+  "script": "string (full body, ~50s for short, ~5min for long)",
+  "on_screen_text": [{"timestamp_seconds": number, "text": "string ≤6 words"}],
+  "b_roll": [{"timestamp_seconds": number, "description": "string"}],
+  "thumbnail_prompt": "string (one sentence)",
+  "title_variants": ["string", "string", "string"],
+  "hashtags": ["string", "string", "..."]
+}
+\`\`\`
+`
+}
+
+export interface YtUserPromptInput {
+  title: string
+  hint: string
+  sourceUrls: string[]
+  tools: string[]
+  perfSignal?: string
+}
+
+export function buildYtUserPrompt(input: YtUserPromptInput): string {
+  const lines: string[] = []
+  lines.push(`# Write this script`)
+  lines.push('')
+  lines.push(`**Working title:** ${input.title}`)
+  lines.push(`**Angle:** ${input.hint || '(none — derive)'}`)
+  if (input.tools.length) lines.push(`**Tools:** ${input.tools.join(', ')}`)
+  if (input.sourceUrls.length) {
+    lines.push('')
+    lines.push('## Source URLs')
+    for (const u of input.sourceUrls) lines.push(`- ${u}`)
+  }
+  if (input.perfSignal) {
+    lines.push('')
+    lines.push('## Performance signal')
+    lines.push(input.perfSignal)
+  }
+  lines.push('')
+  lines.push('Return the JSON now.')
+  return lines.join('\n')
+}
+
+interface NotionBlock {
+  object?: 'block'
+  type: string
+  [k: string]: unknown
+}
+
+function rtText(content: string): unknown[] {
+  return [{ type: 'text', text: { content } }]
+}
+
+function heading2(text: string): NotionBlock {
+  return { object: 'block', type: 'heading_2', heading_2: { rich_text: rtText(text) } }
+}
+
+function paragraph(text: string): NotionBlock {
+  return { object: 'block', type: 'paragraph', paragraph: { rich_text: rtText(text) } }
+}
+
+function bullet(text: string): NotionBlock {
+  return {
+    object: 'block',
+    type: 'bulleted_list_item',
+    bulleted_list_item: { rich_text: rtText(text) },
+  }
+}
+
+export function renderYtScriptToBlocks(s: YTScriptBlocks): NotionBlock[] {
+  const blocks: NotionBlock[] = []
+
+  blocks.push(heading2('Hook'))
+  blocks.push(paragraph(s.hook))
+
+  blocks.push(heading2('Script'))
+  for (const para of s.script.split(/\n\s*\n/)) blocks.push(paragraph(para))
+
+  blocks.push(heading2('On-screen text'))
+  for (const ost of s.onScreenText) blocks.push(bullet(`${ost.timestampSeconds}s — ${ost.text}`))
+
+  blocks.push(heading2('B-roll'))
+  for (const b of s.bRoll) blocks.push(bullet(`${b.timestampSeconds}s — ${b.description}`))
+
+  blocks.push(heading2('Thumbnail'))
+  blocks.push(paragraph(s.thumbnailPrompt))
+
+  blocks.push(heading2('Title variants'))
+  for (const t of s.titleVariants) blocks.push(bullet(t))
+
+  blocks.push(heading2('Hashtags'))
+  blocks.push(paragraph(s.hashtags.map((h) => `#${h}`).join(' ')))
+
+  return blocks
+}

--- a/scripts/agent/lib/editorial.ts
+++ b/scripts/agent/lib/editorial.ts
@@ -1,0 +1,14 @@
+// scripts/agent/lib/editorial.ts
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..')
+
+export function loadEditorialGuide(): string {
+  return readFileSync(join(REPO_ROOT, 'docs', 'EDITORIAL.md'), 'utf8')
+}
+
+export function loadShortsStyleGuide(): string {
+  return readFileSync(join(REPO_ROOT, 'docs', 'SHORTS-STYLE.md'), 'utf8')
+}

--- a/scripts/agent/lib/git-scan.ts
+++ b/scripts/agent/lib/git-scan.ts
@@ -1,0 +1,98 @@
+// scripts/agent/lib/git-scan.ts
+import { CONFIG } from './config'
+import type { CommitInfo } from './types'
+
+interface GhCommit {
+  sha: string
+  html_url: string
+  commit: { message: string; author: { date: string } }
+}
+
+interface GhCommitFile {
+  filename: string
+}
+
+interface GhRepo {
+  name: string
+  pushed_at: string
+  private: boolean
+}
+
+const GH_API = 'https://api.github.com'
+
+function ghHeaders(): Record<string, string> {
+  return {
+    Authorization: `Bearer ${CONFIG.agentGhToken}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+  }
+}
+
+/**
+ * Returns commits across all repos in scope from the last N days.
+ * Scope = always-on repos (CONFIG.scanRepoInclude) + any public repo under
+ * CONFIG.scanRepoOrg with a push in the last CONFIG.scanRepoActiveDays days.
+ */
+export async function recentCommits(daysBack: number = 7): Promise<CommitInfo[]> {
+  const since = new Date(Date.now() - daysBack * 86_400_000).toISOString()
+  const repos = await reposInScope()
+  const allCommits: CommitInfo[] = []
+  for (const repo of repos) {
+    try {
+      const commits = await fetchCommits(repo, since)
+      allCommits.push(...commits)
+    } catch (err) {
+      console.warn(`Failed to fetch commits for ${repo}: ${(err as Error).message}`)
+    }
+  }
+  return allCommits
+}
+
+async function reposInScope(): Promise<string[]> {
+  const always = CONFIG.scanRepoInclude.map((r) => `${CONFIG.scanRepoOrg}/${r}`)
+  const opportunistic = await activeRepos()
+  const set = new Set<string>([...always, ...opportunistic])
+  return [...set]
+}
+
+async function activeRepos(): Promise<string[]> {
+  const url = `${GH_API}/users/${CONFIG.scanRepoOrg}/repos?per_page=100&sort=pushed&type=public`
+  const res = await fetch(url, { headers: ghHeaders() })
+  if (!res.ok) {
+    console.warn(`Failed to list ${CONFIG.scanRepoOrg} repos: ${res.status}`)
+    return []
+  }
+  const repos = (await res.json()) as GhRepo[]
+  const cutoff = Date.now() - CONFIG.scanRepoActiveDays * 86_400_000
+  return repos
+    .filter((r) => !r.private && new Date(r.pushed_at).getTime() >= cutoff)
+    .map((r) => `${CONFIG.scanRepoOrg}/${r.name}`)
+}
+
+async function fetchCommits(repo: string, sinceISO: string): Promise<CommitInfo[]> {
+  const url = `${GH_API}/repos/${repo}/commits?since=${sinceISO}&per_page=50`
+  const res = await fetch(url, { headers: ghHeaders() })
+  if (!res.ok) throw new Error(`${res.status}`)
+  const commits = (await res.json()) as GhCommit[]
+  const results: CommitInfo[] = []
+  for (const c of commits) {
+    const files = await fetchFiles(repo, c.sha)
+    results.push({
+      repo,
+      sha: c.sha,
+      message: c.commit.message,
+      date: c.commit.author.date,
+      filesChanged: files.slice(0, 10),
+      url: c.html_url,
+    })
+  }
+  return results
+}
+
+async function fetchFiles(repo: string, sha: string): Promise<string[]> {
+  const url = `${GH_API}/repos/${repo}/commits/${sha}`
+  const res = await fetch(url, { headers: ghHeaders() })
+  if (!res.ok) return []
+  const data = (await res.json()) as { files?: GhCommitFile[] }
+  return (data.files ?? []).map((f) => f.filename)
+}

--- a/scripts/agent/lib/migrate-mapping.ts
+++ b/scripts/agent/lib/migrate-mapping.ts
@@ -1,0 +1,103 @@
+// scripts/agent/lib/migrate-mapping.ts
+import type {
+  CmsRow,
+  Kind,
+  Stage,
+  Origin,
+  CrossPostTarget,
+  LegacyStatus,
+  LegacyMedium,
+  MappedRow,
+} from './types'
+
+const STATUS_MAP: Record<LegacyStatus, Stage> = {
+  Prepping: 'Idea',
+  'Ready To Record': 'Ready',
+  Recording: 'Recorded',
+  'Post-Processing': 'Edited',
+  Published: 'Published',
+  Abandoned: 'Abandoned',
+  '✅': 'Published',
+}
+
+const MEDIUM_TO_KIND: Record<LegacyMedium, Kind> = {
+  blog: 'blog',
+  youtube: 'YT short', // default YouTube to short; user can adjust
+  'YT short': 'YT short',
+  podcast: 'podcast',
+  presentation: 'presentation',
+  'IG reel': 'IG reel',
+  'stand up': 'stand up',
+}
+
+export function statusToStage(s?: LegacyStatus): Stage {
+  if (!s) return 'Idea'
+  return STATUS_MAP[s] ?? 'Idea'
+}
+
+export function mediumToKind(m: LegacyMedium): Kind {
+  return MEDIUM_TO_KIND[m] ?? 'blog'
+}
+
+function splitSources(s: string): string[] {
+  if (!s) return []
+  return s
+    .split(/[\n,]+/)
+    .map((x) => x.trim())
+    .filter((x) => x.length > 0)
+}
+
+function buildHint(row: CmsRow): string {
+  const parts: string[] = []
+  if (row.keywords) parts.push(row.keywords.trim())
+  return parts.join(' · ')
+}
+
+function isCrossPostTarget(k: Kind): k is CrossPostTarget {
+  return k === 'blog' || k === 'YT short' || k === 'YT long'
+}
+
+export function mapCmsRowToContentRows(row: CmsRow): MappedRow[] {
+  const mediums = row.medium.length > 0 ? row.medium : (['blog'] as LegacyMedium[])
+  const kinds = mediums.map(mediumToKind)
+  const stage = statusToStage(row.status)
+  const hint = buildHint(row)
+  const sourceUrls = splitSources(row.sources)
+  const baseOrigin: Origin = row.origin === 'x-post:blog' ? 'Derivative' : 'OC'
+
+  // x-post:bundle → primary row's Cross-post Targets gets the *other* kinds
+  // When splitting multi-medium without bundle, the primary still gets Cross-post Targets
+  // so the future agent run can recognize the relationship.
+  const crossPostsForPrimary: CrossPostTarget[] = kinds.slice(1).filter(isCrossPostTarget)
+
+  const primary: MappedRow = {
+    title: row.title,
+    kind: kinds[0],
+    stage,
+    origin: baseOrigin,
+    crossPostTargets: crossPostsForPrimary,
+    tags: row.tags,
+    tools: [],
+    hint,
+    sourceUrls,
+    publishedUrl: row.publishedLink || undefined,
+    publishingDate: row.publishing,
+    // primary keeps the original Notion page ID — no source row marker needed
+  }
+
+  const derivatives: MappedRow[] = kinds.slice(1).map((k) => ({
+    title: row.title,
+    kind: k,
+    stage,
+    origin: 'Derivative' as Origin,
+    crossPostTargets: [],
+    tags: row.tags,
+    tools: [],
+    hint,
+    sourceUrls,
+    publishingDate: row.publishing,
+    sourceRowOriginalPageId: row.id,
+  }))
+
+  return [primary, ...derivatives]
+}

--- a/scripts/agent/lib/notion.ts
+++ b/scripts/agent/lib/notion.ts
@@ -7,7 +7,7 @@ const VERSION = '2025-09-03'
 // CONFIG is imported lazily via a cached variable so that module load does not
 // call required() — which throws when env vars are absent. The pure
 // row-mapper (pageToContentRow) therefore stays unit-testable without env vars.
-let _config: { notionToken: string; notionContentDbId: string } | undefined
+let _config: { notionToken: string; notionCmsDbId: string } | undefined
 
 async function getConfig() {
   if (!_config) {
@@ -131,7 +131,7 @@ export function pageToContentRow(page: NotionPage): ContentRow {
 
 export async function queryContentRows(filter: object, sorts?: object[]): Promise<ContentRow[]> {
   const cfg = await getConfig()
-  const dataSourceId = await getDataSourceIdForDb(cfg.notionContentDbId)
+  const dataSourceId = await getDataSourceIdForDb(cfg.notionCmsDbId)
   const rows: ContentRow[] = []
   let cursor: string | undefined
   do {
@@ -173,7 +173,7 @@ export interface CreateRowInput {
 
 export async function createContentRow(input: CreateRowInput): Promise<string> {
   const cfg = await getConfig()
-  const dataSourceId = await getDataSourceIdForDb(cfg.notionContentDbId)
+  const dataSourceId = await getDataSourceIdForDb(cfg.notionCmsDbId)
   const body = {
     parent: { type: 'data_source_id', data_source_id: dataSourceId },
     properties: buildPropertiesPayload(input),

--- a/scripts/agent/lib/notion.ts
+++ b/scripts/agent/lib/notion.ts
@@ -56,12 +56,12 @@ type NotionPage = {
 function textOf(prop: AnyProp | undefined): string {
   if (!prop) return ''
   if (prop.type === 'title') {
-    return ((prop as { title: Array<{ plain_text: string }> }).title ?? [])
+    return (((prop as unknown) as { title: Array<{ plain_text: string }> }).title ?? [])
       .map((t) => t.plain_text)
       .join('')
   }
   if (prop.type === 'rich_text') {
-    return ((prop as { rich_text: Array<{ plain_text: string }> }).rich_text ?? [])
+    return (((prop as unknown) as { rich_text: Array<{ plain_text: string }> }).rich_text ?? [])
       .map((t) => t.plain_text)
       .join('')
   }
@@ -70,31 +70,31 @@ function textOf(prop: AnyProp | undefined): string {
 
 function selectName<T extends string>(prop: AnyProp | undefined): T | undefined {
   if (!prop || prop.type !== 'select') return undefined
-  const sel = (prop as { select: { name: string } | null }).select
+  const sel = ((prop as unknown) as { select: { name: string } | null }).select
   return sel ? (sel.name as T) : undefined
 }
 
 function multiSelectNames<T extends string>(prop: AnyProp | undefined): T[] {
   if (!prop || prop.type !== 'multi_select') return []
-  return ((prop as { multi_select: Array<{ name: string }> }).multi_select ?? []).map(
+  return (((prop as unknown) as { multi_select: Array<{ name: string }> }).multi_select ?? []).map(
     (m) => m.name as T
   )
 }
 
 function urlOf(prop: AnyProp | undefined): string | undefined {
   if (!prop || prop.type !== 'url') return undefined
-  const v = (prop as { url: string | null }).url
+  const v = ((prop as unknown) as { url: string | null }).url
   return v ?? undefined
 }
 
 function dateStartOf(prop: AnyProp | undefined): string | undefined {
   if (!prop || prop.type !== 'date') return undefined
-  return (prop as { date: { start: string } | null }).date?.start
+  return ((prop as unknown) as { date: { start: string } | null }).date?.start
 }
 
 function relationFirstId(prop: AnyProp | undefined): string | undefined {
   if (!prop || prop.type !== 'relation') return undefined
-  const rel = (prop as { relation: Array<{ id: string }> }).relation
+  const rel = ((prop as unknown) as { relation: Array<{ id: string }> }).relation
   return rel?.[0]?.id
 }
 

--- a/scripts/agent/lib/notion.ts
+++ b/scripts/agent/lib/notion.ts
@@ -1,0 +1,249 @@
+// scripts/agent/lib/notion.ts
+import type { ContentRow, Kind, Stage, Origin, CrossPostTarget } from './types'
+
+const BASE = 'https://api.notion.com/v1'
+const VERSION = '2025-09-03'
+
+// CONFIG is imported lazily via a cached variable so that module load does not
+// call required() — which throws when env vars are absent. The pure
+// row-mapper (pageToContentRow) therefore stays unit-testable without env vars.
+let _config: { notionToken: string; notionContentDbId: string } | undefined
+
+async function getConfig() {
+  if (!_config) {
+    const mod = await import('./config')
+    _config = mod.CONFIG
+  }
+  return _config
+}
+
+function buildHeaders(token: string, extra: Record<string, string> = {}): Record<string, string> {
+  return {
+    Authorization: `Bearer ${token}`,
+    'Notion-Version': VERSION,
+    'Content-Type': 'application/json',
+    ...extra,
+  }
+}
+
+async function fetchJson(
+  path: string,
+  init?: { method?: string; body?: string; headers?: Record<string, string> }
+): Promise<unknown> {
+  const cfg = await getConfig()
+  const res = await fetch(`${BASE}${path}`, {
+    method: init?.method,
+    body: init?.body,
+    headers: { ...buildHeaders(cfg.notionToken), ...(init?.headers ?? {}) },
+  })
+  if (!res.ok) {
+    const body = await res.text()
+    throw new Error(`Notion ${init?.method ?? 'GET'} ${path} ${res.status}: ${body}`)
+  }
+  return res.json()
+}
+
+// ---------- Row mapping ----------
+
+type AnyProp = { type: string; [k: string]: unknown }
+type NotionPage = {
+  id: string
+  created_time: string
+  last_edited_time: string
+  properties: Record<string, AnyProp>
+}
+
+function textOf(prop: AnyProp | undefined): string {
+  if (!prop) return ''
+  if (prop.type === 'title') {
+    return ((prop as { title: Array<{ plain_text: string }> }).title ?? [])
+      .map((t) => t.plain_text)
+      .join('')
+  }
+  if (prop.type === 'rich_text') {
+    return ((prop as { rich_text: Array<{ plain_text: string }> }).rich_text ?? [])
+      .map((t) => t.plain_text)
+      .join('')
+  }
+  return ''
+}
+
+function selectName<T extends string>(prop: AnyProp | undefined): T | undefined {
+  if (!prop || prop.type !== 'select') return undefined
+  const sel = (prop as { select: { name: string } | null }).select
+  return sel ? (sel.name as T) : undefined
+}
+
+function multiSelectNames<T extends string>(prop: AnyProp | undefined): T[] {
+  if (!prop || prop.type !== 'multi_select') return []
+  return ((prop as { multi_select: Array<{ name: string }> }).multi_select ?? []).map(
+    (m) => m.name as T
+  )
+}
+
+function urlOf(prop: AnyProp | undefined): string | undefined {
+  if (!prop || prop.type !== 'url') return undefined
+  const v = (prop as { url: string | null }).url
+  return v ?? undefined
+}
+
+function dateStartOf(prop: AnyProp | undefined): string | undefined {
+  if (!prop || prop.type !== 'date') return undefined
+  return (prop as { date: { start: string } | null }).date?.start
+}
+
+function relationFirstId(prop: AnyProp | undefined): string | undefined {
+  if (!prop || prop.type !== 'relation') return undefined
+  const rel = (prop as { relation: Array<{ id: string }> }).relation
+  return rel?.[0]?.id
+}
+
+export function pageToContentRow(page: NotionPage): ContentRow {
+  const p = page.properties
+  const sourceUrlsRaw = textOf(p['Source URLs']).trim()
+  const sourceUrls = sourceUrlsRaw
+    ? sourceUrlsRaw
+        .split(/[\n,]+/)
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0)
+    : []
+  return {
+    id: page.id,
+    title: textOf(p['Title']),
+    kind: (selectName<Kind>(p['Kind']) ?? 'blog') as Kind,
+    stage: (selectName<Stage>(p['Stage']) ?? 'Idea') as Stage,
+    origin: (selectName<Origin>(p['Origin']) ?? 'OC') as Origin,
+    sourceRowId: relationFirstId(p['Source Row']),
+    crossPostTargets: multiSelectNames<CrossPostTarget>(p['Cross-post Targets']),
+    tags: multiSelectNames<string>(p['Tags']),
+    tools: multiSelectNames<string>(p['Tools']),
+    hint: textOf(p['Hint']),
+    sourceUrls,
+    draftUrl: urlOf(p['Draft URL']),
+    publishedUrl: urlOf(p['Published URL']),
+    publishingDate: dateStartOf(p['Publishing']),
+    createdAt: page.created_time,
+    updatedAt: page.last_edited_time,
+  }
+}
+
+// ---------- Public DB ops ----------
+
+export async function queryContentRows(filter: object, sorts?: object[]): Promise<ContentRow[]> {
+  const cfg = await getConfig()
+  const dataSourceId = await getDataSourceIdForDb(cfg.notionContentDbId)
+  const rows: ContentRow[] = []
+  let cursor: string | undefined
+  do {
+    const body = JSON.stringify({ filter, sorts, start_cursor: cursor, page_size: 100 })
+    const data = (await fetchJson(`/data_sources/${dataSourceId}/query`, {
+      method: 'POST',
+      body,
+    })) as { results: NotionPage[]; has_more: boolean; next_cursor?: string }
+    rows.push(...data.results.map(pageToContentRow))
+    cursor = data.has_more ? data.next_cursor : undefined
+  } while (cursor)
+  return rows
+}
+
+async function getDataSourceIdForDb(dbId: string): Promise<string> {
+  const db = (await fetchJson(`/databases/${dbId}`)) as {
+    data_sources: Array<{ id: string }>
+  }
+  const ds = db.data_sources?.[0]
+  if (!ds) throw new Error(`No data source for DB ${dbId}`)
+  return ds.id
+}
+
+export interface CreateRowInput {
+  title: string
+  kind: Kind
+  stage: Stage
+  origin: Origin
+  crossPostTargets?: CrossPostTarget[]
+  tags?: string[]
+  tools?: string[]
+  hint?: string
+  sourceUrls?: string[]
+  draftUrl?: string
+  publishedUrl?: string
+  sourceRowId?: string
+  publishingDate?: string
+}
+
+export async function createContentRow(input: CreateRowInput): Promise<string> {
+  const cfg = await getConfig()
+  const dataSourceId = await getDataSourceIdForDb(cfg.notionContentDbId)
+  const body = {
+    parent: { type: 'data_source_id', data_source_id: dataSourceId },
+    properties: buildPropertiesPayload(input),
+  }
+  const data = (await fetchJson('/pages', { method: 'POST', body: JSON.stringify(body) })) as {
+    id: string
+  }
+  return data.id
+}
+
+export async function updateContentRow(
+  pageId: string,
+  patch: Partial<CreateRowInput>
+): Promise<void> {
+  const body = { properties: buildPropertiesPayload(patch) }
+  await fetchJson(`/pages/${pageId}`, { method: 'PATCH', body: JSON.stringify(body) })
+}
+
+function buildPropertiesPayload(input: Partial<CreateRowInput>): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  if (input.title !== undefined)
+    out['Title'] = { title: [{ type: 'text', text: { content: input.title } }] }
+  if (input.kind !== undefined) out['Kind'] = { select: { name: input.kind } }
+  if (input.stage !== undefined) out['Stage'] = { select: { name: input.stage } }
+  if (input.origin !== undefined) out['Origin'] = { select: { name: input.origin } }
+  if (input.crossPostTargets !== undefined)
+    out['Cross-post Targets'] = {
+      multi_select: input.crossPostTargets.map((n) => ({ name: n })),
+    }
+  if (input.tags !== undefined) out['Tags'] = { multi_select: input.tags.map((n) => ({ name: n })) }
+  if (input.tools !== undefined)
+    out['Tools'] = { multi_select: input.tools.map((n) => ({ name: n })) }
+  if (input.hint !== undefined)
+    out['Hint'] = { rich_text: [{ type: 'text', text: { content: input.hint } }] }
+  if (input.sourceUrls !== undefined)
+    out['Source URLs'] = {
+      rich_text: [{ type: 'text', text: { content: input.sourceUrls.join('\n') } }],
+    }
+  if (input.draftUrl !== undefined) out['Draft URL'] = { url: input.draftUrl }
+  if (input.publishedUrl !== undefined) out['Published URL'] = { url: input.publishedUrl }
+  if (input.sourceRowId !== undefined) out['Source Row'] = { relation: [{ id: input.sourceRowId }] }
+  if (input.publishingDate !== undefined)
+    out['Publishing'] = { date: { start: input.publishingDate } }
+  return out
+}
+
+export async function appendBlocks(pageId: string, blocks: unknown[]): Promise<void> {
+  await fetchJson(`/blocks/${pageId}/children`, {
+    method: 'PATCH',
+    body: JSON.stringify({ children: blocks }),
+  })
+}
+
+export async function replacePageBody(pageId: string, blocks: unknown[]): Promise<void> {
+  // Fetch existing children and archive each, then append new.
+  const existing = (await fetchJson(`/blocks/${pageId}/children?page_size=100`)) as {
+    results: Array<{ id: string }>
+  }
+  for (const child of existing.results) {
+    await fetchJson(`/blocks/${child.id}`, {
+      method: 'DELETE',
+    })
+  }
+  if (blocks.length > 0) await appendBlocks(pageId, blocks)
+}
+
+export async function addPageComment(pageId: string, text: string): Promise<void> {
+  const body = {
+    parent: { page_id: pageId },
+    rich_text: [{ type: 'text', text: { content: text } }],
+  }
+  await fetchJson('/comments', { method: 'POST', body: JSON.stringify(body) })
+}

--- a/scripts/agent/lib/pr.ts
+++ b/scripts/agent/lib/pr.ts
@@ -41,16 +41,7 @@ export function createBranchAndPr(input: PrInput): PrResult {
   if (push.code !== 0) throw new Error(`git push failed: ${push.stderr}`)
 
   // PR
-  const pr = run('gh', [
-    'pr',
-    'create',
-    '--title',
-    input.prTitle,
-    '--body',
-    input.prBody,
-    '--label',
-    'agent-draft',
-  ])
+  const pr = run('gh', ['pr', 'create', '--title', input.prTitle, '--body', input.prBody])
   if (pr.code !== 0) throw new Error(`gh pr create failed: ${pr.stderr}`)
   const url = pr.stdout.trim().split('\n').pop() ?? ''
   if (!url.startsWith('https://')) {

--- a/scripts/agent/lib/pr.ts
+++ b/scripts/agent/lib/pr.ts
@@ -1,0 +1,60 @@
+import { spawnSync } from 'node:child_process'
+
+export interface PrInput {
+  branchName: string
+  commitMessage: string
+  prTitle: string
+  prBody: string
+}
+
+export interface PrResult {
+  branch: string
+  prUrl: string
+}
+
+function run(cmd: string, args: string[]): { code: number; stdout: string; stderr: string } {
+  const proc = spawnSync(cmd, args, { encoding: 'utf8' })
+  return {
+    code: proc.status ?? 1,
+    stdout: proc.stdout ?? '',
+    stderr: proc.stderr ?? '',
+  }
+}
+
+/**
+ * Creates a branch from the current HEAD, commits whatever's staged, pushes,
+ * and opens a PR via `gh`. Returns the PR URL.
+ *
+ * Caller is responsible for `git add`ing the relevant files before calling.
+ */
+export function createBranchAndPr(input: PrInput): PrResult {
+  // Create branch
+  const co = run('git', ['checkout', '-b', input.branchName])
+  if (co.code !== 0) throw new Error(`git checkout -b failed: ${co.stderr}`)
+
+  // Commit
+  const commit = run('git', ['commit', '-m', input.commitMessage])
+  if (commit.code !== 0) throw new Error(`git commit failed: ${commit.stderr}`)
+
+  // Push
+  const push = run('git', ['push', '-u', 'origin', input.branchName])
+  if (push.code !== 0) throw new Error(`git push failed: ${push.stderr}`)
+
+  // PR
+  const pr = run('gh', [
+    'pr',
+    'create',
+    '--title',
+    input.prTitle,
+    '--body',
+    input.prBody,
+    '--label',
+    'agent-draft',
+  ])
+  if (pr.code !== 0) throw new Error(`gh pr create failed: ${pr.stderr}`)
+  const url = pr.stdout.trim().split('\n').pop() ?? ''
+  if (!url.startsWith('https://')) {
+    throw new Error(`Unexpected gh pr create output: ${pr.stdout}`)
+  }
+  return { branch: input.branchName, prUrl: url }
+}

--- a/scripts/agent/lib/promote.ts
+++ b/scripts/agent/lib/promote.ts
@@ -1,0 +1,39 @@
+// scripts/agent/lib/promote.ts
+import type { ContentRow } from './types'
+import type { CreateRowInput } from './notion'
+
+export function selectRowsNeedingPromotion(
+  allRows: ContentRow[],
+  existingDerivatives: ContentRow[]
+): ContentRow[] {
+  const promotedSourceIds = new Set(
+    existingDerivatives
+      .filter((r) => r.origin === 'Derivative' && r.kind === 'blog' && r.sourceRowId)
+      .map((r) => r.sourceRowId as string)
+  )
+  return allRows.filter(
+    (r) =>
+      (r.kind === 'YT short' || r.kind === 'YT long') &&
+      r.stage === 'Published' &&
+      r.crossPostTargets.includes('blog') &&
+      !promotedSourceIds.has(r.id)
+  )
+}
+
+export function buildDerivativeRowInput(source: ContentRow): CreateRowInput {
+  const ytUrl = source.publishedUrl ?? ''
+  const sourceUrls = [...source.sourceUrls]
+  if (ytUrl && !sourceUrls.includes(ytUrl)) sourceUrls.unshift(ytUrl)
+
+  return {
+    title: source.title,
+    kind: 'blog',
+    stage: 'Proposed',
+    origin: 'Derivative',
+    sourceRowId: source.id,
+    tags: source.tags,
+    tools: source.tools,
+    hint: `Blog-length treatment of YT video ${ytUrl}. Expand on: setup, full demo, what surprised me, where this fits.`,
+    sourceUrls,
+  }
+}

--- a/scripts/agent/lib/trending.ts
+++ b/scripts/agent/lib/trending.ts
@@ -1,0 +1,95 @@
+// scripts/agent/lib/trending.ts
+import type { TrendingItem } from './types'
+
+const HN_TOP = 'https://hacker-news.firebaseio.com/v0/topstories.json'
+const HN_ITEM = (id: number): string => `https://hacker-news.firebaseio.com/v0/item/${id}.json`
+
+const HN_KEYWORDS = [
+  'cli',
+  'agent',
+  'claude',
+  'gemini',
+  'copilot',
+  'codex',
+  'cursor',
+  'tool',
+  'mcp',
+]
+
+export async function fetchTrending(extraTools: string[] = []): Promise<TrendingItem[]> {
+  const [hn, gh] = await Promise.all([
+    fetchHnFiltered([...HN_KEYWORDS, ...extraTools]),
+    fetchGhTrending(),
+  ])
+  return [...hn, ...gh]
+}
+
+async function fetchHnFiltered(keywords: string[]): Promise<TrendingItem[]> {
+  try {
+    const topRes = await fetch(HN_TOP)
+    if (!topRes.ok) return []
+    const ids = (await topRes.json()) as number[]
+    const sample = ids.slice(0, 100) // top 100 stories
+    const items: TrendingItem[] = []
+    const kws = keywords.map((k) => k.toLowerCase())
+    for (const id of sample) {
+      const itemRes = await fetch(HN_ITEM(id))
+      if (!itemRes.ok) continue
+      const it = (await itemRes.json()) as {
+        title?: string
+        url?: string
+        score?: number
+        type?: string
+      }
+      if (it.type !== 'story' || !it.title) continue
+      const title = it.title
+      const lower = title.toLowerCase()
+      if (!kws.some((k) => lower.includes(k))) continue
+      items.push({
+        source: 'hn',
+        title,
+        url: it.url ?? `https://news.ycombinator.com/item?id=${id}`,
+        hint: it.score ? `HN ${it.score} points` : undefined,
+      })
+      if (items.length >= 10) break
+    }
+    return items
+  } catch (err) {
+    console.warn(`HN fetch failed: ${(err as Error).message}`)
+    return []
+  }
+}
+
+async function fetchGhTrending(): Promise<TrendingItem[]> {
+  const langs = ['typescript', 'python', 'rust']
+  const items: TrendingItem[] = []
+  for (const lang of langs) {
+    try {
+      const url = `https://github.com/trending/${lang}?since=weekly`
+      const res = await fetch(url, {
+        headers: { 'User-Agent': 'shariq-dev-agent/1.0' },
+      })
+      if (!res.ok) continue
+      const html = await res.text()
+      // Match the standard trending repo card structure
+      const matches = html.match(/href="\/[^/\s]+\/[^/\s"]+"[^>]*>\s*<svg/g) ?? []
+      const seen = new Set<string>()
+      for (const m of matches) {
+        const path = m.match(/href="(\/[^/]+\/[^/"]+)"/)?.[1]
+        if (!path) continue
+        if (seen.has(path)) continue
+        seen.add(path)
+        items.push({
+          source: 'gh-trending',
+          title: path.slice(1),
+          url: `https://github.com${path}`,
+          hint: `trending ${lang}`,
+        })
+        if (items.length >= 15) break
+      }
+    } catch (err) {
+      console.warn(`GH trending ${lang} failed: ${(err as Error).message}`)
+    }
+  }
+  return items
+}

--- a/scripts/agent/lib/types.ts
+++ b/scripts/agent/lib/types.ts
@@ -1,0 +1,91 @@
+// scripts/agent/lib/types.ts
+
+export type Kind =
+  | 'blog'
+  | 'YT short'
+  | 'YT long'
+  | 'podcast'
+  | 'presentation'
+  | 'IG reel'
+  | 'stand up'
+
+export type Stage =
+  | 'Idea'
+  | 'Proposed'
+  | 'Ready'
+  | 'Drafted'
+  | 'Recorded'
+  | 'Edited'
+  | 'Published'
+  | 'Abandoned'
+
+export type Origin = 'OC' | 'Agent Proposed' | 'Derivative'
+
+export type CrossPostTarget = 'blog' | 'YT short' | 'YT long'
+
+export interface ContentRow {
+  id: string // Notion page ID
+  title: string
+  kind: Kind
+  stage: Stage
+  origin: Origin
+  sourceRowId?: string
+  crossPostTargets: CrossPostTarget[]
+  tags: string[]
+  tools: string[]
+  hint: string
+  sourceUrls: string[]
+  draftUrl?: string
+  publishedUrl?: string
+  publishingDate?: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface Candidate {
+  title: string
+  hint: string
+  tags?: string[]
+  tools?: string[]
+  sourceUrls: string[]
+  rationale: string
+}
+
+export interface DiscoveryOutput {
+  blogCandidates: Candidate[]
+  ytCandidates: Candidate[]
+}
+
+export interface YTScriptBlocks {
+  hook: string
+  script: string
+  onScreenText: Array<{ timestampSeconds: number; text: string }>
+  bRoll: Array<{ timestampSeconds: number; description: string }>
+  thumbnailPrompt: string
+  titleVariants: string[]
+  hashtags: string[]
+}
+
+export interface CommitInfo {
+  repo: string // e.g. "shariqh/lognote"
+  sha: string
+  message: string
+  date: string
+  filesChanged: string[]
+  url: string
+}
+
+export interface TrendingItem {
+  source: 'gh-trending' | 'hn'
+  title: string
+  url: string
+  hint?: string // e.g. HN score, GH stars-this-week
+}
+
+export interface YouTubeStat {
+  videoId: string
+  title: string
+  views: number
+  likes: number
+  publishedAt: string
+}

--- a/scripts/agent/lib/types.ts
+++ b/scripts/agent/lib/types.ts
@@ -89,3 +89,67 @@ export interface YouTubeStat {
   likes: number
   publishedAt: string
 }
+
+export type LegacyStatus =
+  | 'Prepping'
+  | 'Ready To Record'
+  | 'Recording'
+  | 'Post-Processing'
+  | 'Published'
+  | 'Abandoned'
+  | '✅'
+
+export type LegacyMedium =
+  | 'blog'
+  | 'youtube'
+  | 'YT short'
+  | 'podcast'
+  | 'presentation'
+  | 'IG reel'
+  | 'stand up'
+
+export type LegacyOrigin = 'OC' | 'x-post:bundle' | 'x-post:blog'
+
+export interface CmsRow {
+  id: string
+  title: string
+  status?: LegacyStatus
+  medium: LegacyMedium[]
+  origin?: LegacyOrigin
+  tags: string[]
+  type?: string
+  keywords: string
+  sources: string
+  publishedLink?: string
+  publishing?: string
+  no?: number
+}
+
+export interface MappedRow {
+  // The new row's intended properties (no ID — caller assigns)
+  title: string
+  kind: Kind
+  stage: Stage
+  origin: Origin
+  crossPostTargets: CrossPostTarget[]
+  tags: string[]
+  tools: string[]
+  hint: string
+  sourceUrls: string[]
+  publishedUrl?: string
+  publishingDate?: string
+  // Bookkeeping for derivatives:
+  // If the row was split, the first piece keeps the original Notion page ID
+  // and this is null. The subsequent piece(s) are NEW rows; this points at
+  // the original page ID to install as Source Row after creation.
+  sourceRowOriginalPageId?: string
+}
+
+export interface MigrationReport {
+  totalInputRows: number
+  rowsKept: number
+  rowsSplit: number
+  newRowsCreated: number
+  abandoned: number
+  unresolvedXPostBlog: string[] // titles where Source Row couldn't be matched
+}

--- a/scripts/agent/lib/validate.ts
+++ b/scripts/agent/lib/validate.ts
@@ -1,0 +1,81 @@
+import matter from 'gray-matter'
+import { writingSchema } from '../../../src/lib/schemas'
+import { spawnSync } from 'node:child_process'
+
+export type ValidationResult =
+  | { ok: true; data: ReturnType<typeof writingSchema.parse> }
+  | { ok: false; error: string }
+
+export function validateMdxFrontmatter(mdx: string): ValidationResult {
+  let parsed
+  try {
+    parsed = matter(mdx)
+  } catch (e) {
+    return { ok: false, error: `gray-matter parse failed: ${(e as Error).message}` }
+  }
+  const result = writingSchema.safeParse(parsed.data)
+  if (!result.success) {
+    return { ok: false, error: result.error.toString() }
+  }
+  return { ok: true, data: result.data }
+}
+
+export interface ValeFinding {
+  line: number
+  column: number
+  rule: string
+  severity: 'error' | 'warning' | 'suggestion'
+  message: string
+}
+
+/**
+ * Runs Vale on a single file. Returns parsed findings (empty array if clean).
+ * If Vale is not installed, returns []. Failure to invoke Vale is non-fatal.
+ */
+export function runVale(filePath: string): ValeFinding[] {
+  const proc = spawnSync('vale', ['--output=JSON', filePath], { encoding: 'utf8' })
+  if (proc.error) return [] // Vale not installed
+  if (!proc.stdout) return []
+  let json: Record<
+    string,
+    Array<{ Line: number; Span: number[]; Check: string; Severity: string; Message: string }>
+  >
+  try {
+    json = JSON.parse(proc.stdout)
+  } catch {
+    return []
+  }
+  const findings: ValeFinding[] = []
+  for (const file of Object.values(json)) {
+    for (const f of file) {
+      findings.push({
+        line: f.Line,
+        column: f.Span?.[0] ?? 0,
+        rule: f.Check,
+        severity: (f.Severity ?? 'warning').toLowerCase() as ValeFinding['severity'],
+        message: f.Message,
+      })
+    }
+  }
+  return findings
+}
+
+export function formatValeReport(findings: ValeFinding[]): string {
+  if (findings.length === 0) return '_(Vale clean)_'
+  const groups = {
+    error: [] as ValeFinding[],
+    warning: [] as ValeFinding[],
+    suggestion: [] as ValeFinding[],
+  }
+  for (const f of findings) groups[f.severity].push(f)
+  const lines: string[] = []
+  for (const sev of ['error', 'warning', 'suggestion'] as const) {
+    if (groups[sev].length === 0) continue
+    lines.push(`**${sev}** (${groups[sev].length}):`)
+    for (const f of groups[sev]) {
+      lines.push(`- L${f.line}: \`${f.rule}\` — ${f.message}`)
+    }
+    lines.push('')
+  }
+  return lines.join('\n')
+}

--- a/scripts/agent/lib/youtube.ts
+++ b/scripts/agent/lib/youtube.ts
@@ -1,0 +1,46 @@
+// scripts/agent/lib/youtube.ts
+import { CONFIG } from './config'
+import type { YouTubeStat } from './types'
+
+const YT = 'https://www.googleapis.com/youtube/v3'
+
+interface YtVideo {
+  id: string
+  snippet: { title: string; publishedAt: string }
+  statistics: { viewCount?: string; likeCount?: string }
+}
+
+interface YtSearchItem {
+  id: { videoId?: string }
+  snippet: { publishedAt: string }
+}
+
+/**
+ * Returns view + like stats for the channel's videos published in the last N days.
+ */
+export async function recentChannelStats(daysBack: number = 30): Promise<YouTubeStat[]> {
+  const publishedAfter = new Date(Date.now() - daysBack * 86_400_000).toISOString()
+  const searchUrl = `${YT}/search?part=id,snippet&channelId=${CONFIG.youtubeChannelId}&type=video&order=date&publishedAfter=${publishedAfter}&maxResults=50&key=${CONFIG.youtubeApiKey}`
+  const searchRes = await fetch(searchUrl)
+  if (!searchRes.ok) {
+    console.warn(`YT search failed: ${searchRes.status}`)
+    return []
+  }
+  const search = (await searchRes.json()) as { items: YtSearchItem[] }
+  const ids = search.items.map((i) => i.id.videoId).filter((x): x is string => !!x)
+  if (ids.length === 0) return []
+
+  const videosUrl = `${YT}/videos?part=snippet,statistics&id=${ids.join(',')}&key=${
+    CONFIG.youtubeApiKey
+  }`
+  const vidRes = await fetch(videosUrl)
+  if (!vidRes.ok) return []
+  const vids = (await vidRes.json()) as { items: YtVideo[] }
+  return vids.items.map((v) => ({
+    videoId: v.id,
+    title: v.snippet.title,
+    views: parseInt(v.statistics.viewCount ?? '0', 10),
+    likes: parseInt(v.statistics.likeCount ?? '0', 10),
+    publishedAt: v.snippet.publishedAt,
+  }))
+}

--- a/scripts/agent/migrate-cms.ts
+++ b/scripts/agent/migrate-cms.ts
@@ -59,11 +59,11 @@ function extractCmsRow(page: { id: string; properties: Record<string, unknown> }
   const text = (prop: { type: string; [k: string]: unknown } | undefined): string => {
     if (!prop) return ''
     if (prop.type === 'title')
-      return ((prop as { title: Array<{ plain_text: string }> }).title ?? [])
+      return (((prop as unknown) as { title: Array<{ plain_text: string }> }).title ?? [])
         .map((t) => t.plain_text)
         .join('')
     if (prop.type === 'rich_text')
-      return ((prop as { rich_text: Array<{ plain_text: string }> }).rich_text ?? [])
+      return (((prop as unknown) as { rich_text: Array<{ plain_text: string }> }).rich_text ?? [])
         .map((t) => t.plain_text)
         .join('')
     return ''
@@ -72,28 +72,28 @@ function extractCmsRow(page: { id: string; properties: Record<string, unknown> }
     prop: { type: string; [k: string]: unknown } | undefined
   ): T | undefined => {
     if (!prop || prop.type !== 'select') return undefined
-    const sel = (prop as { select: { name: string } | null }).select
+    const sel = ((prop as unknown) as { select: { name: string } | null }).select
     return sel ? (sel.name as T) : undefined
   }
   const multi = <T extends string>(
     prop: { type: string; [k: string]: unknown } | undefined
   ): T[] => {
     if (!prop || prop.type !== 'multi_select') return []
-    return ((prop as { multi_select: Array<{ name: string }> }).multi_select ?? []).map(
-      (m) => m.name as T
-    )
+    return (
+      ((prop as unknown) as { multi_select: Array<{ name: string }> }).multi_select ?? []
+    ).map((m) => m.name as T)
   }
   const url = (prop: { type: string; [k: string]: unknown } | undefined): string | undefined => {
     if (!prop || prop.type !== 'url') return undefined
-    return (prop as { url: string | null }).url ?? undefined
+    return ((prop as unknown) as { url: string | null }).url ?? undefined
   }
   const date = (prop: { type: string; [k: string]: unknown } | undefined): string | undefined => {
     if (!prop || prop.type !== 'date') return undefined
-    return (prop as { date: { start: string } | null }).date?.start
+    return ((prop as unknown) as { date: { start: string } | null }).date?.start
   }
   const num = (prop: { type: string; [k: string]: unknown } | undefined): number | undefined => {
     if (!prop || prop.type !== 'number') return undefined
-    return (prop as { number: number | null }).number ?? undefined
+    return ((prop as unknown) as { number: number | null }).number ?? undefined
   }
   return {
     id: page.id,

--- a/scripts/agent/migrate-cms.ts
+++ b/scripts/agent/migrate-cms.ts
@@ -1,0 +1,226 @@
+// scripts/agent/migrate-cms.ts
+import { CONFIG } from './lib/config'
+import { mapCmsRowToContentRows } from './lib/migrate-mapping'
+import { createContentRow } from './lib/notion'
+import type { CmsRow, MappedRow, LegacyMedium, LegacyStatus, LegacyOrigin } from './lib/types'
+
+const DRY_RUN = process.argv.includes('--dry-run')
+const EXECUTE = process.argv.includes('--execute')
+
+if (!DRY_RUN && !EXECUTE) {
+  console.error('Usage: npm run migrate:cms -- (--dry-run | --execute)')
+  process.exit(1)
+}
+
+const NOTION_VERSION = '2025-09-03'
+
+async function fetchLegacyCmsRows(legacyDbId: string): Promise<CmsRow[]> {
+  // Get data source for legacy DB
+  const dbRes = await fetch(`https://api.notion.com/v1/databases/${legacyDbId}`, {
+    headers: {
+      Authorization: `Bearer ${CONFIG.notionToken}`,
+      'Notion-Version': NOTION_VERSION,
+    },
+  })
+  if (!dbRes.ok) throw new Error(`Failed to fetch legacy DB: ${dbRes.status}`)
+  const db = (await dbRes.json()) as { data_sources: Array<{ id: string }> }
+  const ds = db.data_sources[0]?.id
+  if (!ds) throw new Error('No data source on legacy CMS DB')
+
+  const rows: CmsRow[] = []
+  let cursor: string | undefined
+  do {
+    const body = JSON.stringify({ start_cursor: cursor, page_size: 100 })
+    const res = await fetch(`https://api.notion.com/v1/data_sources/${ds}/query`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${CONFIG.notionToken}`,
+        'Notion-Version': NOTION_VERSION,
+        'Content-Type': 'application/json',
+      },
+      body,
+    })
+    if (!res.ok) throw new Error(`Legacy query failed: ${res.status} ${await res.text()}`)
+    const data = (await res.json()) as {
+      results: Array<{ id: string; properties: Record<string, unknown> }>
+      has_more: boolean
+      next_cursor?: string
+    }
+    for (const p of data.results) {
+      rows.push(extractCmsRow(p))
+    }
+    cursor = data.has_more ? data.next_cursor : undefined
+  } while (cursor)
+  return rows
+}
+
+function extractCmsRow(page: { id: string; properties: Record<string, unknown> }): CmsRow {
+  const p = page.properties as Record<string, { type: string; [k: string]: unknown }>
+  const text = (prop: { type: string; [k: string]: unknown } | undefined): string => {
+    if (!prop) return ''
+    if (prop.type === 'title')
+      return ((prop as { title: Array<{ plain_text: string }> }).title ?? [])
+        .map((t) => t.plain_text)
+        .join('')
+    if (prop.type === 'rich_text')
+      return ((prop as { rich_text: Array<{ plain_text: string }> }).rich_text ?? [])
+        .map((t) => t.plain_text)
+        .join('')
+    return ''
+  }
+  const select = <T extends string>(
+    prop: { type: string; [k: string]: unknown } | undefined
+  ): T | undefined => {
+    if (!prop || prop.type !== 'select') return undefined
+    const sel = (prop as { select: { name: string } | null }).select
+    return sel ? (sel.name as T) : undefined
+  }
+  const multi = <T extends string>(
+    prop: { type: string; [k: string]: unknown } | undefined
+  ): T[] => {
+    if (!prop || prop.type !== 'multi_select') return []
+    return ((prop as { multi_select: Array<{ name: string }> }).multi_select ?? []).map(
+      (m) => m.name as T
+    )
+  }
+  const url = (prop: { type: string; [k: string]: unknown } | undefined): string | undefined => {
+    if (!prop || prop.type !== 'url') return undefined
+    return (prop as { url: string | null }).url ?? undefined
+  }
+  const date = (prop: { type: string; [k: string]: unknown } | undefined): string | undefined => {
+    if (!prop || prop.type !== 'date') return undefined
+    return (prop as { date: { start: string } | null }).date?.start
+  }
+  const num = (prop: { type: string; [k: string]: unknown } | undefined): number | undefined => {
+    if (!prop || prop.type !== 'number') return undefined
+    return (prop as { number: number | null }).number ?? undefined
+  }
+  return {
+    id: page.id,
+    title: text(p['Title']),
+    status: select<LegacyStatus>(p['Status']),
+    medium: multi<LegacyMedium>(p['Medium']),
+    origin: select<LegacyOrigin>(p['Origin']),
+    tags: multi<string>(p['Tags']),
+    type: select<string>(p['Type']),
+    keywords: text(p['Keywords']),
+    sources: text(p['Source(s)']),
+    publishedLink: url(p['Published Link']),
+    publishing: date(p['Publishing']),
+    no: num(p['No.']),
+  }
+}
+
+async function main(): Promise<void> {
+  const legacyId = CONFIG.notionLegacyCmsDbId
+  if (!legacyId) {
+    console.error('Set NOTION_LEGACY_CMS_DB_ID in .env.local')
+    process.exit(1)
+  }
+  console.log(`Fetching legacy CMS rows from ${legacyId}...`)
+  const rows = await fetchLegacyCmsRows(legacyId)
+  console.log(`Fetched ${rows.length} legacy rows.`)
+
+  const mapped: Array<{ source: CmsRow; out: MappedRow[] }> = rows.map((r) => ({
+    source: r,
+    out: mapCmsRowToContentRows(r),
+  }))
+
+  // Report
+  const splits = mapped.filter((m) => m.out.length > 1)
+  const totalOutRows = mapped.reduce((s, m) => s + m.out.length, 0)
+
+  console.log('\n=== Migration report ===')
+  console.log(`Input rows:      ${rows.length}`)
+  console.log(`Output rows:     ${totalOutRows}`)
+  console.log(`Rows being split:${splits.length}`)
+  console.log(
+    `New rows created:${
+      totalOutRows - rows.length
+    } (from splits; primary rows reuse original page ID)`
+  )
+
+  if (splits.length > 0) {
+    console.log('\nSplit rows:')
+    for (const s of splits) {
+      console.log(
+        `  ${s.source.title}: ${s.source.medium.join(',')} → ${s.out.map((o) => o.kind).join(',')}`
+      )
+    }
+  }
+
+  if (DRY_RUN) {
+    console.log('\n[dry-run] No writes performed. Re-run with --execute to apply.')
+    return
+  }
+
+  // Execute mode — refuse if Content DB has any rows
+  console.log('\nChecking destination DB is empty...')
+  const dest = await fetch(
+    `https://api.notion.com/v1/data_sources/${await getDataSourceId(
+      CONFIG.notionContentDbId
+    )}/query`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${CONFIG.notionToken}`,
+        'Notion-Version': NOTION_VERSION,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ page_size: 1 }),
+    }
+  )
+  if (!dest.ok) throw new Error(`Destination check failed: ${dest.status}`)
+  const destData = (await dest.json()) as { results: unknown[] }
+  if (destData.results.length > 0) {
+    console.error('Destination Content DB is not empty. Aborting to avoid double-import.')
+    process.exit(1)
+  }
+
+  console.log('Executing migration...')
+  let created = 0
+  for (const m of mapped) {
+    // Create primary first; capture its new ID so derivatives in this group
+    // can link to it directly. This avoids the title-collision risk of a
+    // post-hoc title-based linking pass.
+    let primaryNewId: string | null = null
+    for (const out of m.out) {
+      const sourceRowId = out.sourceRowOriginalPageId && primaryNewId ? primaryNewId : undefined
+      const id = await createContentRow({
+        title: out.title,
+        kind: out.kind,
+        stage: out.stage,
+        origin: out.origin,
+        crossPostTargets: out.crossPostTargets,
+        tags: out.tags,
+        tools: out.tools,
+        hint: out.hint,
+        sourceUrls: out.sourceUrls,
+        publishedUrl: out.publishedUrl,
+        publishingDate: out.publishingDate,
+        sourceRowId,
+      })
+      if (!out.sourceRowOriginalPageId) primaryNewId = id
+      created++
+      if (created % 10 === 0) console.log(`  created ${created} rows...`)
+    }
+  }
+
+  console.log(`Done. Created ${created} rows.`)
+}
+
+async function getDataSourceId(dbId: string): Promise<string> {
+  const dbRes = await fetch(`https://api.notion.com/v1/databases/${dbId}`, {
+    headers: {
+      Authorization: `Bearer ${CONFIG.notionToken}`,
+      'Notion-Version': NOTION_VERSION,
+    },
+  })
+  const db = (await dbRes.json()) as { data_sources: Array<{ id: string }> }
+  return db.data_sources[0].id
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/agent/migrate-cms.ts
+++ b/scripts/agent/migrate-cms.ts
@@ -1,8 +1,33 @@
 // scripts/agent/migrate-cms.ts
+//
+// One-shot in-place migration of the existing CMS Notion DB.
+// Source DB and destination DB are the same.
+//
+// Pre-condition (manual user step in Notion UI before running):
+//   - Rename Status → Stage; rename Status options to match new Stage values
+//   - Add Kind property (single-select)
+//   - Add Origin options: Agent Proposed, Derivative
+//   - Add: Source Row (self-relation), Cross-post Targets (multi-select),
+//          Tools (multi-select), Hint (text), Draft URL (URL)
+//
+// What this script does:
+//   - PATCH every row with: Kind (from first Medium), Hint (from Keywords),
+//     Source URLs (from Source(s)). For Origin=x-post:blog rows, set Origin=Derivative.
+//     For Origin=x-post:bundle rows, populate Cross-post Targets from non-first Mediums.
+//   - For multi-Medium rows, additionally CREATE one new sibling page per
+//     additional Medium with Origin=Derivative and Source Row → primary's page ID.
+//   - Idempotent: rows where Kind is already populated are skipped.
+
 import { CONFIG } from './lib/config'
-import { mapCmsRowToContentRows } from './lib/migrate-mapping'
-import { createContentRow } from './lib/notion'
-import type { CmsRow, MappedRow, LegacyMedium, LegacyStatus, LegacyOrigin } from './lib/types'
+import { createContentRow, updateContentRow } from './lib/notion'
+import type {
+  CmsRow,
+  LegacyMedium,
+  LegacyStatus,
+  LegacyOrigin,
+  Kind,
+  CrossPostTarget,
+} from './lib/types'
 
 const DRY_RUN = process.argv.includes('--dry-run')
 const EXECUTE = process.argv.includes('--execute')
@@ -14,49 +39,58 @@ if (!DRY_RUN && !EXECUTE) {
 
 const NOTION_VERSION = '2025-09-03'
 
-async function fetchLegacyCmsRows(legacyDbId: string): Promise<CmsRow[]> {
-  // Get data source for legacy DB
-  const dbRes = await fetch(`https://api.notion.com/v1/databases/${legacyDbId}`, {
-    headers: {
-      Authorization: `Bearer ${CONFIG.notionToken}`,
-      'Notion-Version': NOTION_VERSION,
-    },
-  })
-  if (!dbRes.ok) throw new Error(`Failed to fetch legacy DB: ${dbRes.status}`)
-  const db = (await dbRes.json()) as { data_sources: Array<{ id: string }> }
-  const ds = db.data_sources[0]?.id
-  if (!ds) throw new Error('No data source on legacy CMS DB')
+interface NotionPageRaw {
+  id: string
+  properties: Record<string, { type: string; [k: string]: unknown }>
+}
 
-  const rows: CmsRow[] = []
+interface CmsRowWithKind extends CmsRow {
+  alreadyMigrated: boolean // true if Kind already populated
+}
+
+async function fetchAllRows(): Promise<CmsRowWithKind[]> {
+  const dsId = await getDataSourceId(CONFIG.notionCmsDbId)
+  const out: CmsRowWithKind[] = []
   let cursor: string | undefined
   do {
-    const body = JSON.stringify({ start_cursor: cursor, page_size: 100 })
-    const res = await fetch(`https://api.notion.com/v1/data_sources/${ds}/query`, {
+    const res = await fetch(`https://api.notion.com/v1/data_sources/${dsId}/query`, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${CONFIG.notionToken}`,
         'Notion-Version': NOTION_VERSION,
         'Content-Type': 'application/json',
       },
-      body,
+      body: JSON.stringify({ start_cursor: cursor, page_size: 100 }),
     })
-    if (!res.ok) throw new Error(`Legacy query failed: ${res.status} ${await res.text()}`)
+    if (!res.ok) throw new Error(`Query failed: ${res.status} ${await res.text()}`)
     const data = (await res.json()) as {
-      results: Array<{ id: string; properties: Record<string, unknown> }>
+      results: NotionPageRaw[]
       has_more: boolean
       next_cursor?: string
     }
-    for (const p of data.results) {
-      rows.push(extractCmsRow(p))
-    }
+    for (const p of data.results) out.push(extractCmsRow(p))
     cursor = data.has_more ? data.next_cursor : undefined
   } while (cursor)
-  return rows
+  return out
 }
 
-function extractCmsRow(page: { id: string; properties: Record<string, unknown> }): CmsRow {
-  const p = page.properties as Record<string, { type: string; [k: string]: unknown }>
-  const text = (prop: { type: string; [k: string]: unknown } | undefined): string => {
+async function getDataSourceId(dbId: string): Promise<string> {
+  const dbRes = await fetch(`https://api.notion.com/v1/databases/${dbId}`, {
+    headers: {
+      Authorization: `Bearer ${CONFIG.notionToken}`,
+      'Notion-Version': NOTION_VERSION,
+    },
+  })
+  if (!dbRes.ok) throw new Error(`DB fetch failed: ${dbRes.status}`)
+  const db = (await dbRes.json()) as { data_sources: Array<{ id: string }> }
+  const ds = db.data_sources[0]?.id
+  if (!ds) throw new Error(`No data source on DB ${dbId}`)
+  return ds
+}
+
+function extractCmsRow(page: NotionPageRaw): CmsRowWithKind {
+  const p = page.properties
+  const text = (prop: typeof p[string] | undefined): string => {
     if (!prop) return ''
     if (prop.type === 'title')
       return (((prop as unknown) as { title: Array<{ plain_text: string }> }).title ?? [])
@@ -68,156 +102,199 @@ function extractCmsRow(page: { id: string; properties: Record<string, unknown> }
         .join('')
     return ''
   }
-  const select = <T extends string>(
-    prop: { type: string; [k: string]: unknown } | undefined
-  ): T | undefined => {
+  const select = <T extends string>(prop: typeof p[string] | undefined): T | undefined => {
     if (!prop || prop.type !== 'select') return undefined
     const sel = ((prop as unknown) as { select: { name: string } | null }).select
     return sel ? (sel.name as T) : undefined
   }
-  const multi = <T extends string>(
-    prop: { type: string; [k: string]: unknown } | undefined
-  ): T[] => {
+  const multi = <T extends string>(prop: typeof p[string] | undefined): T[] => {
     if (!prop || prop.type !== 'multi_select') return []
     return (
       ((prop as unknown) as { multi_select: Array<{ name: string }> }).multi_select ?? []
     ).map((m) => m.name as T)
   }
-  const url = (prop: { type: string; [k: string]: unknown } | undefined): string | undefined => {
+  const url = (prop: typeof p[string] | undefined): string | undefined => {
     if (!prop || prop.type !== 'url') return undefined
     return ((prop as unknown) as { url: string | null }).url ?? undefined
   }
-  const date = (prop: { type: string; [k: string]: unknown } | undefined): string | undefined => {
+  const date = (prop: typeof p[string] | undefined): string | undefined => {
     if (!prop || prop.type !== 'date') return undefined
     return ((prop as unknown) as { date: { start: string } | null }).date?.start
   }
-  const num = (prop: { type: string; [k: string]: unknown } | undefined): number | undefined => {
+  const num = (prop: typeof p[string] | undefined): number | undefined => {
     if (!prop || prop.type !== 'number') return undefined
     return ((prop as unknown) as { number: number | null }).number ?? undefined
   }
+
   return {
     id: page.id,
     title: text(p['Title']),
-    status: select<LegacyStatus>(p['Status']),
+    status: select<LegacyStatus>(p['Status'] ?? p['Stage']), // Stage post-rename also OK
     medium: multi<LegacyMedium>(p['Medium']),
     origin: select<LegacyOrigin>(p['Origin']),
     tags: multi<string>(p['Tags']),
     type: select<string>(p['Type']),
     keywords: text(p['Keywords']),
     sources: text(p['Source(s)']),
-    publishedLink: url(p['Published Link']),
+    publishedLink: url(p['Published Link']) ?? url(p['Published URL']),
     publishing: date(p['Publishing']),
     no: num(p['No.']),
+    alreadyMigrated: select<string>(p['Kind']) !== undefined,
+  }
+}
+
+const KIND_FROM_MEDIUM: Record<LegacyMedium, Kind> = {
+  blog: 'blog',
+  youtube: 'YT short',
+  'YT short': 'YT short',
+  podcast: 'podcast',
+  presentation: 'presentation',
+  'IG reel': 'IG reel',
+  'stand up': 'stand up',
+}
+
+function isCrossPostTarget(k: Kind): k is CrossPostTarget {
+  return k === 'blog' || k === 'YT short' || k === 'YT long'
+}
+
+function splitSources(s: string): string[] {
+  if (!s) return []
+  return s
+    .split(/[\n,]+/)
+    .map((x) => x.trim())
+    .filter((x) => x.length > 0)
+}
+
+interface PlannedPatch {
+  pageId: string
+  title: string
+  kind: Kind
+  origin?: 'Derivative' // only when we're upgrading x-post:blog
+  crossPostTargets: CrossPostTarget[]
+  hint?: string
+  sourceUrls: string[]
+}
+
+interface PlannedSibling {
+  primaryPageId: string
+  title: string
+  kind: Kind
+  tags: string[]
+}
+
+interface MigrationPlan {
+  patches: PlannedPatch[]
+  siblings: PlannedSibling[]
+  skipped: number
+  totalRows: number
+}
+
+function buildPlan(rows: CmsRowWithKind[]): MigrationPlan {
+  const patches: PlannedPatch[] = []
+  const siblings: PlannedSibling[] = []
+  let skipped = 0
+
+  for (const row of rows) {
+    if (row.alreadyMigrated) {
+      skipped++
+      continue
+    }
+
+    const mediums = row.medium.length > 0 ? row.medium : (['blog'] as LegacyMedium[])
+    const kinds = mediums.map((m) => KIND_FROM_MEDIUM[m] ?? 'blog')
+    const primaryKind = kinds[0]
+    const otherKinds = kinds.slice(1).filter(isCrossPostTarget)
+
+    // Build patch for the primary (existing) page
+    const patch: PlannedPatch = {
+      pageId: row.id,
+      title: row.title,
+      kind: primaryKind,
+      crossPostTargets: otherKinds,
+      hint: row.keywords || undefined,
+      sourceUrls: splitSources(row.sources),
+    }
+    if (row.origin === 'x-post:blog') patch.origin = 'Derivative'
+    patches.push(patch)
+
+    // Build siblings for multi-Medium rows
+    for (const siblingKind of kinds.slice(1)) {
+      siblings.push({
+        primaryPageId: row.id,
+        title: row.title,
+        kind: siblingKind,
+        tags: row.tags,
+      })
+    }
+  }
+
+  return { patches, siblings, skipped, totalRows: rows.length }
+}
+
+function printReport(plan: MigrationPlan): void {
+  console.log('\n=== Migration plan ===')
+  console.log(`Total rows in CMS:    ${plan.totalRows}`)
+  console.log(`Already migrated:     ${plan.skipped} (skipped)`)
+  console.log(`Rows to PATCH:        ${plan.patches.length}`)
+  console.log(`Sibling rows to CREATE: ${plan.siblings.length} (from multi-Medium splits)`)
+
+  if (plan.siblings.length > 0) {
+    console.log('\nSplit rows (primary → siblings):')
+    const byPrimary = new Map<string, PlannedSibling[]>()
+    for (const s of plan.siblings) {
+      if (!byPrimary.has(s.primaryPageId)) byPrimary.set(s.primaryPageId, [])
+      byPrimary.get(s.primaryPageId)!.push(s)
+    }
+    for (const [primaryId, sibs] of byPrimary) {
+      const primaryTitle = plan.patches.find((p) => p.pageId === primaryId)?.title ?? '?'
+      console.log(`  ${primaryTitle} → ${sibs.map((s) => s.kind).join(', ')}`)
+    }
   }
 }
 
 async function main(): Promise<void> {
-  const legacyId = CONFIG.notionLegacyCmsDbId
-  if (!legacyId) {
-    console.error('Set NOTION_LEGACY_CMS_DB_ID in .env.local')
-    process.exit(1)
-  }
-  console.log(`Fetching legacy CMS rows from ${legacyId}...`)
-  const rows = await fetchLegacyCmsRows(legacyId)
-  console.log(`Fetched ${rows.length} legacy rows.`)
+  console.log(`Fetching all rows from CMS DB ${CONFIG.notionCmsDbId}...`)
+  const rows = await fetchAllRows()
+  console.log(`Fetched ${rows.length} rows.`)
 
-  const mapped: Array<{ source: CmsRow; out: MappedRow[] }> = rows.map((r) => ({
-    source: r,
-    out: mapCmsRowToContentRows(r),
-  }))
-
-  // Report
-  const splits = mapped.filter((m) => m.out.length > 1)
-  const totalOutRows = mapped.reduce((s, m) => s + m.out.length, 0)
-
-  console.log('\n=== Migration report ===')
-  console.log(`Input rows:      ${rows.length}`)
-  console.log(`Output rows:     ${totalOutRows}`)
-  console.log(`Rows being split:${splits.length}`)
-  console.log(
-    `New rows created:${
-      totalOutRows - rows.length
-    } (from splits; primary rows reuse original page ID)`
-  )
-
-  if (splits.length > 0) {
-    console.log('\nSplit rows:')
-    for (const s of splits) {
-      console.log(
-        `  ${s.source.title}: ${s.source.medium.join(',')} → ${s.out.map((o) => o.kind).join(',')}`
-      )
-    }
-  }
+  const plan = buildPlan(rows)
+  printReport(plan)
 
   if (DRY_RUN) {
     console.log('\n[dry-run] No writes performed. Re-run with --execute to apply.')
     return
   }
 
-  // Execute mode — refuse if Content DB has any rows
-  console.log('\nChecking destination DB is empty...')
-  const dest = await fetch(
-    `https://api.notion.com/v1/data_sources/${await getDataSourceId(
-      CONFIG.notionContentDbId
-    )}/query`,
-    {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${CONFIG.notionToken}`,
-        'Notion-Version': NOTION_VERSION,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ page_size: 1 }),
-    }
-  )
-  if (!dest.ok) throw new Error(`Destination check failed: ${dest.status}`)
-  const destData = (await dest.json()) as { results: unknown[] }
-  if (destData.results.length > 0) {
-    console.error('Destination Content DB is not empty. Aborting to avoid double-import.')
-    process.exit(1)
-  }
-
-  console.log('Executing migration...')
+  console.log('\nExecuting migration...')
+  let patched = 0
   let created = 0
-  for (const m of mapped) {
-    // Create primary first; capture its new ID so derivatives in this group
-    // can link to it directly. This avoids the title-collision risk of a
-    // post-hoc title-based linking pass.
-    let primaryNewId: string | null = null
-    for (const out of m.out) {
-      const sourceRowId = out.sourceRowOriginalPageId && primaryNewId ? primaryNewId : undefined
-      const id = await createContentRow({
-        title: out.title,
-        kind: out.kind,
-        stage: out.stage,
-        origin: out.origin,
-        crossPostTargets: out.crossPostTargets,
-        tags: out.tags,
-        tools: out.tools,
-        hint: out.hint,
-        sourceUrls: out.sourceUrls,
-        publishedUrl: out.publishedUrl,
-        publishingDate: out.publishingDate,
-        sourceRowId,
-      })
-      if (!out.sourceRowOriginalPageId) primaryNewId = id
-      created++
-      if (created % 10 === 0) console.log(`  created ${created} rows...`)
-    }
+
+  for (const p of plan.patches) {
+    await updateContentRow(p.pageId, {
+      kind: p.kind,
+      crossPostTargets: p.crossPostTargets,
+      hint: p.hint,
+      sourceUrls: p.sourceUrls,
+      ...(p.origin ? { origin: p.origin } : {}),
+    })
+    patched++
+    if (patched % 10 === 0) console.log(`  patched ${patched} / ${plan.patches.length}`)
   }
 
-  console.log(`Done. Created ${created} rows.`)
-}
+  for (const s of plan.siblings) {
+    await createContentRow({
+      title: s.title,
+      kind: s.kind,
+      stage: 'Idea',
+      origin: 'Derivative',
+      sourceRowId: s.primaryPageId,
+      tags: s.tags,
+    })
+    created++
+    if (created % 5 === 0) console.log(`  created ${created} / ${plan.siblings.length} siblings`)
+  }
 
-async function getDataSourceId(dbId: string): Promise<string> {
-  const dbRes = await fetch(`https://api.notion.com/v1/databases/${dbId}`, {
-    headers: {
-      Authorization: `Bearer ${CONFIG.notionToken}`,
-      'Notion-Version': NOTION_VERSION,
-    },
-  })
-  const db = (await dbRes.json()) as { data_sources: Array<{ id: string }> }
-  return db.data_sources[0].id
+  console.log(`\nDone. Patched ${patched} rows, created ${created} sibling rows.`)
 }
 
 main().catch((err) => {

--- a/scripts/agent/promote.ts
+++ b/scripts/agent/promote.ts
@@ -1,0 +1,32 @@
+// scripts/agent/promote.ts
+import { queryContentRows, createContentRow, addPageComment } from './lib/notion'
+import { selectRowsNeedingPromotion, buildDerivativeRowInput } from './lib/promote'
+
+async function main(): Promise<void> {
+  const allRows = await queryContentRows({
+    property: 'Stage',
+    select: { does_not_equal: 'Abandoned' },
+  })
+  const toPromote = selectRowsNeedingPromotion(allRows, allRows)
+  if (toPromote.length === 0) {
+    console.log('Nothing to promote.')
+    return
+  }
+  console.log(`Promoting ${toPromote.length} row(s)...`)
+  for (const source of toPromote) {
+    try {
+      const input = buildDerivativeRowInput(source)
+      const newId = await createContentRow(input)
+      const newUrl = `https://www.notion.so/${newId.replace(/-/g, '')}`
+      await addPageComment(source.id, `Created derivative blog row: ${newUrl}`)
+      console.log(`✓ ${source.title} → ${newUrl}`)
+    } catch (err) {
+      console.error(`Failed to promote ${source.title}: ${(err as Error).message}`)
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/agent/tests/dedupe.test.ts
+++ b/scripts/agent/tests/dedupe.test.ts
@@ -1,0 +1,47 @@
+// scripts/agent/tests/dedupe.test.ts
+import { describe, it, expect } from 'vitest'
+import { isTitleDuplicate, hasFullToolsOverlap } from '../lib/dedupe'
+
+describe('isTitleDuplicate', () => {
+  it('treats identical titles as duplicates', () => {
+    expect(isTitleDuplicate('Claude Code agents in CI', ['Claude Code agents in CI'])).toBe(true)
+  })
+
+  it('treats titles differing only by case as duplicates', () => {
+    expect(isTitleDuplicate('claude code agents in ci', ['Claude Code agents in CI'])).toBe(true)
+  })
+
+  it('treats near-identical titles (>80% similar) as duplicates', () => {
+    expect(isTitleDuplicate('Claude Code agents in CI/CD', ['Claude Code agents in CI'])).toBe(true)
+  })
+
+  it('does not flag unrelated titles', () => {
+    expect(isTitleDuplicate('A totally different post', ['Claude Code agents in CI'])).toBe(false)
+  })
+
+  it('returns false for empty existing list', () => {
+    expect(isTitleDuplicate('Anything', [])).toBe(false)
+  })
+})
+
+describe('hasFullToolsOverlap', () => {
+  it('returns true when all proposed tools are covered', () => {
+    expect(hasFullToolsOverlap(['claude-code'], [['claude-code', 'cursor']])).toBe(true)
+  })
+
+  it('returns true when proposed tools are subset of any one row', () => {
+    expect(
+      hasFullToolsOverlap(['claude-code', 'cursor'], [['claude-code', 'cursor', 'gemini']])
+    ).toBe(true)
+  })
+
+  it('returns false when proposed tools partially covered across multiple rows', () => {
+    expect(hasFullToolsOverlap(['claude-code', 'cursor'], [['claude-code'], ['cursor']])).toBe(
+      false
+    )
+  })
+
+  it('returns false for empty proposed tools', () => {
+    expect(hasFullToolsOverlap([], [['claude-code']])).toBe(false)
+  })
+})

--- a/scripts/agent/tests/draft-blog.test.ts
+++ b/scripts/agent/tests/draft-blog.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { buildBlogSystemPrompt, buildBlogUserPrompt, slugify } from '../lib/draft-blog'
+
+describe('slugify', () => {
+  it('lowercases and dashes a title', () => {
+    expect(slugify('Claude Code agents in CI')).toBe('claude-code-agents-in-ci')
+  })
+  it('strips punctuation', () => {
+    expect(slugify('Why TDD? It works.')).toBe('why-tdd-it-works')
+  })
+  it('collapses multiple dashes', () => {
+    expect(slugify('a -- b')).toBe('a-b')
+  })
+})
+
+describe('buildBlogSystemPrompt', () => {
+  it('includes EDITORIAL guide and bucket map', () => {
+    const sp = buildBlogSystemPrompt({ editorialMd: 'EDITORIAL CONTENT', isDerivative: false })
+    expect(sp).toContain('EDITORIAL CONTENT')
+    expect(sp).toContain('Leadership')
+    expect(sp).toContain('Engineering')
+  })
+
+  it('adds derivative instructions when isDerivative=true', () => {
+    const sp = buildBlogSystemPrompt({
+      editorialMd: 'x',
+      isDerivative: true,
+      sourceVideoUrl: 'https://youtu.be/abc123def45',
+    })
+    expect(sp).toContain('<Youtube id="abc123def45" />')
+  })
+})
+
+describe('buildBlogUserPrompt', () => {
+  it('embeds title, hint, source URLs, and commit context', () => {
+    const up = buildBlogUserPrompt({
+      title: 'A post',
+      hint: 'angle here',
+      sourceUrls: ['https://x.com'],
+      tags: ['ai'],
+      commits: [
+        {
+          repo: 'shariqh/lognote',
+          sha: 'abc1234567890def1234567890def1234567890',
+          message: 'feat: add logging',
+          date: '2026-06-01T00:00:00Z',
+          filesChanged: ['src/log.ts'],
+          url: 'https://github.com/shariqh/lognote/commit/abc',
+        },
+      ],
+    })
+    expect(up).toContain('A post')
+    expect(up).toContain('angle here')
+    expect(up).toContain('https://x.com')
+    expect(up).toContain('feat: add logging')
+    expect(up).toContain('src/log.ts')
+  })
+})

--- a/scripts/agent/tests/draft-yt.test.ts
+++ b/scripts/agent/tests/draft-yt.test.ts
@@ -1,0 +1,55 @@
+// scripts/agent/tests/draft-yt.test.ts
+import { describe, it, expect } from 'vitest'
+import { buildYtSystemPrompt, buildYtUserPrompt, renderYtScriptToBlocks } from '../lib/draft-yt'
+import type { YTScriptBlocks } from '../lib/types'
+
+const sample: YTScriptBlocks = {
+  hook: 'Cursor rewrote my git config.',
+  script: 'Here is what happened…',
+  onScreenText: [{ timestampSeconds: 2, text: 'WAIT' }],
+  bRoll: [{ timestampSeconds: 5, description: 'screen recording of git config diff' }],
+  thumbnailPrompt: 'Terminal with red diff, calm face',
+  titleVariants: ['Cursor broke my git', 'Heads up on Cursor', 'A weird thing Cursor did'],
+  hashtags: ['ai', 'cursor', 'developer', 'cli'],
+}
+
+describe('renderYtScriptToBlocks', () => {
+  it('renders all 7 sections as Notion blocks', () => {
+    const blocks = renderYtScriptToBlocks(sample)
+    const headings = blocks.filter((b: { type?: string }) => b.type === 'heading_2')
+    expect(headings).toHaveLength(7)
+  })
+
+  it('preserves timestamps in on-screen-text bullets', () => {
+    const blocks = renderYtScriptToBlocks(sample)
+    const serialized = JSON.stringify(blocks)
+    expect(serialized).toContain('2s — WAIT')
+  })
+})
+
+describe('buildYtSystemPrompt', () => {
+  it('includes SHORTS-STYLE guide and tools', () => {
+    const sp = buildYtSystemPrompt({
+      shortsStyleMd: 'SHORTS GUIDE',
+      kind: 'YT short',
+      tools: ['claude-code'],
+    })
+    expect(sp).toContain('SHORTS GUIDE')
+    expect(sp).toContain('claude-code')
+  })
+})
+
+describe('buildYtUserPrompt', () => {
+  it('embeds title, hint, source URLs, and YT performance signal', () => {
+    const up = buildYtUserPrompt({
+      title: 'A short',
+      hint: 'angle',
+      sourceUrls: ['https://x.com'],
+      tools: ['claude-code'],
+      perfSignal: 'Past videos on claude-code averaged 4k views',
+    })
+    expect(up).toContain('A short')
+    expect(up).toContain('claude-code')
+    expect(up).toContain('4k views')
+  })
+})

--- a/scripts/agent/tests/migrate.test.ts
+++ b/scripts/agent/tests/migrate.test.ts
@@ -1,0 +1,90 @@
+// scripts/agent/tests/migrate.test.ts
+import { describe, it, expect } from 'vitest'
+import { mapCmsRowToContentRows, statusToStage, mediumToKind } from '../lib/migrate-mapping'
+import type { CmsRow } from '../lib/types'
+
+const baseRow: CmsRow = {
+  id: 'orig-page-1',
+  title: 'Sample',
+  status: 'Prepping',
+  medium: ['blog'],
+  origin: 'OC',
+  tags: ['ai'],
+  keywords: '',
+  sources: '',
+}
+
+describe('statusToStage', () => {
+  it('maps each legacy status', () => {
+    expect(statusToStage('Prepping')).toBe('Idea')
+    expect(statusToStage('Ready To Record')).toBe('Ready')
+    expect(statusToStage('Recording')).toBe('Recorded')
+    expect(statusToStage('Post-Processing')).toBe('Edited')
+    expect(statusToStage('Published')).toBe('Published')
+    expect(statusToStage('✅')).toBe('Published')
+    expect(statusToStage('Abandoned')).toBe('Abandoned')
+    expect(statusToStage(undefined)).toBe('Idea')
+  })
+})
+
+describe('mediumToKind', () => {
+  it('maps youtube to YT short by default', () => {
+    expect(mediumToKind('youtube')).toBe('YT short')
+  })
+  it('preserves explicit kinds', () => {
+    expect(mediumToKind('YT short')).toBe('YT short')
+    expect(mediumToKind('blog')).toBe('blog')
+    expect(mediumToKind('podcast')).toBe('podcast')
+  })
+})
+
+describe('mapCmsRowToContentRows', () => {
+  it('produces one row when medium has a single entry', () => {
+    const out = mapCmsRowToContentRows(baseRow)
+    expect(out).toHaveLength(1)
+    expect(out[0].kind).toBe('blog')
+    expect(out[0].stage).toBe('Idea')
+    expect(out[0].origin).toBe('OC')
+    expect(out[0].sourceRowOriginalPageId).toBeUndefined() // first piece keeps original ID
+  })
+
+  it('splits multi-medium rows into one row per kind, linking subsequents to first via sourceRowOriginalPageId', () => {
+    const row: CmsRow = { ...baseRow, medium: ['blog', 'YT short'] }
+    const out = mapCmsRowToContentRows(row)
+    expect(out).toHaveLength(2)
+    expect(out[0].kind).toBe('blog')
+    expect(out[0].origin).toBe('OC')
+    expect(out[0].crossPostTargets).toEqual(['YT short'])
+    expect(out[1].kind).toBe('YT short')
+    expect(out[1].origin).toBe('Derivative')
+    expect(out[1].sourceRowOriginalPageId).toBe('orig-page-1')
+  })
+
+  it('maps x-post:bundle origin to OC + populates Cross-post Targets from other media', () => {
+    const row: CmsRow = { ...baseRow, origin: 'x-post:bundle', medium: ['blog', 'YT short'] }
+    const out = mapCmsRowToContentRows(row)
+    expect(out[0].origin).toBe('OC')
+    expect(out[0].crossPostTargets).toEqual(['YT short'])
+  })
+
+  it('maps x-post:blog origin to Derivative', () => {
+    const row: CmsRow = { ...baseRow, origin: 'x-post:blog' }
+    const out = mapCmsRowToContentRows(row)
+    expect(out[0].origin).toBe('Derivative')
+  })
+
+  it('appends Keywords to Hint when both present', () => {
+    const row: CmsRow = { ...baseRow, keywords: 'tdd, claude' }
+    expect(mapCmsRowToContentRows(row)[0].hint).toContain('tdd, claude')
+  })
+
+  it('splits Source(s) on commas and newlines', () => {
+    const row: CmsRow = { ...baseRow, sources: 'https://a.com,\nhttps://b.com' }
+    expect(mapCmsRowToContentRows(row)[0].sourceUrls).toEqual(['https://a.com', 'https://b.com'])
+  })
+
+  it('carries Published Link through to Published URL', () => {
+    const row: CmsRow = { ...baseRow, publishedLink: 'https://example.com' }
+    expect(mapCmsRowToContentRows(row)[0].publishedUrl).toBe('https://example.com')
+  })
+})

--- a/scripts/agent/tests/notion.test.ts
+++ b/scripts/agent/tests/notion.test.ts
@@ -1,0 +1,81 @@
+// scripts/agent/tests/notion.test.ts
+import { describe, it, expect } from 'vitest'
+import { pageToContentRow } from '../lib/notion'
+
+const samplePage = {
+  id: '2467cc75-7fe9-8052-b08e-e9327ac7fbf1',
+  created_time: '2025-08-05T10:32:00.000Z',
+  last_edited_time: '2025-08-12T16:36:00.000Z',
+  properties: {
+    Title: { type: 'title', title: [{ plain_text: 'A test row' }] },
+    Kind: { type: 'select', select: { name: 'blog' } },
+    Stage: { type: 'select', select: { name: 'Proposed' } },
+    Origin: { type: 'select', select: { name: 'Agent Proposed' } },
+    'Source Row': { type: 'relation', relation: [] },
+    'Cross-post Targets': {
+      type: 'multi_select',
+      multi_select: [{ name: 'YT short' }],
+    },
+    Tags: { type: 'multi_select', multi_select: [{ name: 'ai' }, { name: 'cli' }] },
+    Tools: { type: 'multi_select', multi_select: [{ name: 'claude-code' }] },
+    Hint: { type: 'rich_text', rich_text: [{ plain_text: 'a one-line angle' }] },
+    'Source URLs': { type: 'rich_text', rich_text: [{ plain_text: 'https://example.com' }] },
+    'Draft URL': { type: 'url', url: null },
+    'Published URL': { type: 'url', url: 'https://shariq.dev/blog/x' },
+    Publishing: { type: 'date', date: { start: '2026-06-10' } },
+  },
+}
+
+describe('pageToContentRow', () => {
+  it('maps a fully-populated page to a ContentRow', () => {
+    const row = pageToContentRow(samplePage as never)
+    expect(row.title).toBe('A test row')
+    expect(row.kind).toBe('blog')
+    expect(row.stage).toBe('Proposed')
+    expect(row.origin).toBe('Agent Proposed')
+    expect(row.crossPostTargets).toEqual(['YT short'])
+    expect(row.tags).toEqual(['ai', 'cli'])
+    expect(row.tools).toEqual(['claude-code'])
+    expect(row.hint).toBe('a one-line angle')
+    expect(row.sourceUrls).toEqual(['https://example.com'])
+    expect(row.draftUrl).toBeUndefined()
+    expect(row.publishedUrl).toBe('https://shariq.dev/blog/x')
+    expect(row.publishingDate).toBe('2026-06-10')
+  })
+
+  it('handles empty Source URLs as empty array', () => {
+    const empty = {
+      ...samplePage,
+      properties: {
+        ...samplePage.properties,
+        'Source URLs': { type: 'rich_text', rich_text: [] },
+      },
+    }
+    expect(pageToContentRow(empty as never).sourceUrls).toEqual([])
+  })
+
+  it('splits comma-or-newline-separated Source URLs', () => {
+    const multi = {
+      ...samplePage,
+      properties: {
+        ...samplePage.properties,
+        'Source URLs': {
+          type: 'rich_text',
+          rich_text: [{ plain_text: 'https://a.com\nhttps://b.com' }],
+        },
+      },
+    }
+    expect(pageToContentRow(multi as never).sourceUrls).toEqual(['https://a.com', 'https://b.com'])
+  })
+
+  it('returns sourceRowId when relation has an entry', () => {
+    const withRel = {
+      ...samplePage,
+      properties: {
+        ...samplePage.properties,
+        'Source Row': { type: 'relation', relation: [{ id: 'abc123' }] },
+      },
+    }
+    expect(pageToContentRow(withRel as never).sourceRowId).toBe('abc123')
+  })
+})

--- a/scripts/agent/tests/promote.test.ts
+++ b/scripts/agent/tests/promote.test.ts
@@ -1,0 +1,67 @@
+// scripts/agent/tests/promote.test.ts
+import { describe, it, expect } from 'vitest'
+import { selectRowsNeedingPromotion, buildDerivativeRowInput } from '../lib/promote'
+import type { ContentRow } from '../lib/types'
+
+const baseRow: ContentRow = {
+  id: 'row-1',
+  title: 'A short',
+  kind: 'YT short',
+  stage: 'Published',
+  origin: 'OC',
+  crossPostTargets: ['blog'],
+  tags: ['ai'],
+  tools: ['claude-code'],
+  hint: '',
+  sourceUrls: [],
+  publishedUrl: 'https://youtu.be/abc12345678',
+  createdAt: '2026-06-01T00:00:00Z',
+  updatedAt: '2026-06-02T00:00:00Z',
+}
+
+describe('selectRowsNeedingPromotion', () => {
+  it('selects published YT rows with blog target and no existing derivative', () => {
+    const out = selectRowsNeedingPromotion([baseRow], [])
+    expect(out).toHaveLength(1)
+  })
+
+  it('skips rows without blog target', () => {
+    const r = { ...baseRow, crossPostTargets: [] }
+    expect(selectRowsNeedingPromotion([r], [])).toHaveLength(0)
+  })
+
+  it('skips rows that already have a derivative', () => {
+    const derivative: ContentRow = {
+      ...baseRow,
+      id: 'row-2',
+      kind: 'blog',
+      origin: 'Derivative',
+      sourceRowId: 'row-1',
+    }
+    expect(selectRowsNeedingPromotion([baseRow], [derivative])).toHaveLength(0)
+  })
+
+  it('skips non-published YT rows', () => {
+    const r = { ...baseRow, stage: 'Drafted' as const }
+    expect(selectRowsNeedingPromotion([r], [])).toHaveLength(0)
+  })
+
+  it('skips non-YT rows even if they have blog target', () => {
+    const r = { ...baseRow, kind: 'blog' as const }
+    expect(selectRowsNeedingPromotion([r], [])).toHaveLength(0)
+  })
+})
+
+describe('buildDerivativeRowInput', () => {
+  it('mints a blog derivative carrying tags, tools, and YT URL forward', () => {
+    const out = buildDerivativeRowInput(baseRow)
+    expect(out.kind).toBe('blog')
+    expect(out.stage).toBe('Proposed')
+    expect(out.origin).toBe('Derivative')
+    expect(out.sourceRowId).toBe('row-1')
+    expect(out.tags).toEqual(['ai'])
+    expect(out.tools).toEqual(['claude-code'])
+    expect(out.sourceUrls).toContain('https://youtu.be/abc12345678')
+    expect(out.hint).toContain('Blog-length treatment')
+  })
+})

--- a/scripts/agent/tests/validate.test.ts
+++ b/scripts/agent/tests/validate.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { validateMdxFrontmatter } from '../lib/validate'
+
+describe('validateMdxFrontmatter', () => {
+  it('passes a valid post', () => {
+    const mdx = `---
+title: A test post
+date: 2026-06-01
+tags: ['ai', 'engineering']
+summary: A short summary under 280 chars.
+---
+
+Body goes here.
+`
+    const result = validateMdxFrontmatter(mdx)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.title).toBe('A test post')
+      expect(result.data.tags).toEqual(['ai', 'engineering'])
+    }
+  })
+
+  it('fails when summary too long', () => {
+    const mdx = `---
+title: x
+date: 2026-06-01
+summary: ${'a'.repeat(300)}
+---
+body`
+    const result = validateMdxFrontmatter(mdx)
+    expect(result.ok).toBe(false)
+  })
+
+  it('fails when title missing', () => {
+    const mdx = `---
+date: 2026-06-01
+summary: hi
+---
+body`
+    expect(validateMdxFrontmatter(mdx).ok).toBe(false)
+  })
+
+  it('fails when date is unparseable', () => {
+    const mdx = `---
+title: x
+date: not-a-date
+summary: hi
+---
+body`
+    expect(validateMdxFrontmatter(mdx).ok).toBe(false)
+  })
+})

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,30 +1,31 @@
 import { defineCollection, z } from 'astro:content'
 import { glob } from 'astro/loaders'
 
+export const writingSchema = z.object({
+  title: z.string(),
+  date: z.coerce.date(),
+  tags: z.array(z.string()).default([]),
+  summary: z.string().max(280),
+  hero: z
+    .object({
+      // Path served from /public/ (e.g. /static/images/blog/<slug>/hero.png).
+      // Rendered as a plain <img> in PostHeader. Skips Astro's image
+      // optimization, which is fine for v1 — banner PNGs are already small.
+      image: z.string(),
+      alt: z.string(),
+      prompt: z.string().optional(),
+      background: z.enum(['ink', 'ink-soft', 'ochre', 'terracotta', 'paper']).optional(),
+      titleStyle: z.enum(['italic', 'upper-mono', 'serif-display']).optional(),
+    })
+    .optional(),
+  draft: z.boolean().default(false),
+  updatedAt: z.coerce.date().optional(),
+  canonical: z.string().url().optional(),
+})
+
 const writing = defineCollection({
   loader: glob({ pattern: '**/*.mdx', base: './src/content/writing' }),
-  schema: () =>
-    z.object({
-      title: z.string(),
-      date: z.coerce.date(),
-      tags: z.array(z.string()).default([]),
-      summary: z.string().max(280),
-      hero: z
-        .object({
-          // Path served from /public/ (e.g. /static/images/blog/<slug>/hero.png).
-          // Rendered as a plain <img> in PostHeader. Skips Astro's image
-          // optimization, which is fine for v1 — banner PNGs are already small.
-          image: z.string(),
-          alt: z.string(),
-          prompt: z.string().optional(),
-          background: z.enum(['ink', 'ink-soft', 'ochre', 'terracotta', 'paper']).optional(),
-          titleStyle: z.enum(['italic', 'upper-mono', 'serif-display']).optional(),
-        })
-        .optional(),
-      draft: z.boolean().default(false),
-      updatedAt: z.coerce.date().optional(),
-      canonical: z.string().url().optional(),
-    }),
+  schema: () => writingSchema,
 })
 
 export const collections = { writing }

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,27 +1,8 @@
-import { defineCollection, z } from 'astro:content'
+import { defineCollection } from 'astro:content'
 import { glob } from 'astro/loaders'
+import { writingSchema } from './lib/schemas'
 
-export const writingSchema = z.object({
-  title: z.string(),
-  date: z.coerce.date(),
-  tags: z.array(z.string()).default([]),
-  summary: z.string().max(280),
-  hero: z
-    .object({
-      // Path served from /public/ (e.g. /static/images/blog/<slug>/hero.png).
-      // Rendered as a plain <img> in PostHeader. Skips Astro's image
-      // optimization, which is fine for v1 — banner PNGs are already small.
-      image: z.string(),
-      alt: z.string(),
-      prompt: z.string().optional(),
-      background: z.enum(['ink', 'ink-soft', 'ochre', 'terracotta', 'paper']).optional(),
-      titleStyle: z.enum(['italic', 'upper-mono', 'serif-display']).optional(),
-    })
-    .optional(),
-  draft: z.boolean().default(false),
-  updatedAt: z.coerce.date().optional(),
-  canonical: z.string().url().optional(),
-})
+export { writingSchema }
 
 const writing = defineCollection({
   loader: glob({ pattern: '**/*.mdx', base: './src/content/writing' }),

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod'
+
+/**
+ * Zod schema for writing collection frontmatter.
+ * Defined here (not in content.config.ts) so it can be imported
+ * from both Astro and Node.js contexts (e.g. validate.ts).
+ */
+export const writingSchema = z.object({
+  title: z.string(),
+  date: z.coerce.date(),
+  tags: z.array(z.string()).default([]),
+  summary: z.string().max(280),
+  hero: z
+    .object({
+      // Path served from /public/ (e.g. /static/images/blog/<slug>/hero.png).
+      // Rendered as a plain <img> in PostHeader. Skips Astro's image
+      // optimization, which is fine for v1 — banner PNGs are already small.
+      image: z.string(),
+      alt: z.string(),
+      prompt: z.string().optional(),
+      background: z.enum(['ink', 'ink-soft', 'ochre', 'terracotta', 'paper']).optional(),
+      titleStyle: z.enum(['italic', 'upper-mono', 'serif-display']).optional(),
+    })
+    .optional(),
+  draft: z.boolean().default(false),
+  updatedAt: z.coerce.date().optional(),
+  canonical: z.string().url().optional(),
+})


### PR DESCRIPTION
## What this is

Plan B — the AI drafting agent. A nightly Claude-based agent that watches your real work (Notion ideas, recent commits, AI/dev tool trends, YouTube performance) and proposes content in two formats: blog posts and YouTube scripts. You triage candidates in Notion; the agent drafts each in the right shape. Nothing publishes without your review.

Design: `docs/superpowers/specs/2026-06-02-plan-b-ai-drafting-agent-design.md`
Plan: `docs/superpowers/plans/2026-06-02-plan-b-ai-drafting-agent.md`

## Three workflows (cron + manual dispatch)

- **agent-discover** (Sun 03:00 UTC) — scans Notion ideas + commits + GH trending + HN + YT stats, proposes up to 3 blog + 3 YT candidates as Notion rows
- **agent-draft** (nightly 02:00 UTC) — picks up `Stage=Ready` rows. Blog → MDX file + PR. YT → structured script written into the Notion row body
- **agent-promote** (nightly 04:00 UTC) — published YT shorts marked `Cross-post Targets: blog` get a linked blog-derivative row minted in `Stage=Proposed`

## What's in here

- `scripts/agent/` — entry scripts (discover, draft, promote, migrate-cms) + lib modules (notion HTTP client, Claude Agent SDK wrapper, source readers, validators, prompt builders), 43 passing unit tests
- `.github/workflows/agent-*.yml` — the three cron workflows
- `docs/SHORTS-STYLE.md` — YT script style contract (blog uses existing EDITORIAL.md)
- `src/lib/schemas.ts` — Zod schema extracted from content.config so the agent can reuse the frontmatter validator
- Node bumped 22 → 24 LTS across engines + existing deploy/ci workflows

## Notion

The existing CMS DB was restructured in place (Status→Stage with new options, added Kind/Hint/Source Row/Cross-post Targets/Tools/Draft URL/Site). All 78 existing rows migrated. One source of truth — no separate DB.

## Auth

Runs against the Claude subscription via `CLAUDE_CODE_OAUTH_TOKEN` (no API billing). Secrets + variables configured on the repo.

## Site impact

None — agent code is isolated to `scripts/agent/` and `.github/workflows/agent-*.yml`. The only site-touching changes are the Node 24 bump and the schema extraction, both build-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)