### PR TITLE
fix(seo): emit external rel=canonical for cross-posts + fix 2 bad URLs

### DIFF
--- a/src/content/writing/be-shamelessly-cutting-edge.mdx
+++ b/src/content/writing/be-shamelessly-cutting-edge.mdx
@@ -4,7 +4,7 @@ date: '2021-08-17'
 tags: ['insights']
 draft: false
 summary: 'As a solo developer, startup, or software developer for another organization, your aim should be to operate at the bleeding edge, using chaos to your advantage.'
-canonical: 'https://www.bundleapps.io/blog/be-shamelessy-cutting-edge'
+canonical: 'https://www.bundleapps.io/blog/be-shamelessly-cutting-edge'
 hero:
   image: '/static/images/blog/be-shamelessly-cutting-edge/banner.png'
   alt: 'Be Shamelessly Cutting Edge banner'

--- a/src/content/writing/storing-and-accessing-environment-variables-in-1password.mdx
+++ b/src/content/writing/storing-and-accessing-environment-variables-in-1password.mdx
@@ -4,7 +4,7 @@ date: '2023-01-09'
 tags: ['docker', 'architecture']
 draft: true
 summary: 'Automate local secrets management and keep your credentials secure with 1Password in your development flow.'
-canonical: 'https://www.bundleapps.io/blog/nextjs-context-api-tutorial'
+canonical: 'https://www.bundleapps.io/blog/storing-and-accessing-environment-variables-in-1password'
 ---
 
 <Callout

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -11,11 +11,15 @@ import { SITE } from "../lib/site";
 interface Props {
   title?: string;
   description?: string;
+  // External canonical URL for cross-posts where this page is a COPY of content
+  // published elsewhere. Omit on original content (defaults to this page's URL).
+  canonical?: string;
 }
 
-const { title, description = SITE.description } = Astro.props;
+const { title, description = SITE.description, canonical: canonicalOverride } = Astro.props;
 const fullTitle = title ? `${title} — ${SITE.title}` : SITE.title;
-const canonical = new URL(Astro.url.pathname, SITE.url).toString();
+const pageUrl = new URL(Astro.url.pathname, SITE.url).toString();
+const canonical = canonicalOverride ?? pageUrl;
 ---
 <!doctype html>
 <html lang="en">
@@ -30,7 +34,7 @@ const canonical = new URL(Astro.url.pathname, SITE.url).toString();
     <meta property="og:title" content={fullTitle} />
     <meta property="og:description" content={description} />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content={canonical} />
+    <meta property="og:url" content={pageUrl} />
 
     <!-- GoatCounter — privacy-friendly analytics (no cookies, no PII).
          count.js auto-skips localhost, so no prod-only guard is needed. -->

--- a/src/lib/schemas.test.ts
+++ b/src/lib/schemas.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { writingSchema } from './schemas'
+
+const base = { title: 'T', date: '2024-01-01', summary: 's' }
+
+describe('writingSchema canonical guard', () => {
+  it('accepts an https canonical on an allowed host', () => {
+    const r = writingSchema.safeParse({
+      ...base,
+      canonical: 'https://www.bundleapps.io/blog/x',
+    })
+    expect(r.success).toBe(true)
+  })
+
+  it('rejects a canonical on a non-allowed host (SEO-poisoning vector)', () => {
+    const r = writingSchema.safeParse({ ...base, canonical: 'https://evil.example.com/x' })
+    expect(r.success).toBe(false)
+  })
+
+  it('rejects a non-https scheme', () => {
+    const r = writingSchema.safeParse({ ...base, canonical: 'http://www.bundleapps.io/x' })
+    expect(r.success).toBe(false)
+  })
+
+  it('allows omitting canonical (original content stays self-canonical)', () => {
+    const r = writingSchema.safeParse(base)
+    expect(r.success).toBe(true)
+  })
+})

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -1,6 +1,25 @@
 import { z } from 'zod'
 
 /**
+ * Hosts we legitimately cross-post FROM — i.e. where shariq.dev carries a COPY
+ * and `rel=canonical` must point at the external original. Constraining the
+ * canonical field to these (https only) stops frontmatter from canonicalizing a
+ * page to an arbitrary domain (an SEO-poisoning vector, relevant because the
+ * drafting agent ingests untrusted external content). Adding a host here is a
+ * deliberate, reviewable change.
+ */
+export const CANONICAL_ALLOWED_HOSTS = ['www.bundleapps.io']
+
+function isAllowedCanonical(value: string): boolean {
+  try {
+    const url = new URL(value)
+    return url.protocol === 'https:' && CANONICAL_ALLOWED_HOSTS.includes(url.hostname)
+  } catch {
+    return false
+  }
+}
+
+/**
  * Zod schema for writing collection frontmatter.
  * Defined here (not in content.config.ts) so it can be imported
  * from both Astro and Node.js contexts (e.g. validate.ts).
@@ -24,5 +43,13 @@ export const writingSchema = z.object({
     .optional(),
   draft: z.boolean().default(false),
   updatedAt: z.coerce.date().optional(),
-  canonical: z.string().url().optional(),
+  canonical: z
+    .string()
+    .url()
+    .refine(isAllowedCanonical, {
+      message: `canonical must be an https URL on an allowed host (${CANONICAL_ALLOWED_HOSTS.join(
+        ', '
+      )})`,
+    })
+    .optional(),
 })

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -25,7 +25,11 @@ const readingMinutes = remarkPluginFrontmatter?.readingTime
   ? Math.ceil(remarkPluginFrontmatter.readingTime / 60)
   : undefined;
 ---
-<BaseLayout title={post.data.title} description={post.data.summary}>
+<BaseLayout
+  title={post.data.title}
+  description={post.data.summary}
+  canonical={post.data.canonical}
+>
   <article class="pb-16">
     <PostHeader
       title={post.data.title}


### PR DESCRIPTION
## Summary
Fixes [todo #62]. `BaseLayout.astro` always emitted a **self** `<link rel="canonical">`; the `canonical` frontmatter field only drove the visible "Originally published at…" callout, never the actual tag. So the bundleapps **copy-posts** were telling search engines shariq.dev is the original.

- `BaseLayout` now takes an optional `canonical` prop → emitted as `<link rel="canonical">` when set, else the page's own URL.
- `blog/[...slug].astro` passes `post.data.canonical`.
- `og:url` now always the page's own URL (OG describes *this* page; canonical names the authority).

## Data fixes (both targets verified HTTP 200)
- **1password** post pointed at the wrong original (`…/nextjs-context-api-tutorial`) — corrected to its own bundleapps URL.
- **be-shamelessly-cutting-edge** was a 404 from a `shameles`**`sy`** typo — corrected to `…/be-shamelessly-cutting-edge`.

## Verified in built HTML
| Posts | rel=canonical |
|---|---|
| 7 published bundleapps copy-posts | → their external bundleapps original ✓ |
| All native posts + lognote cross-post | → self (`shariq.dev`) ✓ |
| og:url (all pages) | → self ✓ |

## Test Plan
- [x] `npm run build` — 19 pages, grep-verified canonical per post
- [x] `npm run astro check` — clean
- [x] All 8 canonical targets return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)