### PR TITLE
Mobile polish: center portrait deck + reflow About photo strip

### DIFF
--- a/src/components/PortraitDeck.astro
+++ b/src/components/PortraitDeck.astro
@@ -86,6 +86,12 @@ const len = portraits.length;
   .carousel .dots { position: absolute; top: 100%; left: 0; right: 0; display: flex; gap: 7px; justify-content: center; margin-top: 18px; }
   .carousel .dots button { width: 7px; height: 7px; border-radius: 999px; border: 0; padding: 0; cursor: pointer; background: color-mix(in oklab, var(--fg) 22%, transparent); transition: all .2s; }
   .carousel .dots button.active { background: var(--color-terracotta); width: 20px; }
+  @media (max-width: 880px) {
+    .carousel .deck img.next  { transform: rotate(6deg)   translate(20px, -10px)  scale(.9); }
+    .carousel .deck img.prev  { transform: rotate(-6deg)  translate(-20px, -10px) scale(.9); }
+    .carousel .deck img.next2 { transform: rotate(11deg)  translate(40px, -20px)  scale(.82); }
+    .carousel .deck img.prev2 { transform: rotate(-11deg) translate(-40px, -20px) scale(.82); }
+  }
   @media (prefers-reduced-motion: reduce) {
     .carousel .deck img { transition: none; }
     .carousel .deck img:not(.front) { opacity: 0; }

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -324,7 +324,10 @@ import PageHeader from "../components/PageHeader.astro";
       gap: 32px;
     }
     .statement { font-size: 30px; }
-    .otc .card { margin-right: -40px !important; }
+    .otc .strip { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+    .otc .card { width: 100%; margin: 0 !important; transform: none !important; }
+    .otc .card .cap { opacity: 1; }
+    .otc .hint { display: none; }
   }
 
   /* reduced-motion: kill animations and reset photo card transforms */

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -117,7 +117,7 @@ const m = HOME.manifesto;
 
   @media (max-width: 880px) {
     .hero { grid-template-columns: 1fr; }
-    :global([data-deck]) { order: -1; width: 100%; max-width: 300px; align-self: start; margin-bottom: 40px; }
+    :global([data-deck]) { order: -1; width: 100%; max-width: 260px; justify-self: center; align-self: start; margin-bottom: 40px; }
     :global([data-deck] .deck) { width: 100%; }
     .tags { margin-top: 28px; padding-top: 0; }
     .hero h1 { font-size: 60px; }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -39,6 +39,7 @@
   html {
     background: var(--bg);
     color: var(--fg);
+    overflow-x: hidden;
     font-family: var(--font-sans);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
Small mobile-only fixes spotted via Playwright phone-viewport screenshots:
- **Homepage portrait deck** was left-shifted and clipping off the right on phones — now centered (`justify-self: center`) with a tighter, fitted fan on `≤880px`.
- **About "Off the clock"** photo strip reflows from the desktop overlap to a clean 2-column grid with captions visible (hover-to-straighten hint hidden on touch).
- Added `overflow-x: hidden` to clip residual fanned-card edge overflow (no horizontal scroll).

Verified at 390px viewport (home centered, About grid clean, no h-scroll on About).

🤖 Generated with [Claude Code](https://claude.com/claude-code)