### PR TITLE
Integrate SH mark across site chrome and social cards

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,8 +2,11 @@
 import { SITE } from "../lib/site";
 ---
 <footer class="mt-24 border-t border-[color-mix(in_oklab,var(--fg)_15%,transparent)]">
-  <div class="mx-auto flex max-w-[1100px] flex-col gap-3 px-5 py-8 text-sm sm:flex-row sm:justify-between">
-    <p>&copy; {new Date().getFullYear()} {SITE.author}</p>
+  <div class="mx-auto flex max-w-[1100px] flex-col gap-4 px-5 py-8 text-sm sm:flex-row sm:items-center sm:justify-between">
+    <div class="flex items-center gap-2">
+      <img src="/favicon.svg" alt="" aria-hidden="true" class="h-6 w-6 shrink-0" />
+      <p>&copy; {new Date().getFullYear()} {SITE.author}</p>
+    </div>
     <p class="flex flex-wrap gap-4">
       <a href={SITE.social.twitter} class="hover:text-[var(--accent)]">X / Twitter</a>
       <a href={SITE.social.github} class="hover:text-[var(--accent)]">GitHub</a>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,12 +1,14 @@
 ---
 import { SITE } from "../lib/site";
+
+const shortTitle = SITE.title.split(" ", 1)[0] ?? SITE.title;
+const titleRemainder = SITE.title.slice(shortTitle.length);
 ---
 <header class="w-full border-b border-[color-mix(in_oklab,var(--fg)_15%,transparent)]">
   <div class="mx-auto flex max-w-[1100px] items-center justify-between gap-3 px-5 py-5">
     <a href="/" class="flex shrink-0 items-center gap-2 font-display text-lg italic tracking-tight">
       <img src="/favicon.svg" alt="" aria-hidden="true" class="h-5 w-5 shrink-0" />
-      <span aria-hidden="true">Shariq<span class="hidden sm:inline"> Hirani</span></span>
-      <span class="visually-hidden">{SITE.title}</span>
+      <span>{shortTitle}<span class="hidden sm:inline">{titleRemainder}</span><span class="visually-hidden sm:hidden">{titleRemainder}</span></span>
     </a>
     <nav class="flex items-center gap-3 text-sm sm:gap-6">
       <a href="/blog" class="hover:text-[var(--accent)]">Blog</a>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -2,9 +2,13 @@
 import { SITE } from "../lib/site";
 ---
 <header class="w-full border-b border-[color-mix(in_oklab,var(--fg)_15%,transparent)]">
-  <div class="mx-auto flex max-w-[1100px] items-center justify-between px-5 py-5">
-    <a href="/" class="font-display text-lg italic tracking-tight">{SITE.title}</a>
-    <nav class="flex items-center gap-6 text-sm">
+  <div class="mx-auto flex max-w-[1100px] items-center justify-between gap-3 px-5 py-5">
+    <a href="/" class="flex shrink-0 items-center gap-2 font-display text-lg italic tracking-tight">
+      <img src="/favicon.svg" alt="" aria-hidden="true" class="h-5 w-5 shrink-0" />
+      <span aria-hidden="true">Shariq<span class="hidden sm:inline"> Hirani</span></span>
+      <span class="visually-hidden">{SITE.title}</span>
+    </a>
+    <nav class="flex items-center gap-3 text-sm sm:gap-6">
       <a href="/blog" class="hover:text-[var(--accent)]">Blog</a>
       <a href="/now" class="hover:text-[var(--accent)]">Now</a>
       <a href="/projects" class="hover:text-[var(--accent)]">Projects</a>

--- a/src/lib/og/templates.test.ts
+++ b/src/lib/og/templates.test.ts
@@ -18,6 +18,38 @@ function texts(node: any, out: string[] = []): string[] {
   return out
 }
 
