### PR TITLE
Bump checkout + setup-node to v6 (Node 24 actions runtime)

### DIFF
--- a/.github/workflows/agent-discover.yml
+++ b/.github/workflows/agent-discover.yml
@@ -11,9 +11,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/agent-draft.yml
+++ b/.github/workflows/agent-draft.yml
@@ -12,12 +12,12 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.AGENT_GH_TOKEN }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/agent-promote.yml
+++ b/.github/workflows/agent-promote.yml
@@ -11,9 +11,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -43,7 +43,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -61,7 +61,7 @@ jobs:
 
       - name: Set up Node
         if: steps.guard.outputs.skip == 'false'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: "npm"

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 4
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Vale
         uses: errata-ai/vale-action@reviewdog


### PR DESCRIPTION
Bumps `actions/checkout@v4 → @v6` and `actions/setup-node@v4 → @v6` across all 7 workflows.

These two actions' **v4 runs on Node.js 20**, which GitHub deprecates for actions on **2026-06-16**. v6 (latest: checkout `v6.0.3`, setup-node `v6.4.0`) runs on Node 24, clearing the deprecation annotation that was showing on every workflow run.

No behavior change — same checkout/setup steps, newer runtime. Validated by this PR's own ci + deploy checks, and gets a pass from the new independent AI reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)