### PR TITLE
feat(social): X thread poster (post:thread)

### DIFF
--- a/.env.social.example
+++ b/.env.social.example
@@ -1,0 +1,18 @@
+# X (Twitter) API — OAuth 1.0a user context (lets the script post on your behalf).
+#
+# One-time setup at https://developer.x.com:
+#   Project -> App -> "User authentication settings"
+#   -> enable Read and Write, OAuth 1.0a
+#   -> generate an Access Token & Secret for your own account.
+# That gives you four values: API Key, API Key Secret, Access Token, Access Secret.
+# The FREE API tier covers posting (~1,500 writes/month), so no paid plan is needed.
+#
+# Store the four values in 1Password, then copy this file to `.env.social` and point
+# each line at your 1Password fields. Run with secrets injected at runtime:
+#   op run --env-file=.env.social -- npm run post:thread -- <thread.txt> --post
+#
+# Replace the op:// paths below with your actual item/field references.
+X_API_KEY="op://dev-env-vars/X API/api_key"
+X_API_SECRET="op://dev-env-vars/X API/api_secret"
+X_ACCESS_TOKEN="op://dev-env-vars/X API/access_token"
+X_ACCESS_SECRET="op://dev-env-vars/X API/access_secret"

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ npm-debug.log*
 .env
 .env.local
 .env.*.local
+.env.social
 
 # Agent local env
 .env.local

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "prettier-plugin-astro": "^0.14.1",
         "satori": "^0.26.0",
         "tsx": "^4.22.4",
+        "twitter-api-v2": "^1.29.0",
         "typescript": "^6.0.3",
         "vitest": "^4.1.7"
       },
@@ -9475,6 +9476,13 @@
         "@esbuild/win32-ia32": "0.28.0",
         "@esbuild/win32-x64": "0.28.0"
       }
+    },
+    "node_modules/twitter-api-v2": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/twitter-api-v2/-/twitter-api-v2-1.29.0.tgz",
+      "integrity": "sha512-v473q5bwme4N+DWSg6qY+JCvfg1nSJRWwui3HUALafxfqCvVkKiYmS/5x/pVeJwTmyeBxexMbzHwnzrH4h6oYQ==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/type-is": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "gen:cover": "tsx scripts/cover/cli.ts",
     "gen:cover:all": "tsx scripts/cover/backfill.ts",
     "migrate:cms": "tsx scripts/agent/migrate-cms.ts",
+    "post:thread": "tsx scripts/social/post-thread.ts",
     "preview": "astro preview",
     "test": "vitest run",
     "test:smoke": "playwright test",
@@ -49,6 +50,7 @@
     "prettier-plugin-astro": "^0.14.1",
     "satori": "^0.26.0",
     "tsx": "^4.22.4",
+    "twitter-api-v2": "^1.29.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.7"
   }

--- a/scripts/social/README.md
+++ b/scripts/social/README.md
@@ -1,0 +1,49 @@
+# Social posting
+
+Tooling for pushing blog content out to social.
+
+## `post-thread.ts` — post an X (Twitter) thread
+
+Reads a thread from a text file and posts it as a native X thread (each tweet
+replies to the one before it).
+
+### Thread file format
+
+Plain text. Separate tweets with a line containing only `---`. Each tweet keeps
+its own line breaks. See [`threads/lognote-day-one.txt`](./threads/lognote-day-one.txt).
+
+### One-time setup
+
+1. Create an X developer app at <https://developer.x.com> (Project → App).
+2. In the app's **User authentication settings**, enable **Read and Write** and
+   **OAuth 1.0a**, then generate an **Access Token & Secret** for your account.
+   You now have four values: API Key, API Key Secret, Access Token, Access Secret.
+3. Store the four values in 1Password (e.g. an "X API" item in `dev-env-vars`).
+4. Copy `.env.social.example` to `.env.social` (gitignored) and point each line
+   at your 1Password fields (the `op://...` references).
+
+The **Free** API tier covers posting (~1,500 writes/month), so no paid plan is
+needed for threads.
+
+### Usage
+
+Dry run — preview each tweet with its character count, no credentials needed:
+
+```sh
+npm run post:thread -- scripts/social/threads/lognote-day-one.txt
+```
+
+Publish — credentials injected from 1Password at runtime:
+
+```sh
+op run --env-file=.env.social -- npm run post:thread -- scripts/social/threads/lognote-day-one.txt --post
+```
+
+Flags:
+
+- `--post` actually publishes (omit it for a dry run).
+- `--force` posts even if a tweet looks over 280. URLs count as 23 chars, so the
+  script's estimate is conservative and a link-bearing tweet may still fit.
+
+If a tweet fails mid-thread, the script stops and prints the last posted tweet's
+ID so you can finish the rest as replies to it.