+function nodesByType(node: any, type: string, out: any[] = []): any[] {
+  if (node && node.type === type) out.push(node)
+  if (node && node.props) {
+    ;[]
+      .concat(node.props.children ?? [])
+      .forEach((child) => nodesByType(child, type, out))
+  }
+  return out
+}
+
+function expectSeparatedMark(node: any) {
+  const marks = nodesByType(node, 'svg')
+  expect(marks).toHaveLength(1)
+  expect(marks[0].props.viewBox).toBe('0 0 100 100')
+  expect(
+    nodesByType(marks[0], 'path').map(({ props }) => ({
+      d: props.d,
+      fill: props.fill,
+    })),
+  ).toEqual([
+    {
+      d: 'M10 2h32l6 6v8H18v14h30v36l-6 6H10l-6-6v-8h30V44H4V8Z',
+      fill: '#b04a3a',
+    },
+    {
+      d: 'M60 28h8v28h16V28h8l6 6v58l-6 6h-8V70H68v28h-8l-6-6V34Z',
+      fill: '#f3e8d2',
+    },
+  ])
+  expect(JSON.stringify(node)).not.toContain('rotate(45deg)')
+}
+
 describe('h', () => {
   it('builds a {type, props:{children}} node', () => {
     const n = h('div', { style: { color: 'red' } }, 'hi')
@@ -46,6 +78,9 @@ describe('hybridTemplate', () => {
     walk(node)
     expect(imgs).toContain(data.cover)
   })
+  it('renders the separated SH mark in the site signature', () => {
+    expectSeparatedMark(hybridTemplate(data))
+  })
 })
 
 describe('fallbackTemplate', () => {
@@ -61,5 +96,8 @@ describe('fallbackTemplate', () => {
     }
     walk(node)
     expect(hasImg).toBe(false)
+  })
+  it('renders the separated SH mark in the site signature', () => {
+    expectSeparatedMark(fallbackTemplate({ ...data, cover: null }))
   })
 })

--- a/src/lib/og/templates.ts
+++ b/src/lib/og/templates.ts
@@ -7,15 +7,19 @@ const TERRACOTTA = '#b04a3a'
 const PAPER = '#f3e8d2'
 const WHITE = '#ffffff'
 
-// The mark: "◆ shariq.dev" — the diamond is a rotated square div (a font glyph
-// would be a missing-glyph box, since the vendored fonts lack U+25C6).
+const SH_S_PATH = 'M10 2h32l6 6v8H18v14h30v36l-6 6H10l-6-6v-8h30V44H4V8Z'
+const SH_H_PATH = 'M60 28h8v28h16V28h8l6 6v58l-6 6h-8V70H68v28h-8l-6-6V34Z'
+
 function mark(): OgNode {
   return h(
     'div',
     { style: { display: 'flex', alignItems: 'center', fontFamily: 'JetBrains Mono', fontSize: 24, color: WHITE } },
-    h('div', {
-      style: { display: 'flex', width: 13, height: 13, marginRight: 13, background: OCHRE, transform: 'rotate(45deg)' },
-    }),
+    h(
+      'svg',
+      { viewBox: '0 0 100 100', width: 30, height: 30, style: { marginRight: 13 } },
+      h('path', { d: SH_S_PATH, fill: TERRACOTTA }),
+      h('path', { d: SH_H_PATH, fill: PAPER })
+    ),
     h('div', { style: { display: 'flex' } }, 'shariq.dev')
   )
 }

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -32,13 +32,36 @@ test('homepage renders the zine hero', async ({ page }) => {
 })
 
 test('header nav + footer socials', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 })
   await page.goto('/')
+
+  const homeLink = page.getByRole('link', {
+    name: 'Shariq Hirani',
+    exact: true,
+  })
+  await expect(homeLink).toHaveCount(1)
+  const headerMark = homeLink.locator('img[src="/favicon.svg"]')
+  await expect(headerMark).toHaveAttribute('alt', '')
+  await expect(headerMark).toHaveAttribute('aria-hidden', 'true')
+
   await expect(page.locator('header nav')).toContainText(['Blog'])
   await expect(page.locator('header nav')).toContainText(['Projects'])
+
   const footer = page.locator('footer')
+  const footerMark = footer.locator('img[src="/favicon.svg"]')
+  await expect(footerMark).toHaveAttribute('alt', '')
+  await expect(footerMark).toHaveAttribute('aria-hidden', 'true')
   await expect(footer).toContainText(['GitHub'])
   await expect(footer).toContainText(['YouTube'])
   await expect(footer).toContainText(['LinkedIn'])
+
+  const widths = await page.evaluate(() => ({
+    viewport: document.documentElement.clientWidth,
+    document: document.documentElement.scrollWidth,
+    header: document.querySelector('header')?.scrollWidth ?? 0,
+  }))
+  expect(widths.document).toBeLessThanOrEqual(widths.viewport)
+  expect(widths.header).toBeLessThanOrEqual(widths.viewport)
 })
 
 test('RSS feed serves', async ({ request }) => {


### PR DESCRIPTION
## Summary
- add the canonical separated SH mark to the linked header lockup and footer sign-off
- preserve the full accessible home name while using a compact mobile label at 390px
- replace the OG diamond with inline Satori-compatible SH paths in terracotta and paper
- cover both OG templates plus responsive header/footer behavior with targeted tests

## Validation
- `npm run astro check`
- `npm test`
- `npm run build`
- `npm run test:smoke`

## Visual evidence

### Desktop

| Header | Footer |
| --- | --- |
| ![Desktop header with SH mark](https://github.com/user-attachments/assets/51755d07-182a-4323-b7d6-b3fe8d704b78) | ![Desktop footer with SH mark](https://github.com/user-attachments/assets/caeca14c-17ba-474d-b47f-3684eaa83872) |

### Mobile — 390px

| Header | Footer |
| --- | --- |
| ![390px mobile header with compact SH lockup](https://github.com/user-attachments/assets/516ea3f2-cc62-4c99-abf2-4b9668e7fd51) | ![390px mobile footer with SH sign-off](https://github.com/user-attachments/assets/28300dbd-8ccc-4b78-9de7-428e0a34e751) |

### Rendered OG card

![Rendered OG card with separated SH mark](https://github.com/user-attachments/assets/86eb3916-6e5c-470d-9e02-c44605174dad)

## Caveat
None. `public/favicon.svg` and all out-of-scope page surfaces remain unchanged.