### PR TITLE
ci: run the Playwright smoke suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,5 @@ jobs:
       - run: npm run astro check
       - run: npm test
       - run: npm run build
+      - run: npx playwright install --with-deps chromium
+      - run: npm run test:smoke # Playwright e2e against the built site (preview server)


### PR DESCRIPTION
CI ran `astro check` + vitest + build, but **not** the Playwright smoke suite (`tests/smoke.spec.ts`) — which already has a `blog listing renders + filters` test. That test was silently failing, so the topic-filter regression (fixed in #54) shipped undetected.

Adds two steps after build: `npx playwright install --with-deps chromium` and `npm run test:smoke`. The suite runs against the built site via the preview server (`CI` is set, so Playwright manages its own server).

This PR's own CI run exercises the new step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)