### PR TITLE
Agent: commit diffs + private-repo scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Posts live in `src/content/writing/`. Frontmatter is Zod-validated at build
 time (see `src/content.config.ts`). Tags map to display buckets in
 `src/lib/buckets.ts`. URLs are `/blog/<filename-without-extension>`.
 
-The AI drafting agent is set up in a separate workflow (Plan B). For now,
-write MDX, commit, push, merge.
+You can write a post by hand (create the MDX, commit, push, open a PR), or
+let the drafting agent write one for you — see [Content workflow](#content-workflow).
 
 ## Deploy (Cloudflare Pages via GitHub Actions)
 
@@ -78,8 +78,70 @@ wrangler pages domain add shariq.dev --project-name=shariq-dev
 wrangler pages domain list --project-name=shariq-dev
 ```
 
-## Drafting pipeline
+## Content workflow
 
-Posts and YouTube scripts are drafted by a Claude-based agent that reads from a Notion DB of ideas + my recent commits + AI/dev tool trends. The agent never publishes — every blog post goes through PR review on Cloudflare Pages preview; every YouTube script lives in Notion for me to record manually.
+All content — blog posts and YouTube scripts — is planned in a **Notion CMS
+database**. That DB is the control panel: I add and triage ideas there, and a
+nightly Claude-based agent does discovery and drafting off it. **Nothing
+publishes automatically.** Blog drafts arrive as PRs (with a Cloudflare preview)
+for me to review and merge; YouTube scripts land in the Notion row for me to record.
 
-See [`docs/superpowers/specs/2026-06-02-plan-b-ai-drafting-agent-design.md`](docs/superpowers/specs/2026-06-02-plan-b-ai-drafting-agent-design.md) for the design.
+Each row moves through a **Stage**:
+
+| Stage         | Meaning                                                               |
+| ------------- | --------------------------------------------------------------------- |
+| **Idea**      | A raw seed. Not a commitment — the agent reads these for inspiration. |
+| **Proposed**  | A candidate in triage, waiting for a yes/no (mine or the agent's).    |
+| **Ready**     | Approved — the agent drafts it on the next run.                       |
+| **Drafted**   | Agent opened a PR (blog) or wrote the script into the row (YouTube).  |
+| **Published** | Live.                                                                 |
+| **Abandoned** | Killed; the agent won't resurface it.                                 |
+
+### Add an idea
+
+Make a new row, set **Kind** (`blog`, `YT short`, `YT long`), a **Title**, and a
+one-line **Hint**. Then:
+
+- **Want it drafted now?** Set **Stage = Ready** — the agent picks it up next run.
+- **Just a seed?** Set **Stage = Idea** — no draft yet, but discovery reads it and
+  may spin a sharper candidate into triage.
+
+The **Hint is the field that matters most** — it's what actually steers the draft.
+Put the _point_ there (the decision, the gotcha, the angle), not just a topic.
+
+### Pull in one of my commits
+
+In a Ready row's **Source URLs**, paste a GitHub commit link
+(`.../commit/<sha>`). If it's a recent commit (last ~week) in a repo I own —
+public or private — the agent attaches the real diff to the draft, filtered down
+to the meaningful changes. Older commits, or repos I don't own, won't pull, so
+it's worth capturing the Hint while the work is fresh.
+
+### Triage, kill, or refine
+
+- **Triage:** candidates sit in **Proposed**. Flip the good ones to **Ready** and
+  the agent drafts them.
+- **Don't like it?** Set **Stage = Abandoned** (cleaner than deleting — the agent
+  won't propose it again).
+- **Needs work?** Edit the **Hint / Title** in place, or send it back to **Idea**
+  for discovery to reshape on the next run.
+
+### Schedule
+
+The agent runs on GitHub Actions cron (it never publishes — it only proposes and drafts):
+
+- **Discover** (weekly) — scans Notion ideas, my recent commits, and dev-tool
+  trends; proposes new candidates into triage.
+- **Draft** (daily) — turns **Ready** rows into PRs / scripts.
+- **Promote** (daily) — mints blog-derivative rows from published YouTube videos.
+
+To run a step by hand for testing (needs a local `.env.local` — see
+`.env.local.example`):
+
+```sh
+npm run agent:discover
+npm run agent:draft
+npm run agent:promote
+```
+
+Design details: [`docs/superpowers/specs/2026-06-02-plan-b-ai-drafting-agent-design.md`](docs/superpowers/specs/2026-06-02-plan-b-ai-drafting-agent-design.md).

--- a/docs/superpowers/plans/2026-06-04-agent-commit-diffs.md
+++ b/docs/superpowers/plans/2026-06-04-agent-commit-diffs.md
@@ -1,0 +1,687 @@
+# Agent Commit Diffs + Private-Repo Scope Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the drafting agent attach real (noise-filtered, size-capped) commit diffs to blog drafts, and widen repo scope to all repos owned by the token account (private + public).
+
+**Architecture:** Stop discarding the `patch` field GitHub already returns per file; add a pure `diff-filter` module that drops noise files and caps size; render filtered diffs into the blog draft prompt for the commits a Ready row cites. Switch repo listing from public-only to `affiliation=owner`. Discovery is untouched.
+
+**Tech Stack:** TypeScript (strict), Node 22 agent scripts under `scripts/agent/`, Vitest for unit tests, GitHub REST API.
+
+**Spec:** `docs/superpowers/specs/2026-06-04-agent-commit-diffs-and-private-repos-design.md`
+
+---
+
+## File Structure
+
+- **Modify** `scripts/agent/lib/types.ts` — add `CommitFile`, add `files: CommitFile[]` to `CommitInfo`.
+- **Modify** `scripts/agent/lib/git-scan.ts` — `fetchFiles` returns `CommitFile[]`; `fetchCommits` populates `files`; `activeRepos` uses `/user/repos?affiliation=owner`.
+- **Create** `scripts/agent/lib/diff-filter.ts` — `NOISE_PATTERNS`, `isNoiseFile`, `truncatePatch`, `buildDiffBlock` (pure functions).
+- **Create** `scripts/agent/tests/diff-filter.test.ts` — unit tests for the above.
+- **Modify** `scripts/agent/lib/draft-blog.ts` — render diff blocks in `buildBlogUserPrompt`.
+- **Modify** `scripts/agent/tests/draft-blog.test.ts` — update commit fixture (`files`), assert diff rendering.
+
+---
+
+## Task 1: Plumb `patch` through `CommitInfo` (types + git-scan + fixture)
+
+This is a plumbing change with no new behavior to unit-test (network code stays untested, per the spec). Keep the tree green: type, producer, and the one existing fixture change together.
+
+**Files:**
+
+- Modify: `scripts/agent/lib/types.ts:69-76`
+- Modify: `scripts/agent/lib/git-scan.ts:18-22` (GhCommitFile), `:72-104` (fetchCommits/fetchFiles)
+- Modify: `scripts/agent/tests/draft-blog.test.ts:40-52`
+
+- [ ] **Step 1: Add `CommitFile` and extend `CommitInfo`**
+
+In `scripts/agent/lib/types.ts`, replace the `CommitInfo` interface (lines 69-76) with:
+
+```ts
+export interface CommitFile {
+  filename: string
+  status: string // "added" | "modified" | "removed" | "renamed" | ...
+  additions: number
+  deletions: number
+  patch?: string // absent for binary / too-large files
+}
+
+export interface CommitInfo {
+  repo: string // e.g. "shariqh/lognote"
+  sha: string
+  message: string
+  date: string
+  files: CommitFile[] // full list, with diffs — used for drafting diff blocks
+  filesChanged: string[] // names only, capped — used by discovery (unchanged)
+  url: string
+}
+```
+
+- [ ] **Step 2: Return structured files from `fetchFiles`**
+
+In `scripts/agent/lib/git-scan.ts`, update the `GhCommitFile` interface (lines 18-22) and the `fetchFiles` function (currently lines 96-104). Replace the `GhCommitFile` interface with:
+
+```ts
+interface GhCommitFile {
+  filename: string
+  status: string
+  additions: number
+  deletions: number
+  patch?: string
+}
+```
+
+Replace `fetchFiles` with:
+
+```ts
+async function fetchFiles(repo: string, sha: string): Promise<CommitFile[]> {
+  const url = `${GH_API}/repos/${repo}/commits/${sha}`
+  const res = await fetch(url, { headers: ghHeaders() })
+  if (!res.ok) return []
+  const data = (await res.json()) as { files?: GhCommitFile[] }
+  return (data.files ?? []).map((f) => ({
+    filename: f.filename,
+    status: f.status,
+    additions: f.additions,
+    deletions: f.deletions,
+    patch: f.patch,
+  }))
+}
+```
+
+Add `CommitFile` to the type import at the top of the file (line 3):
+
+```ts
+import type { CommitInfo, CommitFile } from './types'
+```
+
+- [ ] **Step 3: Populate `files` in `fetchCommits`**
+
+In `scripts/agent/lib/git-scan.ts`, the `fetchCommits` loop currently does (around lines 78-89):
+
+```ts
+for (const c of commits) {
+  const files = await fetchFiles(repo, c.sha)
+  results.push({
+    repo,
+    sha: c.sha,
+    message: c.commit.message,
+    date: c.commit.author.date,
+    filesChanged: files.slice(0, 10),
+    url: c.html_url,
+  })
+}
+```
+
+`files` is now `CommitFile[]`, so `filesChanged` can no longer be `files.slice(0, 10)`. Replace the `results.push({...})` block with:
+
+```ts
+results.push({
+  repo,
+  sha: c.sha,
+  message: c.commit.message,
+  date: c.commit.author.date,
+  files,
+  filesChanged: files.map((f) => f.filename).slice(0, 10),
+  url: c.html_url,
+})
+```
+
+- [ ] **Step 4: Update the existing test fixture**
+
+In `scripts/agent/tests/draft-blog.test.ts`, the commit fixture (lines 44-51) is missing the now-required `files`. Add it. Replace the single commit object with:
+
+```ts
+        {
+          repo: 'shariqh/lognote',
+          sha: 'abc1234567890def1234567890def1234567890',
+          message: 'feat: add logging',
+          date: '2026-06-01T00:00:00Z',
+          files: [
+            {
+              filename: 'src/log.ts',
+              status: 'added',
+              additions: 10,
+              deletions: 0,
+              patch: '@@ -0,0 +1,2 @@\n+export const log = () => {}\n',
+            },
+          ],
+          filesChanged: ['src/log.ts'],
+          url: 'https://github.com/shariqh/lognote/commit/abc',
+        },
+```
+
+- [ ] **Step 5: Verify compile + existing tests still pass**
+
+Run: `npm test`
+Expected: PASS, all existing suites green (the draft-blog test still asserts `src/log.ts` and `feat: add logging`).
+
+Run: `npx tsc --noEmit -p scripts/agent/tsconfig.json 2>/dev/null || npx tsc --noEmit`
+Expected: no type errors. (If `scripts/agent` has no own tsconfig, the root strict check covers it.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/agent/lib/types.ts scripts/agent/lib/git-scan.ts scripts/agent/tests/draft-blog.test.ts
+git commit -m "feat(agent): keep commit patch data on CommitInfo.files"
+```
+
+---
+
+## Task 2: `diff-filter` — noise classification
+
+**Files:**
+
+- Create: `scripts/agent/lib/diff-filter.ts`
+- Create: `scripts/agent/tests/diff-filter.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `scripts/agent/tests/diff-filter.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { isNoiseFile } from '../lib/diff-filter'
+
+describe('isNoiseFile', () => {
+  it.each([
+    'package-lock.json',
+    'apps/web/pnpm-lock.yaml',
+    'go.sum',
+    'dist/index.js',
+    'src/.next/build-manifest.json',
+    'app/styles.min.css',
+    'bundle.js.map',
+    'src/__snapshots__/foo.snap',
+    'public/logo.png',
+    'assets/font.woff2',
+  ])('treats %s as noise', (f) => {
+    expect(isNoiseFile(f)).toBe(true)
+  })
+
+  it.each(['src/log.ts', 'src/pages/index.astro', 'README.md', 'lib/auth.ts', 'styles/global.css'])(
+    'treats %s as signal',
+    (f) => {
+      expect(isNoiseFile(f)).toBe(false)
+    }
+  )
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run scripts/agent/tests/diff-filter.test.ts`
+Expected: FAIL — cannot resolve `../lib/diff-filter`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `scripts/agent/lib/diff-filter.ts`:
+
+```ts
+// scripts/agent/lib/diff-filter.ts
+// Pure helpers for turning a commit's file list into a prompt-sized, noise-free
+// diff block. No I/O — unit-tested in isolation.
+
+// Files whose diffs add no editorial signal. Add a pattern here to exclude more.
+export const NOISE_PATTERNS: RegExp[] = [
+  // lockfiles
+  /(^|\/)package-lock\.json$/,
+  /(^|\/)pnpm-lock\.yaml$/,
+  /(^|\/)yarn\.lock$/,
+  /(^|\/)bun\.lockb$/,
+  /(^|\/)Cargo\.lock$/,
+  /(^|\/)poetry\.lock$/,
+  /(^|\/)Pipfile\.lock$/,
+  /(^|\/)composer\.lock$/,
+  /(^|\/)Gemfile\.lock$/,
+  /(^|\/)go\.sum$/,
+  /(^|\/)flake\.lock$/,
+  // generated / build output
+  /(^|\/)(dist|build|out|coverage|node_modules|vendor)\//,
+  /(^|\/)\.next\//,
+  /(^|\/)\.astro\//,
+  // minified & sourcemaps
+  /\.min\.(js|css)$/,
+  /\.map$/,
+  // test snapshots
+  /(^|\/)__snapshots__\//,
+  /\.snap$/,
+  // binary / media
+  /\.(png|jpe?g|gif|webp|ico|svg|pdf|woff2?|ttf|eot|mp4|mov|zip|gz|tgz)$/i,
+]
+
+export function isNoiseFile(filename: string): boolean {
+  return NOISE_PATTERNS.some((re) => re.test(filename))
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run scripts/agent/tests/diff-filter.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/agent/lib/diff-filter.ts scripts/agent/tests/diff-filter.test.ts
+git commit -m "feat(agent): add diff noise classifier"
+```
+
+---
+
+## Task 3: `diff-filter` — `truncatePatch` + `buildDiffBlock`
+
+**Files:**
+
+- Modify: `scripts/agent/lib/diff-filter.ts`
+- Modify: `scripts/agent/tests/diff-filter.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/agent/tests/diff-filter.test.ts`:
+
+````ts
+import { truncatePatch, buildDiffBlock } from '../lib/diff-filter'
+import type { CommitInfo } from '../lib/types'
+
+function commit(files: CommitInfo['files']): CommitInfo {
+  return {
+    repo: 'shariqh/lognote',
+    sha: 'abcdef1234567890',
+    message: 'feat: thing\n\nbody',
+    date: '2026-06-01T00:00:00Z',
+    files,
+    filesChanged: files.map((f) => f.filename),
+    url: 'https://github.com/shariqh/lognote/commit/abcdef1',
+  }
+}
+
+describe('truncatePatch', () => {
+  it('returns patch unchanged when under the line cap', () => {
+    const { text, truncated } = truncatePatch('a\nb\nc', 10)
+    expect(text).toBe('a\nb\nc')
+    expect(truncated).toBe(0)
+  })
+
+  it('truncates and reports dropped line count', () => {
+    const { text, truncated } = truncatePatch('a\nb\nc\nd\ne', 2)
+    expect(text).toBe('a\nb')
+    expect(truncated).toBe(3)
+  })
+})
+
+describe('buildDiffBlock', () => {
+  it('renders a fenced diff with the commit subject', () => {
+    const block = buildDiffBlock(
+      commit([
+        {
+          filename: 'src/log.ts',
+          status: 'modified',
+          additions: 2,
+          deletions: 1,
+          patch: '@@ x @@\n+a\n-b',
+        },
+      ])
+    )
+    expect(block).toContain('shariqh/lognote@abcdef1')
+    expect(block).toContain('feat: thing')
+    expect(block).toContain('```diff')
+    expect(block).toContain('+a')
+    expect(block).toContain('src/log.ts')
+  })
+
+  it('omits noise files but counts them', () => {
+    const block = buildDiffBlock(
+      commit([
+        {
+          filename: 'src/log.ts',
+          status: 'modified',
+          additions: 1,
+          deletions: 0,
+          patch: '@@ @@\n+a',
+        },
+        {
+          filename: 'package-lock.json',
+          status: 'modified',
+          additions: 999,
+          deletions: 0,
+          patch: '@@ @@\n+noise',
+        },
+      ])
+    )
+    expect(block).toContain('1 lockfile/generated')
+    expect(block).not.toContain('+noise')
+  })
+
+  it('shows no fence when every file is noise', () => {
+    const block = buildDiffBlock(
+      commit([
+        {
+          filename: 'package-lock.json',
+          status: 'modified',
+          additions: 9,
+          deletions: 0,
+          patch: '@@ @@\n+x',
+        },
+      ])
+    )
+    expect(block).not.toContain('```diff')
+    expect(block).toContain('1 lockfile/generated')
+  })
+
+  it('truncates an oversized per-file patch', () => {
+    const big = Array.from({ length: 50 }, (_, i) => `+line${i}`).join('\n')
+    const block = buildDiffBlock(
+      commit([
+        { filename: 'src/big.ts', status: 'modified', additions: 50, deletions: 0, patch: big },
+      ]),
+      { maxPatchLines: 5 }
+    )
+    expect(block).toContain('more lines truncated')
+    expect(block).not.toContain('+line49')
+  })
+
+  it('drops trailing files past the byte budget with a note', () => {
+    const body = 'x'.repeat(200)
+    const block = buildDiffBlock(
+      commit([
+        { filename: 'a.ts', status: 'modified', additions: 1, deletions: 0, patch: body },
+        { filename: 'b.ts', status: 'modified', additions: 1, deletions: 0, patch: body },
+        { filename: 'c.ts', status: 'modified', additions: 1, deletions: 0, patch: body },
+      ]),
+      { maxDiffBytes: 250 }
+    )
+    expect(block).toContain('more file(s) omitted')
+  })
+
+  it('lists a binary file without a diff body', () => {
+    const block = buildDiffBlock(
+      commit([{ filename: 'src/data.bin', status: 'added', additions: 0, deletions: 0 }])
+    )
+    expect(block).toContain('src/data.bin')
+    expect(block).toContain('binary or no inline diff')
+  })
+})
+````
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run scripts/agent/tests/diff-filter.test.ts`
+Expected: FAIL — `truncatePatch` / `buildDiffBlock` are not exported.
+
+- [ ] **Step 3: Implement**
+
+Append to `scripts/agent/lib/diff-filter.ts`:
+
+````ts
+import type { CommitInfo } from './types'
+
+// Caps keep one large refactor from blowing the prompt. Tunable.
+const MAX_PATCH_LINES = 150
+const MAX_DIFF_BYTES = 16_000
+
+export interface DiffBlockOptions {
+  maxPatchLines?: number
+  maxDiffBytes?: number
+}
+
+export function truncatePatch(
+  patch: string,
+  maxLines: number
+): { text: string; truncated: number } {
+  const lines = patch.split('\n')
+  if (lines.length <= maxLines) return { text: patch, truncated: 0 }
+  return { text: lines.slice(0, maxLines).join('\n'), truncated: lines.length - maxLines }
+}
+
+/**
+ * Render one commit's reviewable diff as a prompt fragment: a labelled, fenced
+ * `diff` block of signal files only, with noise/over-budget omissions stated
+ * explicitly (never silently hidden).
+ */
+export function buildDiffBlock(commit: CommitInfo, opts: DiffBlockOptions = {}): string {
+  const maxPatchLines = opts.maxPatchLines ?? MAX_PATCH_LINES
+  const maxDiffBytes = opts.maxDiffBytes ?? MAX_DIFF_BYTES
+  const subject = commit.message.split('\n')[0]
+  const header = `### ${commit.repo}@${commit.sha.slice(0, 7)} — ${subject}`
+
+  const noiseCount = commit.files.filter((f) => isNoiseFile(f.filename)).length
+  const signal = commit.files.filter((f) => !isNoiseFile(f.filename))
+  const noiseNote = noiseCount > 0 ? `_${noiseCount} lockfile/generated change(s) omitted_` : ''
+
+  if (signal.length === 0) {
+    return `${header}\n${noiseNote || '_no reviewable changes_'}`
+  }
+
+  const parts: string[] = []
+  let bytes = 0
+  let included = 0
+  for (const f of signal) {
+    const label = `# ${f.filename} (${f.status}, +${f.additions} -${f.deletions})`
+    let body: string
+    if (!f.patch) {
+      body = `${label}\n(binary or no inline diff)`
+    } else {
+      const { text, truncated } = truncatePatch(f.patch, maxPatchLines)
+      body = `${label}\n${text}${truncated ? `\n… (${truncated} more lines truncated)` : ''}`
+    }
+    // Always include at least one file, then stop once the budget is exceeded.
+    if (included > 0 && bytes + body.length > maxDiffBytes) break
+    parts.push(body)
+    bytes += body.length
+    included++
+  }
+
+  const filesOmitted = signal.length - included
+  const omittedNote =
+    filesOmitted > 0 ? `\n… (${filesOmitted} more file(s) omitted for length)` : ''
+
+  const lines = [header]
+  if (noiseNote) lines.push(noiseNote)
+  lines.push('```diff', parts.join('\n'), '```')
+  return lines.join('\n') + omittedNote
+}
+````
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run scripts/agent/tests/diff-filter.test.ts`
+Expected: PASS (all `truncatePatch` and `buildDiffBlock` cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/agent/lib/diff-filter.ts scripts/agent/tests/diff-filter.test.ts
+git commit -m "feat(agent): render noise-filtered, capped commit diff blocks"
+```
+
+---
+
+## Task 4: Widen repo scope to all owned repos (private + public)
+
+Plumbing/network change — no unit test (consistent with the codebase). Verified by typecheck here and a live API call in Task 6.
+
+**Files:**
+
+- Modify: `scripts/agent/lib/git-scan.ts:13-17` (GhRepo), `:54-68` (activeRepos)
+
+- [ ] **Step 1: Widen the `GhRepo` interface**
+
+In `scripts/agent/lib/git-scan.ts`, replace the `GhRepo` interface (lines 13-17) with:
+
+```ts
+interface GhRepo {
+  name: string
+  full_name: string
+  owner: { login: string }
+  pushed_at: string
+  private: boolean
+}
+```
+
+- [ ] **Step 2: Switch `activeRepos` to the authenticated-owner endpoint**
+
+Replace the `activeRepos` function (currently lines 54-68) with:
+
+```ts
+async function activeRepos(): Promise<string[]> {
+  // /user/repos with affiliation=owner returns the token owner's repos —
+  // private AND public — so private-repo commits come into scope. Other
+  // accounts' repos are never returned by this endpoint.
+  const url = `${GH_API}/user/repos?affiliation=owner&per_page=100&sort=pushed`
+  const res = await fetch(url, { headers: ghHeaders() })
+  if (!res.ok) {
+    console.warn(`Failed to list owned repos: ${res.status}`)
+    return []
+  }
+  const repos = (await res.json()) as GhRepo[]
+  const cutoff = Date.now() - CONFIG.scanRepoActiveDays * 86_400_000
+  return repos
+    .filter(
+      (r) => r.owner.login === CONFIG.scanRepoOrg && new Date(r.pushed_at).getTime() >= cutoff
+    )
+    .map((r) => r.full_name)
+}
+```
+
+- [ ] **Step 3: Verify compile + full suite**
+
+Run: `npm test`
+Expected: PASS (no test exercises `activeRepos`; this confirms nothing else broke).
+
+Run: `npx tsc --noEmit` (root) — Expected: no type errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/agent/lib/git-scan.ts
+git commit -m "feat(agent): scan all owned repos (private + public) via affiliation=owner"
+```
+
+---
+
+## Task 5: Render diff blocks in the blog draft prompt
+
+**Files:**
+
+- Modify: `scripts/agent/lib/draft-blog.ts:1-2` (import), `:114-120` (commits section)
+- Modify: `scripts/agent/tests/draft-blog.test.ts` (add assertion)
+
+- [ ] **Step 1: Add the failing assertion**
+
+In `scripts/agent/tests/draft-blog.test.ts`, the `buildBlogUserPrompt` test fixture now has a `patch`. Add two assertions at the end of that `it(...)` block (after the existing `expect(up).toContain('src/log.ts')`):
+
+````ts
+expect(up).toContain('```diff')
+expect(up).toContain('export const log = () => {}')
+````
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run scripts/agent/tests/draft-blog.test.ts`
+Expected: FAIL — prompt has no ` ```diff ` block yet.
+
+- [ ] **Step 3: Wire `buildDiffBlock` into the prompt**
+
+In `scripts/agent/lib/draft-blog.ts`, add the import at the top (after line 2):
+
+```ts
+import { buildDiffBlock } from './diff-filter'
+```
+
+The commits section currently reads (around lines 114-120):
+
+```ts
+if (input.commits.length) {
+  lines.push('## Recent commits (context)')
+  for (const c of input.commits) {
+    lines.push(
+      `- \`${c.repo}@${c.sha.slice(0, 7)}\` (${c.date.slice(0, 10)}) — ${c.message.split('\n')[0]}`
+    )
+    if (c.filesChanged.length) lines.push(`  files: ${c.filesChanged.slice(0, 5).join(', ')}`)
+  }
+  lines.push('')
+}
+```
+
+Append a diffs section immediately after that `if` block (before the `Today's date` line):
+
+```ts
+if (input.commits.length) {
+  lines.push('## Diffs of referenced commits')
+  lines.push('')
+  for (const c of input.commits) {
+    lines.push(buildDiffBlock(c))
+    lines.push('')
+  }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npx vitest run scripts/agent/tests/draft-blog.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `npm test`
+Expected: PASS (all suites).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/agent/lib/draft-blog.ts scripts/agent/tests/draft-blog.test.ts
+git commit -m "feat(agent): include commit diffs in blog draft prompt"
+```
+
+---
+
+## Task 6: Final verification + live private-repo check
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full suite + typecheck**
+
+Run: `npm test`
+Expected: PASS — every suite green.
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 2: Lint/format**
+
+Run: `npx prettier --check scripts/agent`
+Expected: all matched files use Prettier code style. (If it reports unformatted files, run `npx prettier --write scripts/agent` and amend the last commit.)
+
+- [ ] **Step 3: Live private-repo read (confirms the widened PAT works)**
+
+This proves the `AGENT_GH_TOKEN` scope reaches private repos. Replace `<PRIVATE_REPO>` with a real private repo name owned by the account. Using the local token from `.env.local`:
+
+```bash
+source scripts/agent/../../.env.local 2>/dev/null || source .env.local
+curl -s -o /dev/null -w "%{http_code}\n" \
+  -H "Authorization: Bearer $AGENT_GH_TOKEN" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "https://api.github.com/repos/shariqh/<PRIVATE_REPO>/commits?per_page=1"
+```
+
+Expected: `200`. A `404` means the PAT still lacks Contents/Metadata read on that repo — fix the PAT scope before relying on private-repo coverage. (This is the only step that can't be verified from code alone.)
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+git push -u origin agent/commit-diffs
+gh pr create --title "Agent: commit diffs + private-repo scope" \
+  --body "Implements docs/superpowers/specs/2026-06-04-agent-commit-diffs-and-private-repos-design.md. Drafting now attaches noise-filtered, size-capped diffs of cited commits; repo scope widened to all owned repos (private + public). Discovery unchanged."
+```
+
+The `ai-code-review` and `vale` workflows run on the PR. Address any HIGH findings before merge.
+
+---
+
+## Notes for the implementer
+
+- **Node 22 / native `fetch`:** `git-scan.ts` uses global `fetch` — no import needed.
+- **`Date.now()` is fine here:** these are ordinary Node agent scripts, not a Workflow script, so date/random restrictions don't apply.
+- **Don't touch `discover.ts`:** it consumes a structural subtype of `CommitInfo` (no `files`), so the added field is transparent to it. Adding diffs to discovery is explicitly out of scope (token cost).
+- **`filesChanged` stays capped at 10 names** to preserve the exact discovery prompt behavior; only `files` (full, with patches) is new.

--- a/docs/superpowers/specs/2026-06-04-agent-commit-diffs-and-private-repos-design.md
+++ b/docs/superpowers/specs/2026-06-04-agent-commit-diffs-and-private-repos-design.md
@@ -1,0 +1,175 @@
+# Commit diffs + private-repo scope for the drafting agent
+
+**Date:** 2026-06-04
+**Status:** Approved (design)
+**Builds on:** `2026-06-02-plan-b-ai-drafting-agent-design.md`
+
+## Problem
+
+When the drafting agent (`agent-draft`) writes a blog post from a Notion
+`Stage=Ready` row, it can attach context from GitHub commits the row cites in
+its **Source URLs**. Today that context is impoverished in two ways:
+
+1. **It throws away the diff.** The `/commits/{sha}` GitHub API call the agent
+   already makes returns a `patch` (unified diff) per file. `fetchFiles` in
+   `lib/git-scan.ts` keeps only `filename` and discards `patch`. The agent
+   therefore sees _which_ files changed (headline + filenames), never _what_
+   changed. The substance has to be hand-written into the row's Hint.
+
+2. **It can't see private repos.** Repo scope is built from public repos only
+   (`/users/shariqh/repos?type=public`, with `!private` filtered out), so a
+   commit in a private repo never matches a Source URL and never contributes
+   context.
+
+This makes the 7-day commit window feel lossy: a change not written up quickly
+loses its auto-pulled context. Passing real (filtered) diffs and covering
+private repos makes commit-sourced drafts substantially richer.
+
+## Goals
+
+- Drafting reads the **actual diff** of the commits a Ready row references,
+  filtered for noise and size-capped.
+- Repo scope covers **all repos owned by the token account** (`shariqh`),
+  private and public, recently pushed — and _only_ those (never other
+  accounts' public repos).
+- **Discovery is unchanged.** It keeps using commit headline + filenames; full
+  diffs are not fed into discovery (decision below).
+
+## Non-goals (YAGNI)
+
+- No diffs in discovery. Discovery scans up to ~40 commits; full diffs there
+  would balloon the nightly prompt and token cost, mostly on commits that never
+  become drafts. Confirmed: drafting-only.
+- No per-repo or per-row overrides for the noise list, diff caps, or repo
+  scope. One global denylist + two global caps. Confirmed.
+- No reading of PR objects (descriptions, review threads) or open/unmerged PRs.
+  The source remains the commit list on the default branch; merged PRs surface
+  as commits there.
+- No diff fetching for commits a Ready row does **not** reference.
+
+## Design
+
+Three units, each with one job.
+
+### 1. Diff capture — `lib/git-scan.ts`
+
+Stop discarding `patch`. No new API calls; the data is already in the response
+we pay for.
+
+- `fetchFiles(repo, sha)` returns `CommitFile[]` instead of `string[]`, where:
+  ```ts
+  interface CommitFile {
+    filename: string
+    status: string // "added" | "modified" | "removed" | "renamed" | ...
+    additions: number
+    deletions: number
+    patch?: string // absent for binary / too-large files (expected)
+  }
+  ```
+- `CommitInfo` gains `files: CommitFile[]`. The existing
+  `filesChanged: string[]` field stays, derived as `files.map(f => f.filename)`,
+  so **`discover.ts` and its prompt are untouched**.
+
+### 2. Noise filter — `lib/diff-filter.ts` (new)
+
+Pure functions, unit-tested in isolation. Exposes:
+
+- `NOISE_PATTERNS: string[]` — single exported array; amending is a one-line
+  edit. Covers:
+  - Lockfiles: `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`,
+    `bun.lockb`, `Cargo.lock`, `poetry.lock`, `Pipfile.lock`,
+    `composer.lock`, `Gemfile.lock`, `go.sum`, `flake.lock`
+  - Generated/build dirs: `dist/`, `build/`, `out/`, `.next/`, `.astro/`,
+    `coverage/`, `node_modules/`, `vendor/`
+  - Minified & maps: `*.min.js`, `*.min.css`, `*.map`
+  - Snapshots: `__snapshots__/`, `*.snap`
+  - Binary/media by extension: images, fonts, video, archives, `.pdf`
+- `isNoiseFile(filename): boolean`
+- `buildDiffBlock(commit, opts): string` — renders the prompt fragment:
+  - Drops noise files from the diff but **counts** them, e.g.
+    `+ 2 lockfile/generated changes omitted` (never silently hidden).
+  - Per-file patch truncated at `MAX_PATCH_LINES` (~150) →
+    `… (N more lines truncated)`.
+  - Per-commit signal-diff budget `MAX_DIFF_BYTES` (~16 KB): include files
+    until the budget is hit; note the remainder omitted.
+  - Files with no `patch` (binary) are listed by name + status, no diff body.
+
+`MAX_PATCH_LINES` and `MAX_DIFF_BYTES` are module constants — tunable.
+
+### 3. Prompt wiring + private-repo scope
+
+**`lib/draft-blog.ts`** — `buildBlogUserPrompt` renders, for each referenced
+commit, a fenced ` ```diff ` block via `buildDiffBlock`. Only commits cited in
+the row's Source URLs get diffs (typically 1–3), so the prompt stays focused.
+The existing "Recent commits (context)" headline list is kept; the diff blocks
+augment it.
+
+**`lib/git-scan.ts` `activeRepos()`** — switch the listing from the public-only
+user endpoint to the authenticated-owner endpoint:
+
+- `GET /user/repos?affiliation=owner&per_page=100&sort=pushed`
+- Filter to `owner.login === CONFIG.scanRepoOrg` (belt-and-suspenders; the
+  endpoint already returns only owned repos) and `pushed_at` within
+  `CONFIG.scanRepoActiveDays`.
+- Drop the `!private` exclusion.
+
+The always-on `CONFIG.scanRepoInclude` list is retained as a safety net for
+repos not pushed within the active-days window.
+
+#### Token prerequisite (operator action — already done)
+
+`AGENT_GH_TOKEN` (fine-grained PAT) must grant **Contents: Read** +
+**Metadata: Read**. The operator has set it to **All repositories**. The code
+change is inert without this. Post-change verification: a live API call against
+a known private repo's commit list must return 200 before we trust the scope.
+
+## Data flow (drafting, after change)
+
+```
+Ready row ──┐
+            │ Source URLs cite commit URLs (.../commit/<sha>)
+            ▼
+recentCommits(7)  ── /user/repos?affiliation=owner → in-scope repos (priv+pub)
+            │           └─ per repo: /commits?since=7d → /commits/{sha} (w/ patch)
+            ▼
+draftBlogRow: match cited SHAs → commits[]
+            ▼
+buildBlogUserPrompt → buildDiffBlock(commit) per cited commit
+            │   ├─ drop noise files (counted)
+            │   ├─ truncate per-file patch
+            │   └─ cap per-commit diff bytes
+            ▼
+Claude prompt: headline list + fenced diff blocks
+```
+
+## Error handling
+
+- Binary / too-large files: `patch` absent → list filename + status, no body
+  (already handled by the optional `patch` field).
+- A commit with _only_ noise files: diff block shows just the omitted-count
+  line; no empty fence.
+- Private-repo fetch failure (token lacks access): existing per-repo
+  `try/catch` in `recentCommits` logs a warning and skips — drafting still
+  proceeds with whatever it could fetch. Surfaced in CI logs.
+- Over-budget commit: included files until budget, explicit
+  `… (M more files omitted)` note — never silent truncation.
+
+## Testing
+
+Unit tests (`scripts/agent/tests/`) for `diff-filter.ts` only — pure functions:
+
+- `isNoiseFile`: lockfile/min.js/snapshot/image → `true`; `.ts`/`.astro`/`.md`
+  → `false`.
+- `buildDiffBlock`: noise files excluded but counted; per-file truncation past
+  `MAX_PATCH_LINES`; per-commit budget overflow drops trailing files with a
+  note; binary (no `patch`) listed without body.
+
+The network code in `git-scan.ts` stays thin and untested, consistent with the
+current codebase.
+
+## Rollout
+
+1. Land code change (this branch → PR).
+2. Operator confirms `AGENT_GH_TOKEN` scope (done: All repositories).
+3. Verify private-repo read with a live API call before merge.
+4. Next `agent-draft` run picks it up automatically — no workflow edits needed.

--- a/scripts/agent/lib/diff-filter.ts
+++ b/scripts/agent/lib/diff-filter.ts
@@ -1,0 +1,35 @@
+// scripts/agent/lib/diff-filter.ts
+// Pure helpers for turning a commit's file list into a prompt-sized, noise-free
+// diff block. No I/O — unit-tested in isolation.
+
+// Files whose diffs add no editorial signal. Add a pattern here to exclude more.
+export const NOISE_PATTERNS: RegExp[] = [
+  // lockfiles
+  /(^|\/)package-lock\.json$/,
+  /(^|\/)pnpm-lock\.yaml$/,
+  /(^|\/)yarn\.lock$/,
+  /(^|\/)bun\.lockb$/,
+  /(^|\/)Cargo\.lock$/,
+  /(^|\/)poetry\.lock$/,
+  /(^|\/)Pipfile\.lock$/,
+  /(^|\/)composer\.lock$/,
+  /(^|\/)Gemfile\.lock$/,
+  /(^|\/)go\.sum$/,
+  /(^|\/)flake\.lock$/,
+  // generated / build output
+  /(^|\/)(dist|build|out|coverage|node_modules|vendor)\//,
+  /(^|\/)\.next\//,
+  /(^|\/)\.astro\//,
+  // minified & sourcemaps
+  /\.min\.(js|css)$/,
+  /\.map$/,
+  // test snapshots
+  /(^|\/)__snapshots__\//,
+  /\.snap$/,
+  // binary / media
+  /\.(png|jpe?g|gif|webp|ico|svg|pdf|woff2?|ttf|eot|mp4|mov|zip|gz|tgz)$/i,
+]
+
+export function isNoiseFile(filename: string): boolean {
+  return NOISE_PATTERNS.some((re) => re.test(filename))
+}

--- a/scripts/agent/lib/diff-filter.ts
+++ b/scripts/agent/lib/diff-filter.ts
@@ -2,6 +2,8 @@
 // Pure helpers for turning a commit's file list into a prompt-sized, noise-free
 // diff block. No I/O — unit-tested in isolation.
 
+import type { CommitInfo } from './types'
+
 // Files whose diffs add no editorial signal. Add a pattern here to exclude more.
 export const NOISE_PATTERNS: RegExp[] = [
   // lockfiles
@@ -32,4 +34,70 @@ export const NOISE_PATTERNS: RegExp[] = [
 
 export function isNoiseFile(filename: string): boolean {
   return NOISE_PATTERNS.some((re) => re.test(filename))
+}
+
+// Caps keep one large refactor from blowing the prompt. Tunable.
+const MAX_PATCH_LINES = 150
+const MAX_DIFF_BYTES = 16_000
+
+export interface DiffBlockOptions {
+  maxPatchLines?: number
+  maxDiffBytes?: number
+}
+
+export function truncatePatch(
+  patch: string,
+  maxLines: number
+): { text: string; truncated: number } {
+  const lines = patch.split('\n')
+  if (lines.length <= maxLines) return { text: patch, truncated: 0 }
+  return { text: lines.slice(0, maxLines).join('\n'), truncated: lines.length - maxLines }
+}
+
+/**
+ * Render one commit's reviewable diff as a prompt fragment: a labelled, fenced
+ * `diff` block of signal files only, with noise/over-budget omissions stated
+ * explicitly (never silently hidden).
+ */
+export function buildDiffBlock(commit: CommitInfo, opts: DiffBlockOptions = {}): string {
+  const maxPatchLines = opts.maxPatchLines ?? MAX_PATCH_LINES
+  const maxDiffBytes = opts.maxDiffBytes ?? MAX_DIFF_BYTES
+  const subject = commit.message.split('\n')[0]
+  const header = `### ${commit.repo}@${commit.sha.slice(0, 7)} — ${subject}`
+
+  const noiseCount = commit.files.filter((f) => isNoiseFile(f.filename)).length
+  const signal = commit.files.filter((f) => !isNoiseFile(f.filename))
+  const noiseNote = noiseCount > 0 ? `_${noiseCount} lockfile/generated change(s) omitted_` : ''
+
+  if (signal.length === 0) {
+    return `${header}\n${noiseNote || '_no reviewable changes_'}`
+  }
+
+  const parts: string[] = []
+  let bytes = 0
+  let included = 0
+  for (const f of signal) {
+    const label = `# ${f.filename} (${f.status}, +${f.additions} -${f.deletions})`
+    let body: string
+    if (!f.patch) {
+      body = `${label}\n(binary or no inline diff)`
+    } else {
+      const { text, truncated } = truncatePatch(f.patch, maxPatchLines)
+      body = `${label}\n${text}${truncated ? `\n… (${truncated} more lines truncated)` : ''}`
+    }
+    // Always include at least one file, then stop once the budget is exceeded.
+    if (included > 0 && bytes + body.length > maxDiffBytes) break
+    parts.push(body)
+    bytes += body.length
+    included++
+  }
+
+  const filesOmitted = signal.length - included
+  const omittedNote =
+    filesOmitted > 0 ? `\n… (${filesOmitted} more file(s) omitted for length)` : ''
+
+  const lines = [header]
+  if (noiseNote) lines.push(noiseNote)
+  lines.push('```diff', parts.join('\n'), '```')
+  return lines.join('\n') + omittedNote
 }

--- a/scripts/agent/lib/draft-blog.ts
+++ b/scripts/agent/lib/draft-blog.ts
@@ -1,5 +1,6 @@
 import { BUCKETS } from './bucket'
 import type { CommitInfo } from './types'
+import { buildDiffBlock } from './diff-filter'
 
 export function slugify(title: string): string {
   return title
@@ -117,6 +118,15 @@ export function buildBlogUserPrompt(input: BlogUserPromptInput): string {
       if (c.filesChanged.length) lines.push(`  files: ${c.filesChanged.slice(0, 5).join(', ')}`)
     }
     lines.push('')
+  }
+
+  if (input.commits.length) {
+    lines.push('## Diffs of referenced commits')
+    lines.push('')
+    for (const c of input.commits) {
+      lines.push(buildDiffBlock(c))
+      lines.push('')
+    }
   }
 
   lines.push(`Today's date: ${new Date().toISOString().slice(0, 10)}`)

--- a/scripts/agent/lib/draft-blog.ts
+++ b/scripts/agent/lib/draft-blog.ts
@@ -2,6 +2,10 @@ import { BUCKETS } from './bucket'
 import type { CommitInfo } from './types'
 import { buildDiffBlock } from './diff-filter'
 
+// Max number of cited commits to render full diffs for in one draft prompt.
+// Per-commit size is already capped in diff-filter; this bounds the count.
+const MAX_DIFF_COMMITS = 8
+
 export function slugify(title: string): string {
   return title
     .toLowerCase()
@@ -123,8 +127,16 @@ export function buildBlogUserPrompt(input: BlogUserPromptInput): string {
   if (input.commits.length) {
     lines.push('## Diffs of referenced commits')
     lines.push('')
-    for (const c of input.commits) {
+    // buildDiffBlock caps size per commit; cap the COUNT here so a row citing
+    // many commits can't balloon the prompt. Realistic rows cite 1–3.
+    const diffCommits = input.commits.slice(0, MAX_DIFF_COMMITS)
+    for (const c of diffCommits) {
       lines.push(buildDiffBlock(c))
+      lines.push('')
+    }
+    const overflow = input.commits.length - diffCommits.length
+    if (overflow > 0) {
+      lines.push(`_(${overflow} more referenced commit(s) omitted from diffs for length)_`)
       lines.push('')
     }
   }

--- a/scripts/agent/lib/git-scan.ts
+++ b/scripts/agent/lib/git-scan.ts
@@ -1,6 +1,6 @@
 // scripts/agent/lib/git-scan.ts
 import { CONFIG } from './config'
-import type { CommitInfo } from './types'
+import type { CommitInfo, CommitFile } from './types'
 
 interface GhCommit {
   sha: string
@@ -10,6 +10,10 @@ interface GhCommit {
 
 interface GhCommitFile {
   filename: string
+  status: string
+  additions: number
+  deletions: number
+  patch?: string
 }
 
 interface GhRepo {
@@ -82,17 +86,27 @@ async function fetchCommits(repo: string, sinceISO: string): Promise<CommitInfo[
       sha: c.sha,
       message: c.commit.message,
       date: c.commit.author.date,
-      filesChanged: files.slice(0, 10),
+      files,
+      filesChanged: files.map((f) => f.filename).slice(0, 10),
       url: c.html_url,
     })
   }
   return results
 }
 
-async function fetchFiles(repo: string, sha: string): Promise<string[]> {
+async function fetchFiles(repo: string, sha: string): Promise<CommitFile[]> {
   const url = `${GH_API}/repos/${repo}/commits/${sha}`
   const res = await fetch(url, { headers: ghHeaders() })
-  if (!res.ok) return []
+  if (!res.ok) {
+    console.warn(`Failed to fetch files for ${repo}@${sha}: ${res.status}`)
+    return []
+  }
   const data = (await res.json()) as { files?: GhCommitFile[] }
-  return (data.files ?? []).map((f) => f.filename)
+  return (data.files ?? []).map((f) => ({
+    filename: f.filename,
+    status: f.status,
+    additions: f.additions,
+    deletions: f.deletions,
+    patch: f.patch,
+  }))
 }

--- a/scripts/agent/lib/git-scan.ts
+++ b/scripts/agent/lib/git-scan.ts
@@ -18,6 +18,8 @@ interface GhCommitFile {
 
 interface GhRepo {
   name: string
+  full_name: string
+  owner: { login: string }
   pushed_at: string
   private: boolean
 }
@@ -60,17 +62,22 @@ async function reposInScope(): Promise<string[]> {
 }
 
 async function activeRepos(): Promise<string[]> {
-  const url = `${GH_API}/users/${CONFIG.scanRepoOrg}/repos?per_page=100&sort=pushed&type=public`
+  // /user/repos with affiliation=owner returns the token owner's repos —
+  // private AND public — so private-repo commits come into scope. Other
+  // accounts' repos are never returned by this endpoint.
+  const url = `${GH_API}/user/repos?affiliation=owner&per_page=100&sort=pushed`
   const res = await fetch(url, { headers: ghHeaders() })
   if (!res.ok) {
-    console.warn(`Failed to list ${CONFIG.scanRepoOrg} repos: ${res.status}`)
+    console.warn(`Failed to list owned repos: ${res.status}`)
     return []
   }
   const repos = (await res.json()) as GhRepo[]
   const cutoff = Date.now() - CONFIG.scanRepoActiveDays * 86_400_000
   return repos
-    .filter((r) => !r.private && new Date(r.pushed_at).getTime() >= cutoff)
-    .map((r) => `${CONFIG.scanRepoOrg}/${r.name}`)
+    .filter(
+      (r) => r.owner.login === CONFIG.scanRepoOrg && new Date(r.pushed_at).getTime() >= cutoff
+    )
+    .map((r) => r.full_name)
 }
 
 async function fetchCommits(repo: string, sinceISO: string): Promise<CommitInfo[]> {

--- a/scripts/agent/lib/types.ts
+++ b/scripts/agent/lib/types.ts
@@ -66,12 +66,21 @@ export interface YTScriptBlocks {
   hashtags: string[]
 }
 
+export interface CommitFile {
+  filename: string
+  status: string // "added" | "modified" | "removed" | "renamed" | ...
+  additions: number
+  deletions: number
+  patch?: string // absent for binary / too-large files
+}
+
 export interface CommitInfo {
   repo: string // e.g. "shariqh/lognote"
   sha: string
   message: string
   date: string
-  filesChanged: string[]
+  files: CommitFile[] // full list, with diffs — used for drafting diff blocks
+  filesChanged: string[] // names only, capped — used by discovery (unchanged)
   url: string
 }
 

--- a/scripts/agent/tests/diff-filter.test.ts
+++ b/scripts/agent/tests/diff-filter.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { isNoiseFile } from '../lib/diff-filter'
+
+describe('isNoiseFile', () => {
+  it.each([
+    'package-lock.json',
+    'apps/web/pnpm-lock.yaml',
+    'go.sum',
+    'dist/index.js',
+    'src/.next/build-manifest.json',
+    'app/styles.min.css',
+    'bundle.js.map',
+    'src/__snapshots__/foo.snap',
+    'public/logo.png',
+    'assets/font.woff2',
+  ])('treats %s as noise', (f) => {
+    expect(isNoiseFile(f)).toBe(true)
+  })
+
+  it.each(['src/log.ts', 'src/pages/index.astro', 'README.md', 'lib/auth.ts', 'styles/global.css'])(
+    'treats %s as signal',
+    (f) => {
+      expect(isNoiseFile(f)).toBe(false)
+    }
+  )
+})

--- a/scripts/agent/tests/diff-filter.test.ts
+++ b/scripts/agent/tests/diff-filter.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { isNoiseFile } from '../lib/diff-filter'
+import { truncatePatch, buildDiffBlock } from '../lib/diff-filter'
+import type { CommitInfo } from '../lib/types'
 
 describe('isNoiseFile', () => {
   it.each([
@@ -23,4 +25,138 @@ describe('isNoiseFile', () => {
       expect(isNoiseFile(f)).toBe(false)
     }
   )
+})
+
+function commit(files: CommitInfo['files']): CommitInfo {
+  return {
+    repo: 'shariqh/lognote',
+    sha: 'abcdef1234567890',
+    message: 'feat: thing\n\nbody',
+    date: '2026-06-01T00:00:00Z',
+    files,
+    filesChanged: files.map((f) => f.filename),
+    url: 'https://github.com/shariqh/lognote/commit/abcdef1',
+  }
+}
+
+describe('truncatePatch', () => {
+  it('returns patch unchanged when under the line cap', () => {
+    const { text, truncated } = truncatePatch('a\nb\nc', 10)
+    expect(text).toBe('a\nb\nc')
+    expect(truncated).toBe(0)
+  })
+
+  it('truncates and reports dropped line count', () => {
+    const { text, truncated } = truncatePatch('a\nb\nc\nd\ne', 2)
+    expect(text).toBe('a\nb')
+    expect(truncated).toBe(3)
+  })
+
+  it('does not truncate when the line count equals the cap', () => {
+    const { text, truncated } = truncatePatch('a\nb\nc', 3)
+    expect(text).toBe('a\nb\nc')
+    expect(truncated).toBe(0)
+  })
+})
+
+describe('buildDiffBlock', () => {
+  it('renders a fenced diff with the commit subject', () => {
+    const block = buildDiffBlock(
+      commit([
+        {
+          filename: 'src/log.ts',
+          status: 'modified',
+          additions: 2,
+          deletions: 1,
+          patch: '@@ x @@\n+a\n-b',
+        },
+      ])
+    )
+    expect(block).toContain('shariqh/lognote@abcdef1')
+    expect(block).toContain('feat: thing')
+    expect(block).toContain('```diff')
+    expect(block).toContain('+a')
+    expect(block).toContain('src/log.ts')
+  })
+
+  it('omits noise files but counts them', () => {
+    const block = buildDiffBlock(
+      commit([
+        {
+          filename: 'src/log.ts',
+          status: 'modified',
+          additions: 1,
+          deletions: 0,
+          patch: '@@ @@\n+a',
+        },
+        {
+          filename: 'package-lock.json',
+          status: 'modified',
+          additions: 999,
+          deletions: 0,
+          patch: '@@ @@\n+noise',
+        },
+      ])
+    )
+    expect(block).toContain('1 lockfile/generated')
+    expect(block).not.toContain('+noise')
+    expect(block.indexOf('lockfile/generated')).toBeLessThan(block.indexOf('```diff'))
+  })
+
+  it('shows no fence when every file is noise', () => {
+    const block = buildDiffBlock(
+      commit([
+        {
+          filename: 'package-lock.json',
+          status: 'modified',
+          additions: 9,
+          deletions: 0,
+          patch: '@@ @@\n+x',
+        },
+      ])
+    )
+    expect(block).not.toContain('```diff')
+    expect(block).toContain('1 lockfile/generated')
+  })
+
+  it('truncates an oversized per-file patch', () => {
+    const big = Array.from({ length: 50 }, (_, i) => `+line${i}`).join('\n')
+    const block = buildDiffBlock(
+      commit([
+        { filename: 'src/big.ts', status: 'modified', additions: 50, deletions: 0, patch: big },
+      ]),
+      { maxPatchLines: 5 }
+    )
+    expect(block).toContain('more lines truncated')
+    expect(block).not.toContain('+line49')
+  })
+
+  it('drops trailing files past the byte budget with a note', () => {
+    const body = 'x'.repeat(200)
+    const block = buildDiffBlock(
+      commit([
+        { filename: 'a.ts', status: 'modified', additions: 1, deletions: 0, patch: body },
+        { filename: 'b.ts', status: 'modified', additions: 1, deletions: 0, patch: body },
+        { filename: 'c.ts', status: 'modified', additions: 1, deletions: 0, patch: body },
+      ]),
+      { maxDiffBytes: 250 }
+    )
+    expect(block).toContain('a.ts')
+    expect(block).toContain('more file(s) omitted')
+  })
+
+  it('lists a binary file without a diff body', () => {
+    const block = buildDiffBlock(
+      commit([{ filename: 'src/data.bin', status: 'added', additions: 0, deletions: 0 }])
+    )
+    expect(block).toContain('src/data.bin')
+    expect(block).toContain('binary or no inline diff')
+  })
+
+  it('reports no reviewable changes for an empty commit', () => {
+    const block = buildDiffBlock(commit([]))
+    expect(block).toContain('shariqh/lognote@abcdef1')
+    expect(block).toContain('no reviewable changes')
+    expect(block).not.toContain('```diff')
+  })
 })

--- a/scripts/agent/tests/draft-blog.test.ts
+++ b/scripts/agent/tests/draft-blog.test.ts
@@ -63,5 +63,7 @@ describe('buildBlogUserPrompt', () => {
     expect(up).toContain('https://x.com')
     expect(up).toContain('feat: add logging')
     expect(up).toContain('src/log.ts')
+    expect(up).toContain('```diff')
+    expect(up).toContain('export const log = () => {}')
   })
 })

--- a/scripts/agent/tests/draft-blog.test.ts
+++ b/scripts/agent/tests/draft-blog.test.ts
@@ -66,4 +66,34 @@ describe('buildBlogUserPrompt', () => {
     expect(up).toContain('```diff')
     expect(up).toContain('export const log = () => {}')
   })
+
+  it('caps the number of commits rendered as diffs and notes the overflow', () => {
+    const commits = Array.from({ length: 10 }, (_, i) => ({
+      repo: 'shariqh/lognote',
+      sha: `${i}`.repeat(40),
+      message: `feat: change ${i}`,
+      date: '2026-06-01T00:00:00Z',
+      files: [
+        {
+          filename: `src/f${i}.ts`,
+          status: 'modified',
+          additions: 1,
+          deletions: 0,
+          patch: `@@ @@\n+x${i}`,
+        },
+      ],
+      filesChanged: [`src/f${i}.ts`],
+      url: `https://github.com/shariqh/lognote/commit/${i}`,
+    }))
+    const up = buildBlogUserPrompt({
+      title: 'A post',
+      hint: '',
+      sourceUrls: [],
+      tags: [],
+      commits,
+    })
+    // 10 cited, cap is 8 → 8 diff fences + a "2 more ... omitted" note.
+    expect(up.match(/```diff/g)?.length).toBe(8)
+    expect(up).toContain('2 more referenced commit(s) omitted from diffs for length')
+  })
 })

--- a/scripts/agent/tests/draft-blog.test.ts
+++ b/scripts/agent/tests/draft-blog.test.ts
@@ -44,6 +44,15 @@ describe('buildBlogUserPrompt', () => {
           sha: 'abc1234567890def1234567890def1234567890',
           message: 'feat: add logging',
           date: '2026-06-01T00:00:00Z',
+          files: [
+            {
+              filename: 'src/log.ts',
+              status: 'added',
+              additions: 10,
+              deletions: 0,
+              patch: '@@ -0,0 +1,2 @@\n+export const log = () => {}\n',
+            },
+          ],
           filesChanged: ['src/log.ts'],
           url: 'https://github.com/shariqh/lognote/commit/abc',
         },


### PR DESCRIPTION
## Summary
- The drafting agent now attaches **real commit diffs** (not just filenames) to a blog draft's prompt for the commits a Ready row cites — noise-filtered (lockfiles, build output, minified, snapshots, binaries) and size-capped (per-file line cap, per-commit byte budget, and a global cap on how many commits get diffs).
- Repo scope widened from public-only to **all repos owned by the token account** (private + public) via `/user/repos?affiliation=owner`; never reaches other accounts' repos. Validated live against private `shariqh/lognote`.
- New pure module `scripts/agent/lib/diff-filter.ts` (`NOISE_PATTERNS`, `isNoiseFile`, `truncatePatch`, `buildDiffBlock`), fully unit-tested. Discovery is intentionally untouched (still headline + filenames; diffs are drafting-only).

Spec: `docs/superpowers/specs/2026-06-04-agent-commit-diffs-and-private-repos-design.md`
Plan: `docs/superpowers/plans/2026-06-04-agent-commit-diffs.md`

## Test Plan
- [x] `npm test` — 76/76 green
- [x] `npx tsc --noEmit` — clean
- [x] Live check: widened PAT reads private `shariqh/lognote` commits (200) and the `affiliation=owner` listing returns it
- [ ] ai-code-review (Copilot) + vale workflows pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)