### PR TITLE
Bootstrap shared GPT-5.6 Sol code review

### DIFF
--- a/.github/workflows/ai-code-review-shared-pilot.yml
+++ b/.github/workflows/ai-code-review-shared-pilot.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: shariqh/ai-code-review@a9bb0fe94767d8b250e2a06e293df2aa8c707db0
+      - uses: shariqh/ai-code-review@07592511accc379c8234733848755f016e1edf85
         with:
           copilot-token: ${{ secrets.COPILOT_REVIEW_PAT }}
           github-token: ${{ github.token }}

--- a/.github/workflows/ai-code-review-shared-pilot.yml
+++ b/.github/workflows/ai-code-review-shared-pilot.yml
@@ -1,0 +1,31 @@
+name: AI code review (shared pilot)
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ai-code-review-shared-pilot-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    if: >-
+      github.event.pull_request.user.login == github.repository_owner &&
+      github.actor == github.repository_owner &&
+      github.triggering_actor == github.repository_owner &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: shariqh/ai-code-review@a9bb0fe94767d8b250e2a06e293df2aa8c707db0
+        with:
+          copilot-token: ${{ secrets.COPILOT_REVIEW_PAT }}
+          github-token: ${{ github.token }}
+          model: gpt-5.6-sol
+          comment-marker: ai-code-review-shared-pilot


### PR DESCRIPTION
## Summary

- add the trusted-default-branch shared AI review workflow beside the legacy GPT-5.4 workflow
- pin `shariqh/ai-code-review` to validated commit `a9bb0fe`
- keep the legacy workflow unchanged until a follow-up migration PR validates both

## Test plan

- merge this bootstrap workflow
- open a follow-up migration PR and compare both sticky reviews before deleting the legacy workflow