--- a/scripts/social/post-thread.ts
+++ b/scripts/social/post-thread.ts
@@ -33,8 +33,10 @@ function tweetLength(text: string): number {
 function sanitize(text: string): string {
   return Array.from(text)
     .filter((c) => {
+      if (c === '\n') return true
       const code = c.codePointAt(0) ?? 0
-      return c === '\n' || (code >= 0x20 && code !== 0x7f)
+      // drop C0 (< 0x20), DEL (0x7f), and C1 (0x80-0x9f) control characters
+      return code >= 0x20 && code !== 0x7f && (code < 0x80 || code > 0x9f)
     })
     .join('')
 }

--- a/scripts/social/post-thread.ts
+++ b/scripts/social/post-thread.ts
@@ -1,0 +1,115 @@
+#!/usr/bin/env tsx
+/**
+ * Post an X (Twitter) thread from a text file.
+ *
+ * Thread file format: tweets separated by a line containing only `---`.
+ * Each tweet keeps its own internal line breaks. See threads/ for examples.
+ *
+ * Usage:
+ *   npm run post:thread -- scripts/social/threads/<file>.txt           # dry run
+ *   npm run post:thread -- scripts/social/threads/<file>.txt --post    # publish
+ *
+ * Credentials (OAuth 1.0a user context) come from env. Source them from
+ * 1Password rather than hard-coding:
+ *   op run --env-file=.env.social -- npm run post:thread -- <file> --post
+ */
+import { readFileSync } from 'node:fs'
+import { TwitterApi } from 'twitter-api-v2'
+
+const ENV_KEYS = ['X_API_KEY', 'X_API_SECRET', 'X_ACCESS_TOKEN', 'X_ACCESS_SECRET'] as const
+
+// X counts every URL as 23 chars (the t.co wrap), regardless of the real length.
+function tweetLength(text: string): number {
+  return text.replace(/https?:\/\/\S+/g, 'x'.repeat(23)).length
+}
+
+function parseThread(path: string): string[] {
+  const groups: string[][] = [[]]
+  for (const line of readFileSync(path, 'utf8').split(/\r?\n/)) {
+    if (line.trim() === '---') groups.push([])
+    else groups[groups.length - 1]!.push(line)
+  }
+  return groups.map((g) => g.join('\n').trim()).filter(Boolean)
+}
+
+function loadCreds() {
+  const missing = ENV_KEYS.filter((k) => !process.env[k])
+  if (missing.length) {
+    console.error(`\nMissing env vars: ${missing.join(', ')}`)
+    console.error('Source them from 1Password, e.g.:')
+    console.error('  op run --env-file=.env.social -- npm run post:thread -- <file> --post\n')
+    process.exit(1)
+  }
+  return {
+    appKey: process.env.X_API_KEY!,
+    appSecret: process.env.X_API_SECRET!,
+    accessToken: process.env.X_ACCESS_TOKEN!,
+    accessSecret: process.env.X_ACCESS_SECRET!,
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2)
+  const post = args.includes('--post')
+  const force = args.includes('--force')
+  const file = args.find((a) => !a.startsWith('--'))
+  if (!file) {
+    console.error('usage: post:thread <thread.txt> [--post] [--force]')
+    process.exit(1)
+  }
+
+  const tweets = parseThread(file)
+  if (!tweets.length) {
+    console.error(`No tweets parsed from ${file} (separate tweets with a line containing only "---").`)
+    process.exit(1)
+  }
+
+  let overLimit = false
+  tweets.forEach((t, i) => {
+    const len = tweetLength(t)
+    const over = len > 280
+    if (over) overLimit = true
+    console.log(`\n--- [${i + 1}/${tweets.length}] ${len}/280${over ? '  !! OVER LIMIT' : ''} ---\n${t}`)
+  })
+
+  if (overLimit && !force) {
+    console.error('\nOne or more tweets exceed 280 chars. Trim them, or pass --force to try anyway.')
+    process.exit(1)
+  }
+
+  if (!post) {
+    console.log(`\n[dry run] ${tweets.length} tweets ready. Re-run with --post to publish.`)
+    return
+  }
+
+  const client = new TwitterApi(loadCreds())
+  const me = (await client.v2.me()).data.username
+  console.log(`\nPosting ${tweets.length} tweets as @${me} ...`)
+
+  let replyTo: string | undefined
+  for (let i = 0; i < tweets.length; i++) {
+    try {
+      const res = await client.v2.tweet(
+        tweets[i]!,
+        replyTo ? { reply: { in_reply_to_tweet_id: replyTo } } : {}
+      )
+      replyTo = res.data.id
+      console.log(`  ok ${i + 1}/${tweets.length}  https://x.com/${me}/status/${replyTo}`)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      console.error(`\n  FAILED at tweet ${i + 1}/${tweets.length}: ${msg}`)
+      console.error(
+        replyTo
+          ? `  Posted ${i} of ${tweets.length}. To finish, reply the remaining tweets to ${replyTo}.`
+          : '  Nothing was posted.'
+      )
+      process.exit(1)
+    }
+  }
+  console.log(`\nDone. Thread posted (${tweets.length} tweets).`)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/scripts/social/post-thread.ts
+++ b/scripts/social/post-thread.ts
@@ -18,9 +18,25 @@ import { TwitterApi } from 'twitter-api-v2'
 
 const ENV_KEYS = ['X_API_KEY', 'X_API_SECRET', 'X_ACCESS_TOKEN', 'X_ACCESS_SECRET'] as const
 
-// X counts every URL as 23 chars (the t.co wrap), regardless of the real length.
+// X wraps every URL to 23 chars (t.co). Match URLs but don't swallow trailing
+// punctuation, which X counts as real characters, so the estimate stays
+// conservative instead of undercounting a borderline tweet.
 function tweetLength(text: string): number {
-  return text.replace(/https?:\/\/\S+/g, 'x'.repeat(23)).length
+  return text.replace(/https?:\/\/\S+/g, (match) => {
+    const url = match.replace(/[).,!?:;'"\]]+$/, '')
+    return 'x'.repeat(23) + match.slice(url.length)
+  }).length
+}
+
+// Strip control/escape chars (keeping newlines) so a thread file can't rewrite
+// the terminal during preview. The original text is still what gets posted.
+function sanitize(text: string): string {
+  return Array.from(text)
+    .filter((c) => {
+      const code = c.codePointAt(0) ?? 0
+      return c === '\n' || (code >= 0x20 && code !== 0x7f)
+    })
+    .join('')
 }
 
 function parseThread(path: string): string[] {
@@ -69,7 +85,7 @@ async function main() {
     const len = tweetLength(t)
     const over = len > 280
     if (over) overLimit = true
-    console.log(`\n--- [${i + 1}/${tweets.length}] ${len}/280${over ? '  !! OVER LIMIT' : ''} ---\n${t}`)
+    console.log(`\n--- [${i + 1}/${tweets.length}] ${len}/280${over ? '  !! OVER LIMIT' : ''} ---\n${sanitize(t)}`)
   })
 
   if (overLimit && !force) {

--- a/scripts/social/threads/lognote-day-one.txt
+++ b/scripts/social/threads/lognote-day-one.txt
@@ -1,0 +1,33 @@
+A tester froze their Mac at 64GB of RAM on day one of lognote. Under "Obsidian." Eight gigs of models, loaded several times over, off one missing guard on a brand-new import button.
+
+That was one bug, and day one had a whole queue.
+---
+13 minutes after the launch post went live, I was already pushing a hotfix.
+
+The whole site had been deploying to a Cloudflare preview alias, so the post 404'd on the real domain. My big moment shipped to a URL only I could load.
+---
+Back to the frozen Mac. The import had no in-flight guard, and a stale modal promised "~5s," so a slow first run looked dead and the tester re-clicked until several 8GB models were loading in parallel.
+
+Fixed in ~5 hours: load lock + RAM gate + guard.
+---
+Then I found notifications had been silently broken for every early tester, because onboarding never asked for permission.
+
+Every "notes ready" banner had been firing into the void for weeks, and nobody told me because nobody saw anything.
+---
+obsidian-git's "git clean" quietly deleted plugin files for some testers, while the UI kept showing a cheerful green "installed" check.
+
+The most confident lie in software is a checkmark over an empty folder.
+---
+Then CI ran out of free GitHub Actions minutes mid-day, exactly when I needed it, so I moved CI to a self-hosted runner on an Intel NUC at home and topped up credits.
+
+Then the NUC's fan died. Self-hosting means you're the datacenter now, HVAC included.
+---
+So launch week also meant physically swapping a fan in the literal box running my CI.
+
+Through all of it, the core, recording and on-device transcription, never broke once. The heart of the product was the one thing I didn't have to touch.
+---
+Day one was a fire drill, and the product underneath it held steady.
+
+Be early, be agile, be open to feedback. It was worth every hour of it.
+
+Thanks to everyone testing lognote with me so far. The full account, fan and all: https://shariq.dev/blog/the-night-i-shipped-lognote/


### PR DESCRIPTION
A reusable CLI to post an X thread from a text file, so a multi-tweet thread goes out in one command instead of by hand.

**What it does**
- Reads a thread file (tweets separated by lines of `---`), validates each against 280 chars (URL-aware), and **dry-runs by default**; `--post` publishes.
- Posts the chain natively, each tweet replying to the one before it. If one fails mid-thread, it stops and prints the last posted ID so you can finish by hand.

**Files**
- `scripts/social/post-thread.ts` — the script (uses `twitter-api-v2` for OAuth 1.0a + threading)
- `scripts/social/threads/lognote-day-one.txt` — the launch thread, ready to fire
- `.env.social.example` + `scripts/social/README.md` — dev-app + 1Password setup

**Setup (one-time, yours):** create an X app (Read+Write, OAuth 1.0a), drop the four keys in 1Password, copy `.env.social.example` → `.env.social` with `op://` refs. Free API tier covers posting.

**Run:** `op run --env-file=.env.social -- npm run post:thread -- scripts/social/threads/lognote-day-one.txt --post`

🤖 Generated with [Claude Code](https://claude.com/claude-code)