### PR TITLE
Fix blog topic filter (scoped CSS never matched the cards)

### DIFF
--- a/src/components/FilterPills.astro
+++ b/src/components/FilterPills.astro
@@ -84,5 +84,11 @@ const { buckets } = Astro.props;
   }
   .pill.active { background: var(--color-terracotta); border-color: var(--color-terracotta); color: var(--color-paper); opacity: 1; }
   .pill:not(.active):hover { border-color: var(--fg); opacity: 1; }
-  [data-bucket][data-hidden="true"] { display: none; }
+  /* The cards live in the parent page / PostCard, not in this component, so this
+     rule must be global (un-scoped) to match them. It also needs the
+     [data-filter-scope] ancestor: PostCard's `.card { display: block }` becomes
+     `.card[data-astro-cid-…]` (specificity 0,2,0) under Astro scoping, which ties
+     a bare `[data-bucket][data-hidden]` and wins on source order. The ancestor
+     lifts this to 0,3,0 so the hide always wins. */
+  :global([data-filter-scope] [data-bucket][data-hidden="true"]) { display: none; }
 </style>


### PR DESCRIPTION
**Bug:** clicking a blog topic pill updated the URL (`?tag=engineering`) but the page didn't filter — posts stayed put.

**Root cause:** the card-hide rule `[data-bucket][data-hidden="true"] { display:none }` lived in `FilterPills.astro`'s *scoped* `<style>`. Astro scoped it to FilterPills' own elements (`data-astro-cid-…`), but the cards are rendered by `blog/index.astro` + `PostCard.astro` with different scope hashes — so it never matched them. The JS flipped `data-hidden` and pushed the URL, but `display:none` never applied.

Going `:global` alone still lost a specificity tie: PostCard's `.card { display:block }` becomes `.card[data-astro-cid-…]` (0,2,0) under scoping, tying a bare `[data-bucket][data-hidden]` and winning on source order. Qualifying with the `[data-filter-scope]` ancestor lifts the hide to (0,3,0) so it always wins.

**Verified:** the existing `blog listing renders + filters` smoke test — which was *silently failing* — now passes; full Playwright smoke suite 21/21.

_Aside: that smoke suite doesn't appear to gate in CI (only vitest does), which is why this slipped through. Wiring `npm run test:smoke` into CI would catch this class of regression._

🤖 Generated with [Claude Code](https://claude.com/claude-code)