### PR TITLE
Make global header mark icon-only

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,14 +1,20 @@
 ---
 import { SITE } from "../lib/site";
-
-const shortTitle = SITE.title.split(" ", 1)[0] ?? SITE.title;
-const titleRemainder = SITE.title.slice(shortTitle.length);
 ---
-<header class="w-full border-b border-[color-mix(in_oklab,var(--fg)_15%,transparent)]">
-  <div class="mx-auto flex max-w-[1100px] items-center justify-between gap-3 px-5 py-5">
-    <a href="/" class="flex shrink-0 items-center gap-2 font-display text-lg italic tracking-tight">
-      <img src="/favicon.svg" alt="" aria-hidden="true" class="h-5 w-5 shrink-0" />
-      <span>{shortTitle}<span class="hidden sm:inline">{titleRemainder}</span><span class="visually-hidden sm:hidden">{titleRemainder}</span></span>
+
+<header
+  class="w-full border-b border-[color-mix(in_oklab,var(--fg)_15%,transparent)]"
+>
+  <div
+    class="mx-auto flex max-w-[1100px] items-center justify-between gap-3 px-5 py-5"
+  >
+    <a href="/" aria-label={SITE.title} class="flex shrink-0 items-center">
+      <img
+        src="/favicon.svg"
+        alt=""
+        aria-hidden="true"
+        class="h-5 w-5 shrink-0"
+      />
     </a>
     <nav class="flex items-center gap-3 text-sm sm:gap-6">
       <a href="/blog" class="hover:text-[var(--accent)]">Blog</a>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -13,7 +13,7 @@ import { SITE } from "../lib/site";
         src="/favicon.svg"
         alt=""
         aria-hidden="true"
-        class="h-5 w-5 shrink-0"
+        class="h-7 w-7 shrink-0"
       />
     </a>
     <nav class="flex items-center gap-3 text-sm sm:gap-6">

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test'
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
 import { join } from 'node:path'
+import { SITE } from '../src/lib/site'
 
 function walkMdx(dir: string, prefix = ''): string[] {
   const out: string[] = []
@@ -36,11 +37,13 @@ test('header nav + footer socials', async ({ page }) => {
   await page.goto('/')
 
   const homeLink = page.getByRole('link', {
-    name: 'Shariq Hirani',
+    name: SITE.title,
     exact: true,
   })
   await expect(homeLink).toHaveCount(1)
+  await expect(homeLink).toHaveText('')
   const headerMark = homeLink.locator('img[src="/favicon.svg"]')
+  await expect(headerMark).toHaveCount(1)
   await expect(headerMark).toHaveAttribute('alt', '')
   await expect(headerMark).toHaveAttribute('aria-hidden', 'true')
 

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -46,6 +46,8 @@ test('header nav + footer socials', async ({ page }) => {
   await expect(headerMark).toHaveCount(1)
   await expect(headerMark).toHaveAttribute('alt', '')
   await expect(headerMark).toHaveAttribute('aria-hidden', 'true')
+  await expect(headerMark).toHaveCSS('width', '28px')
+  await expect(headerMark).toHaveCSS('height', '28px')
 
   await expect(page.locator('header nav')).toContainText(['Blog'])
   await expect(page.locator('header nav')).toContainText(['Projects'])


### PR DESCRIPTION
## Summary
- remove the responsive site-name text from the global header home link
- keep the canonical SH mark decorative while naming the link from `SITE.title`
- extend the focused smoke coverage for the icon-only accessible contract and 390px overflow boundary

## Validation
- `npm run astro check`
- `npm test`
- `npm run build`
- `npm run test:smoke`
- Impeccable detector: no findings