### PR TITLE
Mobile: truly center the portrait deck + casual tilt on About grid

### DIFF
--- a/src/components/PortraitDeck.astro
+++ b/src/components/PortraitDeck.astro
@@ -87,6 +87,8 @@ const len = portraits.length;
   .carousel .dots button { width: 7px; height: 7px; border-radius: 999px; border: 0; padding: 0; cursor: pointer; background: color-mix(in oklab, var(--fg) 22%, transparent); transition: all .2s; }
   .carousel .dots button.active { background: var(--color-terracotta); width: 20px; }
   @media (max-width: 880px) {
+    .carousel { width: 100%; max-width: 240px; margin-left: auto; margin-right: auto; }
+    .carousel .deck { width: 100%; }
     .carousel .deck img.next  { transform: rotate(6deg)   translate(20px, -10px)  scale(.9); }
     .carousel .deck img.prev  { transform: rotate(-6deg)  translate(-20px, -10px) scale(.9); }
     .carousel .deck img.next2 { transform: rotate(11deg)  translate(40px, -20px)  scale(.82); }

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -324,8 +324,10 @@ import PageHeader from "../components/PageHeader.astro";
       gap: 32px;
     }
     .statement { font-size: 30px; }
-    .otc .strip { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
-    .otc .card { width: 100%; margin: 0 !important; transform: none !important; }
+    .otc .strip { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+    .otc .card { width: 100%; margin: 0 !important; }
+    .otc .card:nth-child(odd)  { transform: rotate(-2deg) !important; }
+    .otc .card:nth-child(even) { transform: rotate(2deg)  !important; }
     .otc .card .cap { opacity: 1; }
     .otc .hint { display: none; }
   }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -117,7 +117,7 @@ const m = HOME.manifesto;
 
   @media (max-width: 880px) {
     .hero { grid-template-columns: 1fr; }
-    :global([data-deck]) { order: -1; width: 100%; max-width: 260px; justify-self: center; align-self: start; margin-bottom: 40px; }
+    :global([data-deck]) { order: -1; margin-bottom: 40px; }
     :global([data-deck] .deck) { width: 100%; }
     .tags { margin-top: 28px; padding-top: 0; }
     .hero h1 { font-size: 60px; }


### PR DESCRIPTION
Follow-up to the mobile polish. The deck still read as shifted because PortraitDeck's own scoped `.carousel`/`.deck { width: 300px }` rules outrank the global mobile overrides in `index.astro` (Astro scoped-style specificity). Moved the mobile sizing/centering INTO `PortraitDeck.astro` so it actually wins — deck is now 240px, `margin-inline: auto`, reduced fan → dead-center on phones, no horizontal overflow.

Also gave the About "Off the clock" mobile grid a slight alternating tilt (±2°) so it reads as casually-placed photos instead of a sterile grid.

Verified at 390px (home deck centered, no h-scroll; About grid tidy with personality).

🤖 Generated with [Claude Code](https://claude.com/claude-code)