### PR TITLE
Blog polish: featured cover, post-cover margin, dark code blocks + copy button

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -22,7 +22,9 @@ export default defineConfig({
       rehypeKatex,
     ],
     shikiConfig: {
-      themes: { light: "github-light", dark: "github-dark" },
+      // Single dark theme: the site background is white, so a dark code block
+      // (vs. white-on-white with github-light) gives clear separation on-brand.
+      theme: "github-dark",
       wrap: true,
     },
   },

--- a/src/components/FeaturedCard.astro
+++ b/src/components/FeaturedCard.astro
@@ -1,12 +1,15 @@
 ---
+import { resolveCover } from "../lib/cover";
 interface Props {
   href: string;
   category: string;
   title: string;
   hook: string;
   cta?: string;
+  coverData?: { hero?: { image?: string; alt?: string }; tags?: string[] };
 }
-const { href, category, title, hook, cta = "Read it" } = Astro.props;
+const { href, category, title, hook, cta = "Read it", coverData } = Astro.props;
+const cover = coverData ? resolveCover(coverData) : null;
 ---
 <a class="featured" href={href}>
   <div class="panel">
@@ -16,15 +19,19 @@ const { href, category, title, hook, cta = "Read it" } = Astro.props;
     <span class="more"><span class="dot">→</span> {cta}</span>
   </div>
   <div class="art">
-    <svg width="230" height="180" viewBox="0 0 230 180" fill="none" stroke="var(--color-terracotta)" stroke-width="2.5">
-      <circle cx="62" cy="62" r="30"></circle>
-      <circle cx="158" cy="116" r="22" fill="var(--color-ochre)" stroke="none"></circle>
-      <path d="M30 138 q42 -52 94 -22 t76 -30" stroke="var(--color-ink)"></path>
-      <rect x="124" y="42" width="52" height="14" rx="7" fill="var(--color-ochre)" stroke="none"></rect>
-      <circle cx="42" cy="126" r="4" fill="var(--color-ink)" stroke="none"></circle>
-      <circle cx="60" cy="126" r="4" fill="var(--color-ink)" stroke="none"></circle>
-      <circle cx="78" cy="126" r="4" fill="var(--color-ink)" stroke="none"></circle>
-    </svg>
+    {cover && cover.kind === "image" ? (
+      <img class="art-img" src={cover.src} alt={cover.alt} loading="lazy" decoding="async" />
+    ) : (
+      <svg width="230" height="180" viewBox="0 0 230 180" fill="none" stroke="var(--color-terracotta)" stroke-width="2.5">
+        <circle cx="62" cy="62" r="30"></circle>
+        <circle cx="158" cy="116" r="22" fill="var(--color-ochre)" stroke="none"></circle>
+        <path d="M30 138 q42 -52 94 -22 t76 -30" stroke="var(--color-ink)"></path>
+        <rect x="124" y="42" width="52" height="14" rx="7" fill="var(--color-ochre)" stroke="none"></rect>
+        <circle cx="42" cy="126" r="4" fill="var(--color-ink)" stroke="none"></circle>
+        <circle cx="60" cy="126" r="4" fill="var(--color-ink)" stroke="none"></circle>
+        <circle cx="78" cy="126" r="4" fill="var(--color-ink)" stroke="none"></circle>
+      </svg>
+    )}
   </div>
 </a>
 
@@ -38,6 +45,7 @@ const { href, category, title, hook, cta = "Read it" } = Astro.props;
   .more .dot { width: 42px; height: 42px; border-radius: 999px; background: var(--color-ochre); color: var(--color-ink); display: grid; place-items: center; font-size: 18px; transition: transform .15s; }
   .featured:hover .more .dot { transform: translateX(4px); }
   .art { background: linear-gradient(135deg, color-mix(in oklab, var(--color-paper) 88%, var(--color-ink)), var(--color-paper)); display: grid; place-items: center; }
+  .art-img { width: 100%; height: 100%; object-fit: cover; display: block; }
   @media (prefers-reduced-motion: reduce) {
     .more .dot { transition: none; }
   }

