### PR TITLE
Update AI review documentation for GPT-5.6 Sol

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,9 +148,10 @@ personal OAuth) with `CLOUDFLARE_API_TOKEN` (the CI secret).
 
 Two independent AI reviews can run on a PR:
 
-- **`gpt-5.4` via Copilot CLI** — a GitHub Action (`review` check + a
-  `## 🤖 AI code review` sticky comment). Re-runs automatically on every
-  push. Always watch it (and address findings) before calling a PR ready.
+- **GPT-5.6 Sol via the shared Copilot CLI action** — a GitHub Action
+  (`review` check + an `## AI code review` sticky comment). Runs when an
+  owner-authored PR becomes ready and after owner-triggered pushes. Always
+  watch it (and address findings) before calling a PR ready.
 - **Built-in GitHub Copilot reviewer** — triggered manually:
 
   ```sh

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Cloudflare Pages CI. Here's how they fit.
      (by hand,      patch hero.image                 │
       or agent)                                       ▼
                                      PR checks: CI (vitest) · Vale ·
-                                     gpt-5.4 AI review · Pages preview
+                                  GPT-5.6 Sol AI review · Pages preview
                                                       │ review + merge
                                                       ▼
                                 push to main ─► build (+ OG) ─► Cloudflare


### PR DESCRIPTION
## Summary

- update the code-review runbook from GPT-5.4 to the shared GPT-5.6 Sol action
- update the README lifecycle diagram
- document the owner-authored, ready-PR trigger behavior

## Validation

- no remaining GPT-5.4 references in `CLAUDE.md` or `README.md`