### PR TITLE
feat: add GoatCounter analytics site-wide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Static Astro 6 + TypeScript + Tailwind 4 site. Content lives as MDX in
 `src/content/writing/`, validated by Astro Content Collections (Zod schema
 in `src/content.config.ts`). Hosted on Cloudflare Pages (DNS also on
-Cloudflare). No analytics, no comments — engagement routes to email / X
+Cloudflare). Privacy-friendly analytics via GoatCounter (no cookies/PII,
+loaded in `BaseLayout.astro`); no comments — engagement routes to email / X
 via the footer.
 
 ### Content pipeline

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -31,6 +31,15 @@ const canonical = new URL(Astro.url.pathname, SITE.url).toString();
     <meta property="og:description" content={description} />
     <meta property="og:type" content="website" />
     <meta property="og:url" content={canonical} />
+
+    <!-- GoatCounter — privacy-friendly analytics (no cookies, no PII).
+         count.js auto-skips localhost, so no prod-only guard is needed. -->
+    <script
+      is:inline
+      data-goatcounter="https://shariq-blog.goatcounter.com/count"
+      async
+      src="//gc.zgo.at/count.js"></script>
+
     <script is:inline>
       // Apply theme before first paint to avoid FOUC.
       (function () {


### PR DESCRIPTION
## Summary
Adds privacy-friendly [GoatCounter](https://shariq-blog.goatcounter.com) analytics (no cookies, no PII) to the shared `BaseLayout.astro`, so it loads on **every page** — verified present on 19/19 built HTML pages (home, about, projects, 404, all blog posts).

- `is:inline` so Astro emits the exact snippet verbatim (preserves `data-goatcounter`, `async`, protocol-relative src)
- `count.js` auto-skips `localhost`, so local dev isn't counted (matches lognote's setup; no prod-only guard needed)
- Updated the now-stale "No analytics" line in `CLAUDE.md`

Endpoint: `https://shariq-blog.goatcounter.com/count`

## Test Plan
- [x] `npm run build` — clean, 19 pages
- [x] Snippet present on 19/19 built HTML pages
- [x] `npm run astro check` — clean
- [ ] After deploy: confirm a hit registers in the GoatCounter dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)