--- a/src/components/FeaturedCard.astro
+++ b/src/components/FeaturedCard.astro
@@ -22,7 +22,7 @@ const cover = coverData ? resolveCover(coverData) : null;
     {cover && cover.kind === "image" ? (
       <img class="art-img" src={cover.src} alt={cover.alt} loading="lazy" decoding="async" />
     ) : (
-      <svg width="230" height="180" viewBox="0 0 230 180" fill="none" stroke="var(--color-terracotta)" stroke-width="2.5">
+      <svg width="230" height="180" viewBox="0 0 230 180" fill="none" stroke="var(--color-terracotta)" stroke-width="2.5" aria-hidden="true">
         <circle cx="62" cy="62" r="30"></circle>
         <circle cx="158" cy="116" r="22" fill="var(--color-ochre)" stroke="none"></circle>
         <path d="M30 138 q42 -52 94 -22 t76 -30" stroke="var(--color-ink)"></path>

--- a/src/components/Prose.astro
+++ b/src/components/Prose.astro
@@ -75,7 +75,10 @@
 
 <script>
   // Add a one-click "Copy" button to every code block in the prose.
-  for (const pre of document.querySelectorAll(".prose pre")) {
+  // Skip when the Clipboard API is unavailable (insecure contexts / old
+  // browsers) so we never inject a button that throws on click.
+  const canCopy = navigator.clipboard && navigator.clipboard.writeText;
+  if (canCopy) for (const pre of document.querySelectorAll(".prose pre")) {
     if (pre.querySelector(".copy-btn")) continue;
     const btn = document.createElement("button");
     btn.type = "button";

--- a/src/components/Prose.astro
+++ b/src/components/Prose.astro
@@ -34,11 +34,74 @@
     @apply rounded bg-[var(--bg-soft)] px-1.5 py-0.5 font-mono text-[0.9em];
   }
   .prose pre {
-    @apply my-6 overflow-x-auto rounded-lg p-4 text-sm;
+    @apply relative my-6 overflow-x-auto rounded-lg p-4 text-sm;
+    border: 1px solid color-mix(in oklab, var(--color-paper) 16%, transparent);
   }
   .prose pre code { @apply font-mono; }
+  /* One-click copy button (injected by the script below) */
+  .prose pre .copy-btn {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    line-height: 1;
+    padding: 6px 10px;
+    border-radius: 7px;
+    cursor: pointer;
+    color: var(--color-paper);
+    background: color-mix(in oklab, var(--color-paper) 12%, transparent);
+    border: 1px solid color-mix(in oklab, var(--color-paper) 24%, transparent);
+    opacity: 0.6;
+    transition: opacity 0.15s, background 0.15s, color 0.15s, border-color 0.15s;
+  }
+  .prose pre:hover .copy-btn,
+  .prose pre:focus-within .copy-btn { opacity: 1; }
+  .prose pre .copy-btn:hover,
+  .prose pre .copy-btn.copied {
+    opacity: 1;
+    background: var(--color-ochre);
+    color: var(--color-ink);
+    border-color: var(--color-ochre);
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .prose pre .copy-btn { transition: none; }
+  }
   .prose img { @apply my-6 rounded-lg; }
   .prose hr {
     @apply my-12 border-0 border-t border-[color-mix(in_oklab,var(--fg)_15%,transparent)];
   }
 </style>
+
+<script>
+  // Add a one-click "Copy" button to every code block in the prose.
+  for (const pre of document.querySelectorAll(".prose pre")) {
+    if (pre.querySelector(".copy-btn")) continue;
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "copy-btn";
+    btn.setAttribute("aria-label", "Copy code to clipboard");
+    btn.textContent = "Copy";
+    btn.addEventListener("click", () => {
+      const code = pre.querySelector("code");
+      const text = ((code && code.textContent) || "").replace(/\n$/, "");
+      navigator.clipboard
+        .writeText(text)
+        .then(() => {
+          btn.textContent = "Copied";
+          btn.classList.add("copied");
+          setTimeout(() => {
+            btn.textContent = "Copy";
+            btn.classList.remove("copied");
+          }, 1600);
+        })
+        .catch(() => {
+          btn.textContent = "Failed";
+          setTimeout(() => {
+            btn.textContent = "Copy";
+          }, 1600);
+        });
+    });
+    pre.appendChild(btn);
+  }
+</script>

--- a/src/components/Prose.astro
+++ b/src/components/Prose.astro
@@ -77,7 +77,7 @@
   // Add a one-click "Copy" button to every code block in the prose.
   // Skip when the Clipboard API is unavailable (insecure contexts / old
   // browsers) so we never inject a button that throws on click.
-  const canCopy = navigator.clipboard && navigator.clipboard.writeText;
+  const canCopy = typeof navigator.clipboard?.writeText === "function";
   if (canCopy) for (const pre of document.querySelectorAll(".prose pre")) {
     if (pre.querySelector(".copy-btn")) continue;
     const btn = document.createElement("button");

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -69,5 +69,5 @@ const ogImage = new URL(`/og/${slug}.png`, SITE.url).toString();
 </BaseLayout>
 
 <style>
-  .post-cover { aspect-ratio: 16 / 9; border-radius: 18px; overflow: hidden; margin-bottom: 32px; }
+  .post-cover { aspect-ratio: 16 / 9; border-radius: 18px; overflow: hidden; margin-top: 40px; margin-bottom: 32px; }
 </style>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -35,6 +35,7 @@ const slug = (id: string) => `/blog/${id.replace(/\.mdx$/, "")}`;
           title={featured.data.title}
           hook={featured.data.summary}
           cta="Read full article"
+          coverData={featured.data}
         />
       </div>
     )}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -52,6 +52,7 @@ const m = HOME.manifesto;
       category={`${fb.label} · Latest`}
       title={featured.data.title}
       hook={featured.data.summary}
+      coverData={featured.data}
     />
   )}
 


### PR DESCRIPTION
Three follow-up polish fixes after the OG/cover work (#46):

1. **Featured card shows the cover** — `FeaturedCard` rendered a decorative line-art SVG even though posts now have generated covers. It now renders the post's `hero` cover (via `resolveCover`, so the same `safeLocalImage` validation applies), falling back to the line-art motif for any post without one. Wired on both `/blog` and the homepage.
2. **Post cover top margin** — the cover image was flush against the header's bottom stroke; added `margin-top` so it has breathing room.
3. **Code blocks** — the page background is white and shiki's `github-light` background is also white, so code blocks blended in with no border and no copy affordance. Switched shiki to a dark theme (clear separation, on-brand), added a border, and a one-click **Copy** button (small client script in `Prose.astro`, hover/focus-revealed, reduced-motion safe).

Verified in dev with screenshots; `astro check` clean, unit tests pass, full build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)