### PR TITLE
fix(cover): stream + cap generate response bytes

### DIFF
--- a/scripts/cover/azure.test.ts
+++ b/scripts/cover/azure.test.ts
@@ -36,4 +36,22 @@ describe('generateImage', () => {
     await expect(generateImage('p')).rejects.toThrow(/not a valid PNG/);
     fetchSpy.mockRestore();
   });
+  it('throws when streamed body exceeds MAX_IMAGE_BYTES (26 MB across chunks)', async () => {
+    // Build a ReadableStream that pushes >25MB of data in chunks.
+    const chunk = new Uint8Array(10 * 1024 * 1024); // 10 MB per chunk
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(chunk);
+        controller.enqueue(chunk);
+        controller.enqueue(chunk); // 30 MB total — exceeds 25 MB cap
+        controller.close();
+      },
+    });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(stream, { status: 200 }),
+    );
+    const { generateImage } = await import('./azure.js');
+    await expect(generateImage('p')).rejects.toThrow(/too large/);
+    fetchSpy.mockRestore();
+  });
 });

--- a/scripts/cover/azure.ts
+++ b/scripts/cover/azure.ts
@@ -22,8 +22,10 @@ export async function generateImage(prompt: string): Promise<Buffer> {
       throw new Error(`gateway generate: response too large (${declared} bytes)`);
     }
     // The result is written verbatim as a public cover.png — never trust a 2xx blindly.
-    // Stream the body and abort mid-stream if accumulated bytes exceed the cap, so a gateway
-    // that omits/lies about Content-Length cannot OOM the process.
+    // Stream the body and reject mid-stream as soon as accumulated bytes exceed the cap.
+    // Each individual chunk is also checked before being accepted so a single oversized
+    // chunk is caught at chunk-granularity rather than only after full accumulation.
+    // This bounds peak allocation to MAX_IMAGE_BYTES + one chunk (typically ≤ a few KB).
     if (!res.body) throw new Error('gateway generate: response body is null');
     const reader = res.body.getReader();
     const chunks: Uint8Array[] = [];
@@ -32,11 +34,12 @@ export async function generateImage(prompt: string): Promise<Buffer> {
       for (;;) {
         const { done, value } = await reader.read();
         if (done) break;
-        total += value.length;
-        if (total > MAX_IMAGE_BYTES) {
+        // Check before pushing so the chunk is never retained if it tips us over.
+        if (total + value.length > MAX_IMAGE_BYTES) {
           await reader.cancel();
           throw new Error(`gateway generate: response too large (>${MAX_IMAGE_BYTES} bytes)`);
         }
+        total += value.length;
         chunks.push(value);
       }
     } finally {

--- a/scripts/cover/azure.ts
+++ b/scripts/cover/azure.ts
@@ -22,11 +22,28 @@ export async function generateImage(prompt: string): Promise<Buffer> {
       throw new Error(`gateway generate: response too large (${declared} bytes)`);
     }
     // The result is written verbatim as a public cover.png — never trust a 2xx blindly.
-    // Validate size + the actual PNG signature so a misrouted/error/huge body can't be published.
-    const buf = Buffer.from(await res.arrayBuffer());
-    if (buf.length > MAX_IMAGE_BYTES) {
-      throw new Error(`gateway generate: response too large (${buf.length} bytes)`);
+    // Stream the body and abort mid-stream if accumulated bytes exceed the cap, so a gateway
+    // that omits/lies about Content-Length cannot OOM the process.
+    if (!res.body) throw new Error('gateway generate: response body is null');
+    const reader = res.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        total += value.length;
+        if (total > MAX_IMAGE_BYTES) {
+          await reader.cancel();
+          throw new Error(`gateway generate: response too large (>${MAX_IMAGE_BYTES} bytes)`);
+        }
+        chunks.push(value);
+      }
+    } finally {
+      // Ensure the reader is always released, even if read() itself throws (e.g. AbortError).
+      reader.releaseLock();
     }
+    const buf = Buffer.concat(chunks.map((c) => Buffer.from(c)));
     if (buf.length < 8 || !buf.subarray(0, 8).equals(PNG_MAGIC)) {
       throw new Error(`gateway generate: response is not a valid PNG (${buf.length} bytes)`);
     }

--- a/scripts/cover/azure.ts
+++ b/scripts/cover/azure.ts
@@ -22,31 +22,30 @@ export async function generateImage(prompt: string): Promise<Buffer> {
       throw new Error(`gateway generate: response too large (${declared} bytes)`);
     }
     // The result is written verbatim as a public cover.png — never trust a 2xx blindly.
-    // Stream the body and reject mid-stream as soon as accumulated bytes exceed the cap.
-    // Each individual chunk is also checked before being accepted so a single oversized
-    // chunk is caught at chunk-granularity rather than only after full accumulation.
-    // This bounds peak allocation to MAX_IMAGE_BYTES + one chunk (typically ≤ a few KB).
+    // Stream the body into a single preallocated buffer so we can enforce the byte cap
+    // incrementally without a second full allocation from Buffer.concat.
     if (!res.body) throw new Error('gateway generate: response body is null');
     const reader = res.body.getReader();
-    const chunks: Uint8Array[] = [];
+    // Preallocate the maximum allowed size; we'll subarray to actual length afterward.
+    const preallocated = Buffer.allocUnsafe(MAX_IMAGE_BYTES);
     let total = 0;
     try {
       for (;;) {
         const { done, value } = await reader.read();
         if (done) break;
-        // Check before pushing so the chunk is never retained if it tips us over.
+        // Reject before copying so an oversized chunk is never written into the buffer.
         if (total + value.length > MAX_IMAGE_BYTES) {
           await reader.cancel();
           throw new Error(`gateway generate: response too large (>${MAX_IMAGE_BYTES} bytes)`);
         }
+        preallocated.set(value, total);
         total += value.length;
-        chunks.push(value);
       }
     } finally {
       // Ensure the reader is always released, even if read() itself throws (e.g. AbortError).
       reader.releaseLock();
     }
-    const buf = Buffer.concat(chunks.map((c) => Buffer.from(c)));
+    const buf = preallocated.subarray(0, total);
     if (buf.length < 8 || !buf.subarray(0, 8).equals(PNG_MAGIC)) {
       throw new Error(`gateway generate: response is not a valid PNG (${buf.length} bytes)`);
     }


### PR DESCRIPTION
## Summary

- Replaces `res.arrayBuffer()` (full buffer before size check) in `generateImage()` with a streamed read via `res.body.getReader()`
- Counts bytes incrementally; calls `reader.cancel()` and throws `/too large/` as soon as accumulated size exceeds `MAX_IMAGE_BYTES` (25 MB)
- A gateway that omits or lies about `Content-Length` can no longer force an unbounded memory allocation in the cover-gen process
- `reader.releaseLock()` in a `finally` block ensures clean teardown even on `AbortError` from the timeout controller

## Test plan

- [x] Existing happy-path test passes (`new Response(pngBuffer)` provides a readable `.body`)
- [x] New test: `ReadableStream` emitting 3×10 MB chunks → rejects with `/too large/`
- [x] Non-2xx and non-PNG tests unchanged and passing
- [x] `npx vitest run scripts/cover/azure.test.ts` — 4/4 green
- [x] `npm run astro check` — 0 errors, 0 warnings

Closes Solo todo #144 (blog-site project 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)