### PR TITLE
Add GoatCounter article view counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,12 +115,18 @@ npm run dev    # http://localhost:4321
 
 ### GoatCounter article view counts
 
-Article metadata reads public pageview totals from GoatCounter's JSON counter
-endpoint. No admin API, token, cookies, or additional tracking is involved. In
-GoatCounter, enable **Settings → Allow adding visitor counts on your website**;
-the setting is off by default. When it is disabled or the endpoint is
-unavailable, the count stays hidden. GoatCounter caches counter responses for
-up to four hours.
+Article metadata reads public pageview totals through the same-origin
+`/api/read-count` Pages Function. The function exists because Firefox Enhanced
+Tracking Protection and other content blockers can block direct browser
+requests to GoatCounter. It validates canonical `/blog/.../` paths and forwards
+only to the fixed public GoatCounter JSON endpoint; there is no admin API,
+token, cookie, user data storage, or additional tracking.
+
+In GoatCounter, keep **Settings → Allow adding visitor counts on your website**
+enabled. When it is disabled or the upstream is unavailable, the count stays
+hidden. Successful proxy responses use `max-age=300` for browsers and
+`s-maxage=14400` (four hours) for shared caches, matching GoatCounter's
+up-to-four-hour response cache.
 
 ## Authoring posts
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,15 @@ npm run dev    # http://localhost:4321
 - `npm run gen:cover <slug> [--style line-art|conceptual] [--concept "..."] [--force]` — generate a post's AI cover (via the image-gateway)
 - `npm run gen:cover:all [--force]` — backfill AI covers across all posts
 
+### GoatCounter article view counts
+
+Article metadata reads public pageview totals from GoatCounter's JSON counter
+endpoint. No admin API, token, cookies, or additional tracking is involved. In
+GoatCounter, enable **Settings → Allow adding visitor counts on your website**;
+the setting is off by default. When it is disabled or the endpoint is
+unavailable, the count stays hidden. GoatCounter caches counter responses for
+up to four hours.
+
 ## Authoring posts
 
 Posts live in `src/content/writing/`. Frontmatter is Zod-validated at build

--- a/functions/api/read-count.ts
+++ b/functions/api/read-count.ts
@@ -1,0 +1,9 @@
+import { handleReadCountRequest } from '../../src/lib/read-count-proxy'
+
+interface Context {
+  request: Request
+}
+
+export function onRequest({ request }: Context): Promise<Response> {
+  return handleReadCountRequest(request)
+}

--- a/src/components/PostHeader.astro
+++ b/src/components/PostHeader.astro
@@ -1,6 +1,7 @@
 ---
 import { formatDate } from "../lib/formatDate";
 import { EYEBROW_PREFIX, type BucketKey } from "../lib/buckets";
+import ReadCount from "./ReadCount.astro";
 
 interface Props {
   title: string;
@@ -9,9 +10,10 @@ interface Props {
   bucketLabel: string;
   summary?: string;
   readingMinutes?: number;
+  articlePath: string;
 }
 
-const { title, date, bucket, bucketLabel, summary, readingMinutes } = Astro.props;
+const { title, date, bucket, bucketLabel, summary, readingMinutes, articlePath } = Astro.props;
 ---
 <header class="py-12">
   <p class="font-mono text-xs uppercase tracking-[0.22em] text-[var(--fg-soft)]">
@@ -19,6 +21,7 @@ const { title, date, bucket, bucketLabel, summary, readingMinutes } = Astro.prop
     <span class="mx-2">·</span>
     {formatDate(date)}
     {readingMinutes ? <><span class="mx-2">·</span>{readingMinutes} min read</> : null}
+    <ReadCount path={articlePath} />
   </p>
 
   <h1 class="mt-4 font-display text-4xl italic leading-[1.05] tracking-tight sm:text-5xl">{title}</h1>
@@ -26,5 +29,4 @@ const { title, date, bucket, bucketLabel, summary, readingMinutes } = Astro.prop
   {summary && (
     <p class="mt-5 max-w-prose font-sans text-lg text-[var(--fg-soft)]">{summary}</p>
   )}
-
 </header>

--- a/src/components/ReadCount.astro
+++ b/src/components/ReadCount.astro
@@ -28,7 +28,8 @@ const { path } = Astro.props;
     const path = element.dataset.path;
     const value = element.querySelector<HTMLElement>("[data-read-count-value]");
     if (!path || !value) {
-      throw new Error("ReadCount requires a path and value element");
+      element.dataset.readCountState = "unavailable";
+      return;
     }
 
     element.dataset.readCountState = "loading";

--- a/src/components/ReadCount.astro
+++ b/src/components/ReadCount.astro
@@ -32,7 +32,13 @@ const { path } = Astro.props;
     }
 
     element.dataset.readCountState = "loading";
-    const result = await fetchReadCount(path);
+    let result;
+    try {
+      result = await fetchReadCount(path);
+    } catch {
+      element.dataset.readCountState = "unavailable";
+      return;
+    }
     if (!result.ok) {
       element.dataset.readCountState = "unavailable";
       return;

--- a/src/components/ReadCount.astro
+++ b/src/components/ReadCount.astro
@@ -1,0 +1,51 @@
+---
+interface Props {
+  path: string;
+}
+
+const { path } = Astro.props;
+---
+
+<span
+  data-read-count
+  data-read-count-state="idle"
+  data-path={path}
+  aria-live="polite"
+  hidden
+>
+  <span class="whitespace-nowrap">
+    <span class="mx-2" aria-hidden="true">·</span>
+    <span data-read-count-value></span>
+  </span>
+</span>
+
+<script>
+  import { fetchReadCount, formatReadCount } from "../lib/read-count";
+
+  async function loadReadCount(element: HTMLElement) {
+    if (element.dataset.readCountState !== "idle") return;
+
+    const path = element.dataset.path;
+    const value = element.querySelector<HTMLElement>("[data-read-count-value]");
+    if (!path || !value) {
+      throw new Error("ReadCount requires a path and value element");
+    }
+
+    element.dataset.readCountState = "loading";
+    const result = await fetchReadCount(path);
+    if (!result.ok) {
+      element.dataset.readCountState = "unavailable";
+      return;
+    }
+
+    value.textContent = formatReadCount(result.count);
+    element.hidden = false;
+    element.dataset.readCountState = "loaded";
+  }
+
+  document
+    .querySelectorAll<HTMLElement>("[data-read-count]")
+    .forEach((element) => {
+      void loadReadCount(element);
+    });
+</script>

--- a/src/lib/read-count-proxy.test.ts
+++ b/src/lib/read-count-proxy.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  handleReadCountRequest,
+  READ_COUNT_BROWSER_MAX_AGE_SECONDS,
+  READ_COUNT_SHARED_MAX_AGE_SECONDS,
+} from './read-count-proxy'
+
+const ARTICLE_PATH = '/blog/example/'
+const REQUEST_URL = `https://shariq.dev/api/read-count?path=${encodeURIComponent(ARTICLE_PATH)}`
+
+function request(url = REQUEST_URL, method = 'GET'): Request {
+  return new Request(url, { method })
+}
+
+function upstreamResponse(
+  body: object | string,
+  init: ResponseInit = {},
+): Response {
+  return new Response(
+    typeof body === 'string' ? body : JSON.stringify(body),
+    init,
+  )
+}
+
+describe('handleReadCountRequest', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('allows only GET', async () => {
+    const fetchMock = vi.fn<typeof fetch>()
+    const response = await handleReadCountRequest(
+      request(REQUEST_URL, 'POST'),
+      {
+        fetch: fetchMock,
+      },
+    )
+
+    expect(response.status).toBe(405)
+    expect(response.headers.get('allow')).toBe('GET')
+    expect(response.headers.get('cache-control')).toBe('no-store')
+    expect(await response.json()).toEqual({ error: 'method_not_allowed' })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    'https://shariq.dev/api/read-count',
+    `https://shariq.dev/api/read-count?path=${encodeURIComponent(ARTICLE_PATH)}&path=${encodeURIComponent(ARTICLE_PATH)}`,
+    `https://shariq.dev/api/read-count?path=${encodeURIComponent(ARTICLE_PATH)}&extra=1`,
+    'https://shariq.dev/api/read-count?path=blog%2Fexample%2F',
+    'https://shariq.dev/api/read-count?path=%2Fprojects%2F',
+    'https://shariq.dev/api/read-count?path=%2Fblog%2Fexample',
+    'https://shariq.dev/api/read-count?path=%2Fblog%2F..%2Fsecret%2F',
+    'https://shariq.dev/api/read-count?path=%2Fblog%2F%252e%252e%2Fsecret%2F',
+    'https://shariq.dev/api/read-count?path=%2Fblog%2F%252Fsecret%2F',
+    'https://shariq.dev/api/read-count?path=%2Fblog%2Fbad%25path%2F',
+  ])('rejects invalid request URL %s', async (url) => {
+    const fetchMock = vi.fn<typeof fetch>()
+    const response = await handleReadCountRequest(request(url), {
+      fetch: fetchMock,
+    })
+
+    expect(response.status).toBe(400)
+    expect(response.headers.get('cache-control')).toBe('no-store')
+    expect(await response.json()).toEqual({ error: 'invalid_path' })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects article paths over the length bound', async () => {
+    const path = `/blog/${'a'.repeat(512)}/`
+    const fetchMock = vi.fn<typeof fetch>()
+    const response = await handleReadCountRequest(
+      request(
+        `https://shariq.dev/api/read-count?path=${encodeURIComponent(path)}`,
+      ),
+      { fetch: fetchMock },
+    )
+
+    expect(response.status).toBe(400)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('fetches the exact encoded upstream path and returns minimal cached JSON', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(upstreamResponse({ count: '1,234' }))
+
+    const response = await handleReadCountRequest(request(), {
+      fetch: fetchMock,
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://shariq-blog.goatcounter.com/counter/%2Fblog%2Fexample%2F.json',
+      expect.objectContaining({
+        credentials: 'omit',
+        headers: { accept: 'application/json' },
+        signal: expect.any(AbortSignal),
+      }),
+    )
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toBe(
+      'application/json; charset=utf-8',
+    )
+    expect(response.headers.get('x-content-type-options')).toBe('nosniff')
+    expect(response.headers.get('cache-control')).toBe(
+      `public, max-age=${READ_COUNT_BROWSER_MAX_AGE_SECONDS}, s-maxage=${READ_COUNT_SHARED_MAX_AGE_SECONDS}`,
+    )
+    expect(await response.json()).toEqual({ count: '1234' })
+  })
+
+  it.each([
+    { upstream: 403, expected: 502, error: 'unavailable' },
+    { upstream: 404, expected: 404, error: 'not_found' },
+  ])(
+    'maps upstream $upstream to $expected',
+    async ({ upstream, expected, error }) => {
+      const fetchMock = vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(new Response(null, { status: upstream }))
+
+      const response = await handleReadCountRequest(request(), {
+        fetch: fetchMock,
+      })
+
+      expect(response.status).toBe(expected)
+      expect(response.headers.get('cache-control')).toBe('no-store')
+      expect(await response.json()).toEqual({ error })
+    },
+  )
+
+  it.each([upstreamResponse('{'), upstreamResponse({ count: 'many' })])(
+    'maps malformed upstream responses to 502',
+    async (upstream) => {
+      const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(upstream)
+      const response = await handleReadCountRequest(request(), {
+        fetch: fetchMock,
+      })
+
+      expect(response.status).toBe(502)
+      expect(await response.json()).toEqual({ error: 'unavailable' })
+    },
+  )
+
+  it('maps upstream network failures to 502', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockRejectedValue(new TypeError('Failed to fetch'))
+    const response = await handleReadCountRequest(request(), {
+      fetch: fetchMock,
+    })
+
+    expect(response.status).toBe(502)
+    expect(await response.json()).toEqual({ error: 'unavailable' })
+  })
+
+  it('maps unexpected upstream failures to 502', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockRejectedValue(new Error('upstream body failed'))
+    const response = await handleReadCountRequest(request(), {
+      fetch: fetchMock,
+    })
+
+    expect(response.status).toBe(502)
+    expect(response.headers.get('cache-control')).toBe('no-store')
+    expect(await response.json()).toEqual({ error: 'unavailable' })
+  })
+
+  it('maps upstream timeout to 504', async () => {
+    vi.useFakeTimers()
+    const fetchMock: typeof fetch = async (_input, init) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener(
+          'abort',
+          () => reject(new DOMException('Aborted', 'AbortError')),
+          { once: true },
+        )
+      })
+
+    const responsePromise = handleReadCountRequest(request(), {
+      fetch: fetchMock,
+      timeoutMs: 50,
+    })
+    await vi.advanceTimersByTimeAsync(50)
+    const response = await responsePromise
+
+    expect(response.status).toBe(504)
+    expect(await response.json()).toEqual({ error: 'unavailable' })
+  })
+})

--- a/src/lib/read-count-proxy.ts
+++ b/src/lib/read-count-proxy.ts
@@ -1,0 +1,91 @@
+import {
+  DEFAULT_READ_COUNT_TIMEOUT_MS,
+  fetchGoatCounterReadCount,
+  isCanonicalArticlePath,
+  type ReadCountFetchOptions,
+} from './read-count'
+
+export const READ_COUNT_BROWSER_MAX_AGE_SECONDS = 300
+export const READ_COUNT_SHARED_MAX_AGE_SECONDS = 14_400
+
+const JSON_HEADERS = {
+  'content-type': 'application/json; charset=utf-8',
+  'x-content-type-options': 'nosniff',
+}
+
+export interface ReadCountProxyOptions extends Pick<
+  ReadCountFetchOptions,
+  'fetch' | 'timeoutMs'
+> {}
+
+function jsonResponse(
+  body: object,
+  status: number,
+  cacheControl: string,
+  headers: Record<string, string> = {},
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      ...JSON_HEADERS,
+      'cache-control': cacheControl,
+      ...headers,
+    },
+  })
+}
+
+function errorResponse(
+  status: number,
+  error: 'invalid_path' | 'method_not_allowed' | 'not_found' | 'unavailable',
+  headers: Record<string, string> = {},
+): Response {
+  return jsonResponse({ error }, status, 'no-store', headers)
+}
+
+export async function handleReadCountRequest(
+  request: Request,
+  options: ReadCountProxyOptions = {},
+): Promise<Response> {
+  if (request.method !== 'GET') {
+    return errorResponse(405, 'method_not_allowed', { allow: 'GET' })
+  }
+
+  const url = new URL(request.url)
+  const paths = url.searchParams.getAll('path')
+  const hasUnexpectedParameter = [...url.searchParams.keys()].some(
+    (key) => key !== 'path',
+  )
+  if (
+    paths.length !== 1 ||
+    hasUnexpectedParameter ||
+    !isCanonicalArticlePath(paths[0])
+  ) {
+    return errorResponse(400, 'invalid_path')
+  }
+
+  let result
+  try {
+    result = await fetchGoatCounterReadCount(paths[0], {
+      fetch: options.fetch,
+      signal: request.signal,
+      timeoutMs: options.timeoutMs ?? DEFAULT_READ_COUNT_TIMEOUT_MS,
+    })
+  } catch {
+    return errorResponse(502, 'unavailable')
+  }
+
+  if (result.ok) {
+    return jsonResponse(
+      { count: String(result.count) },
+      200,
+      `public, max-age=${READ_COUNT_BROWSER_MAX_AGE_SECONDS}, s-maxage=${READ_COUNT_SHARED_MAX_AGE_SECONDS}`,
+    )
+  }
+  if (result.reason === 'http' && result.status === 404) {
+    return errorResponse(404, 'not_found')
+  }
+  if (result.reason === 'timeout') {
+    return errorResponse(504, 'unavailable')
+  }
+  return errorResponse(502, 'unavailable')
+}

--- a/src/lib/read-count.test.ts
+++ b/src/lib/read-count.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  buildReadCountUrl,
+  fetchReadCount,
+  formatReadCount,
+  parseReadCount,
+} from './read-count'
+
+describe('buildReadCountUrl', () => {
+  it('encodes the exact canonical path for GoatCounter', () => {
+    expect(buildReadCountUrl('/blog/nested/an article')).toBe(
+      'https://shariq-blog.goatcounter.com/counter/%2Fblog%2Fnested%2Fan%20article.json',
+    )
+  })
+
+  it.each(['/blog/post?source=home', '/blog/post#section', 'blog/post'])(
+    'rejects non-canonical path %s',
+    (path) => {
+      expect(() => buildReadCountUrl(path)).toThrow(TypeError)
+    },
+  )
+})
+
+describe('parseReadCount', () => {
+  it('parses plain and comma-formatted counts', () => {
+    expect(parseReadCount({ count: '0' })).toBe(0)
+    expect(parseReadCount({ count: '999' })).toBe(999)
+    expect(parseReadCount({ count: '1,234,567' })).toBe(1_234_567)
+  })
+
+  it.each([
+    '1.234.567',
+    "1'234'567",
+    '1 234 567',
+    '1\u00a0234\u00a0567',
+    '1\u202f234\u202f567',
+  ])('parses GoatCounter separator format %s', (count) => {
+    expect(parseReadCount({ count })).toBe(1_234_567)
+  })
+
+  it.each([
+    null,
+    {},
+    { count: 12 },
+    { count: '' },
+    { count: '1,23' },
+    { count: '1,234.567' },
+    { count: '-1' },
+    { count: '12 views' },
+    { count: '9,007,199,254,740,992' },
+  ])('rejects malformed payload %#', (payload) => {
+    expect(parseReadCount(payload)).toBeNull()
+  })
+})
+
+describe('formatReadCount', () => {
+  it('formats zero, one, and many views precisely', () => {
+    expect(formatReadCount(0)).toBe('0 views')
+    expect(formatReadCount(1)).toBe('1 view')
+    expect(formatReadCount(1_234)).toBe('1,234 views')
+  })
+
+  it.each([-1, 1.5, Number.MAX_SAFE_INTEGER + 1])(
+    'rejects invalid count %s',
+    (count) => {
+      expect(() => formatReadCount(count)).toThrow(RangeError)
+    },
+  )
+})
+
+describe('fetchReadCount', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns a parsed count and omits credentials', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ count: '2,345' }), {
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+
+    await expect(
+      fetchReadCount('/blog/post', { fetch: fetchMock }),
+    ).resolves.toEqual({ ok: true, count: 2_345 })
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://shariq-blog.goatcounter.com/counter/%2Fblog%2Fpost.json',
+      expect.objectContaining({
+        credentials: 'omit',
+        headers: { accept: 'application/json' },
+        signal: expect.any(AbortSignal),
+      }),
+    )
+  })
+
+  it.each([403, 404])(
+    'returns an HTTP failure for status %s',
+    async (status) => {
+      const fetchMock = vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(new Response(null, { status }))
+
+      await expect(
+        fetchReadCount('/blog/post', { fetch: fetchMock }),
+      ).resolves.toEqual({ ok: false, reason: 'http', status })
+    },
+  )
+
+  it('returns an invalid response for malformed JSON', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response('{', { status: 200 }))
+
+    await expect(
+      fetchReadCount('/blog/post', { fetch: fetchMock }),
+    ).resolves.toEqual({ ok: false, reason: 'invalid-response' })
+  })
+
+  it('returns an invalid response for a malformed count', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(JSON.stringify({ count: 'many' })))
+
+    await expect(
+      fetchReadCount('/blog/post', { fetch: fetchMock }),
+    ).resolves.toEqual({ ok: false, reason: 'invalid-response' })
+  })
+
+  it('returns a network failure for fetch errors', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockRejectedValue(new TypeError('Failed to fetch'))
+
+    await expect(
+      fetchReadCount('/blog/post', { fetch: fetchMock }),
+    ).resolves.toEqual({ ok: false, reason: 'network' })
+  })
+
+  it('aborts and returns a timeout failure', async () => {
+    vi.useFakeTimers()
+    const fetchMock: typeof fetch = async (_input, init) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener(
+          'abort',
+          () => reject(new DOMException('Aborted', 'AbortError')),
+          { once: true },
+        )
+      })
+
+    const result = fetchReadCount('/blog/post', {
+      fetch: fetchMock,
+      timeoutMs: 50,
+    })
+    await vi.advanceTimersByTimeAsync(50)
+
+    await expect(result).resolves.toEqual({ ok: false, reason: 'timeout' })
+  })
+
+  it('does not fetch when the caller signal is already aborted', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const fetchMock = vi.fn<typeof fetch>()
+
+    await expect(
+      fetchReadCount('/blog/post', {
+        fetch: fetchMock,
+        signal: controller.signal,
+      }),
+    ).resolves.toEqual({ ok: false, reason: 'aborted' })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('does not swallow unexpected programming errors', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockRejectedValue(new Error('broken fetch adapter'))
+
+    await expect(
+      fetchReadCount('/blog/post', { fetch: fetchMock }),
+    ).rejects.toThrow('broken fetch adapter')
+  })
+
+  it('does not classify response processing TypeErrors as network failures', async () => {
+    const response = new Response(JSON.stringify({ count: '1' }))
+    Object.defineProperty(response, 'ok', {
+      get() {
+        throw new TypeError('broken response adapter')
+      },
+    })
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(response)
+
+    await expect(
+      fetchReadCount('/blog/post', { fetch: fetchMock }),
+    ).rejects.toThrow('broken response adapter')
+  })
+})

--- a/src/lib/read-count.test.ts
+++ b/src/lib/read-count.test.ts
@@ -170,6 +170,18 @@ describe('fetchReadCount', () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
+  it.each([0, -1, 1.5, 2_147_483_648, Number.POSITIVE_INFINITY])(
+    'rejects unsupported timeout %s',
+    async (timeoutMs) => {
+      const fetchMock = vi.fn<typeof fetch>()
+
+      await expect(
+        fetchReadCount('/blog/post', { fetch: fetchMock, timeoutMs }),
+      ).rejects.toThrow(RangeError)
+      expect(fetchMock).not.toHaveBeenCalled()
+    },
+  )
+
   it('does not swallow unexpected programming errors', async () => {
     const fetchMock = vi
       .fn<typeof fetch>()

--- a/src/lib/read-count.test.ts
+++ b/src/lib/read-count.test.ts
@@ -175,6 +175,26 @@ describe('fetchReadCount', () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
+  it('aborts an in-flight fetch when the caller signal aborts', async () => {
+    const controller = new AbortController()
+    const fetchMock: typeof fetch = async (_input, init) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener(
+          'abort',
+          () => reject(new DOMException('Aborted', 'AbortError')),
+          { once: true },
+        )
+      })
+
+    const result = fetchReadCount('/blog/post', {
+      fetch: fetchMock,
+      signal: controller.signal,
+    })
+    controller.abort()
+
+    await expect(result).resolves.toEqual({ ok: false, reason: 'aborted' })
+  })
+
   it.each([0, -1, 1.5, 2_147_483_648, Number.POSITIVE_INFINITY])(
     'rejects unsupported timeout %s',
     async (timeoutMs) => {

--- a/src/lib/read-count.test.ts
+++ b/src/lib/read-count.test.ts
@@ -96,13 +96,18 @@ describe('fetchReadCount', () => {
   it.each([403, 404])(
     'returns an HTTP failure for status %s',
     async (status) => {
+      let requestSignal: AbortSignal | undefined
       const fetchMock = vi
         .fn<typeof fetch>()
-        .mockResolvedValue(new Response(null, { status }))
+        .mockImplementation(async (_input, init) => {
+          requestSignal = init?.signal ?? undefined
+          return new Response(null, { status })
+        })
 
       await expect(
         fetchReadCount('/blog/post', { fetch: fetchMock }),
       ).resolves.toEqual({ ok: false, reason: 'http', status })
+      expect(requestSignal?.aborted).toBe(true)
     },
   )
 

--- a/src/lib/read-count.test.ts
+++ b/src/lib/read-count.test.ts
@@ -7,9 +7,9 @@ import {
 } from './read-count'
 
 describe('buildReadCountUrl', () => {
-  it('encodes the exact canonical path for GoatCounter', () => {
-    expect(buildReadCountUrl('/blog/nested/an article')).toBe(
-      'https://shariq-blog.goatcounter.com/counter/%2Fblog%2Fnested%2Fan%20article.json',
+  it('encodes the exact URL pathname for GoatCounter', () => {
+    expect(buildReadCountUrl('/blog/nested/an%20article')).toBe(
+      'https://shariq-blog.goatcounter.com/counter/%2Fblog%2Fnested%2Fan%2520article.json',
     )
   })
 

--- a/src/lib/read-count.test.ts
+++ b/src/lib/read-count.test.ts
@@ -1,24 +1,64 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  buildGoatCounterReadCountUrl,
   buildReadCountUrl,
   fetchReadCount,
   formatReadCount,
+  isCanonicalArticlePath,
   parseReadCount,
 } from './read-count'
 
+const ARTICLE_PATH = '/blog/post/'
+
 describe('buildReadCountUrl', () => {
-  it('encodes the exact URL pathname for GoatCounter', () => {
-    expect(buildReadCountUrl('/blog/nested/an%20article')).toBe(
-      'https://shariq-blog.goatcounter.com/counter/%2Fblog%2Fnested%2Fan%2520article.json',
+  it('encodes the exact URL pathname for the same-origin endpoint', () => {
+    expect(buildReadCountUrl('/blog/nested/an%20article/')).toBe(
+      '/api/read-count?path=%2Fblog%2Fnested%2Fan%2520article%2F',
     )
   })
 
-  it.each(['/blog/post?source=home', '/blog/post#section', 'blog/post'])(
+  it('encodes the exact URL pathname for GoatCounter upstream', () => {
+    expect(buildGoatCounterReadCountUrl('/blog/nested/an%20article/')).toBe(
+      'https://shariq-blog.goatcounter.com/counter/%2Fblog%2Fnested%2Fan%2520article%2F.json',
+    )
+  })
+
+  it.each(['/blog/post/?source=home', '/blog/post/#section', 'blog/post/'])(
     'rejects non-canonical path %s',
     (path) => {
       expect(() => buildReadCountUrl(path)).toThrow(TypeError)
     },
   )
+})
+
+describe('isCanonicalArticlePath', () => {
+  it.each([
+    '/blog/post/',
+    '/blog/nested/post/',
+    '/blog/an%20article/',
+    '/blog/nextjs_context/',
+  ])('accepts canonical article path %s', (path) => {
+    expect(isCanonicalArticlePath(path)).toBe(true)
+  })
+
+  it.each([
+    '',
+    '/',
+    '/projects/',
+    '/blog/',
+    '/blog/post',
+    '/blog//post/',
+    '/blog/./post/',
+    '/blog/../post/',
+    '/blog/%2e%2e/post/',
+    '/blog/%2Fsecret/',
+    '/blog/bad%path/',
+    '/blog/raw space/',
+    '/blog/back\\slash/',
+    `/blog/${'a'.repeat(512)}/`,
+  ])('rejects invalid article path %s', (path) => {
+    expect(isCanonicalArticlePath(path)).toBe(false)
+  })
 })
 
 describe('parseReadCount', () => {
@@ -81,10 +121,10 @@ describe('fetchReadCount', () => {
     )
 
     await expect(
-      fetchReadCount('/blog/post', { fetch: fetchMock }),
+      fetchReadCount(ARTICLE_PATH, { fetch: fetchMock }),
     ).resolves.toEqual({ ok: true, count: 2_345 })
     expect(fetchMock).toHaveBeenCalledWith(
-      'https://shariq-blog.goatcounter.com/counter/%2Fblog%2Fpost.json',
+      '/api/read-count?path=%2Fblog%2Fpost%2F',
       expect.objectContaining({
         credentials: 'omit',
         headers: { accept: 'application/json' },
@@ -105,7 +145,7 @@ describe('fetchReadCount', () => {
         })
 
       await expect(
-        fetchReadCount('/blog/post', { fetch: fetchMock }),
+        fetchReadCount(ARTICLE_PATH, { fetch: fetchMock }),
       ).resolves.toEqual({ ok: false, reason: 'http', status })
       expect(requestSignal?.aborted).toBe(true)
     },
@@ -117,7 +157,7 @@ describe('fetchReadCount', () => {
       .mockResolvedValue(new Response('{', { status: 200 }))
 
     await expect(
-      fetchReadCount('/blog/post', { fetch: fetchMock }),
+      fetchReadCount(ARTICLE_PATH, { fetch: fetchMock }),
     ).resolves.toEqual({ ok: false, reason: 'invalid-response' })
   })
 
@@ -127,7 +167,7 @@ describe('fetchReadCount', () => {
       .mockResolvedValue(new Response(JSON.stringify({ count: 'many' })))
 
     await expect(
-      fetchReadCount('/blog/post', { fetch: fetchMock }),
+      fetchReadCount(ARTICLE_PATH, { fetch: fetchMock }),
     ).resolves.toEqual({ ok: false, reason: 'invalid-response' })
   })
 
@@ -137,7 +177,7 @@ describe('fetchReadCount', () => {
       .mockRejectedValue(new TypeError('Failed to fetch'))
 
     await expect(
-      fetchReadCount('/blog/post', { fetch: fetchMock }),
+      fetchReadCount(ARTICLE_PATH, { fetch: fetchMock }),
     ).resolves.toEqual({ ok: false, reason: 'network' })
   })
 
@@ -152,7 +192,7 @@ describe('fetchReadCount', () => {
         )
       })
 
-    const result = fetchReadCount('/blog/post', {
+    const result = fetchReadCount(ARTICLE_PATH, {
       fetch: fetchMock,
       timeoutMs: 50,
     })
@@ -167,7 +207,7 @@ describe('fetchReadCount', () => {
     const fetchMock = vi.fn<typeof fetch>()
 
     await expect(
-      fetchReadCount('/blog/post', {
+      fetchReadCount(ARTICLE_PATH, {
         fetch: fetchMock,
         signal: controller.signal,
       }),
@@ -186,7 +226,7 @@ describe('fetchReadCount', () => {
         )
       })
 
-    const result = fetchReadCount('/blog/post', {
+    const result = fetchReadCount(ARTICLE_PATH, {
       fetch: fetchMock,
       signal: controller.signal,
     })
@@ -201,7 +241,7 @@ describe('fetchReadCount', () => {
       const fetchMock = vi.fn<typeof fetch>()
 
       await expect(
-        fetchReadCount('/blog/post', { fetch: fetchMock, timeoutMs }),
+        fetchReadCount(ARTICLE_PATH, { fetch: fetchMock, timeoutMs }),
       ).rejects.toThrow(RangeError)
       expect(fetchMock).not.toHaveBeenCalled()
     },
@@ -213,7 +253,7 @@ describe('fetchReadCount', () => {
       .mockRejectedValue(new Error('broken fetch adapter'))
 
     await expect(
-      fetchReadCount('/blog/post', { fetch: fetchMock }),
+      fetchReadCount(ARTICLE_PATH, { fetch: fetchMock }),
     ).rejects.toThrow('broken fetch adapter')
   })
 
@@ -227,7 +267,7 @@ describe('fetchReadCount', () => {
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(response)
 
     await expect(
-      fetchReadCount('/blog/post', { fetch: fetchMock }),
+      fetchReadCount(ARTICLE_PATH, { fetch: fetchMock }),
     ).rejects.toThrow('broken response adapter')
   })
 })

--- a/src/lib/read-count.test.ts
+++ b/src/lib/read-count.test.ts
@@ -5,6 +5,7 @@ import {
   fetchReadCount,
   formatReadCount,
   isCanonicalArticlePath,
+  MAX_READ_COUNT_RESPONSE_BYTES,
   parseReadCount,
 } from './read-count'
 
@@ -165,6 +166,24 @@ describe('fetchReadCount', () => {
     const fetchMock = vi
       .fn<typeof fetch>()
       .mockResolvedValue(new Response(JSON.stringify({ count: 'many' })))
+
+    await expect(
+      fetchReadCount(ARTICLE_PATH, { fetch: fetchMock }),
+    ).resolves.toEqual({ ok: false, reason: 'invalid-response' })
+  })
+
+  it.each([
+    new Response(
+      JSON.stringify({ count: '1' }) +
+        ' '.repeat(MAX_READ_COUNT_RESPONSE_BYTES),
+    ),
+    new Response(JSON.stringify({ count: '1' }), {
+      headers: {
+        'content-length': String(MAX_READ_COUNT_RESPONSE_BYTES + 1),
+      },
+    }),
+  ])('rejects oversized responses', async (response) => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(response)
 
     await expect(
       fetchReadCount(ARTICLE_PATH, { fetch: fetchMock }),

--- a/src/lib/read-count.ts
+++ b/src/lib/read-count.ts
@@ -140,6 +140,7 @@ export async function fetchReadCount(
     }
 
     if (!response.ok) {
+      controller.abort()
       return { ok: false, reason: 'http', status: response.status }
     }
 

--- a/src/lib/read-count.ts
+++ b/src/lib/read-count.ts
@@ -106,14 +106,14 @@ export async function fetchReadCount(
     )
   }
 
-  if (options.signal?.aborted) {
-    return { ok: false, reason: 'aborted' }
-  }
-
   const controller = new AbortController()
   let timedOut = false
   const abortFromCaller = () => controller.abort(options.signal?.reason)
   options.signal?.addEventListener('abort', abortFromCaller, { once: true })
+  if (options.signal?.aborted) {
+    options.signal.removeEventListener('abort', abortFromCaller)
+    return { ok: false, reason: 'aborted' }
+  }
 
   const timeout = setTimeout(() => {
     timedOut = true

--- a/src/lib/read-count.ts
+++ b/src/lib/read-count.ts
@@ -4,6 +4,7 @@ export const GOATCOUNTER_COUNTER_BASE_URL =
 export const READ_COUNT_API_PATH = '/api/read-count'
 export const DEFAULT_READ_COUNT_TIMEOUT_MS = 4_000
 export const MAX_ARTICLE_PATH_LENGTH = 512
+export const MAX_READ_COUNT_RESPONSE_BYTES = 4_096
 
 const MAX_TIMER_DELAY_MS = 2_147_483_647
 
@@ -133,6 +134,65 @@ function classifyRequestFailure(
   return null
 }
 
+class InvalidReadCountResponseError extends Error {}
+
+async function readLimitedJson(response: Response): Promise<unknown> {
+  const contentLength = response.headers.get('content-length')
+  if (contentLength !== null) {
+    const declaredBytes = Number(contentLength)
+    if (
+      !Number.isSafeInteger(declaredBytes) ||
+      declaredBytes < 0 ||
+      declaredBytes > MAX_READ_COUNT_RESPONSE_BYTES
+    ) {
+      await response.body?.cancel().catch(() => undefined)
+      throw new InvalidReadCountResponseError()
+    }
+  }
+
+  if (!response.body) {
+    throw new InvalidReadCountResponseError()
+  }
+
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder('utf-8', { fatal: true })
+  let body = ''
+  let receivedBytes = 0
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+
+      receivedBytes += value.byteLength
+      if (receivedBytes > MAX_READ_COUNT_RESPONSE_BYTES) {
+        await reader.cancel().catch(() => undefined)
+        throw new InvalidReadCountResponseError()
+      }
+
+      try {
+        body += decoder.decode(value, { stream: true })
+      } catch {
+        await reader.cancel().catch(() => undefined)
+        throw new InvalidReadCountResponseError()
+      }
+    }
+    try {
+      body += decoder.decode()
+    } catch {
+      throw new InvalidReadCountResponseError()
+    }
+  } finally {
+    reader.releaseLock()
+  }
+
+  try {
+    return JSON.parse(body) as unknown
+  } catch {
+    throw new InvalidReadCountResponseError()
+  }
+}
+
 async function fetchReadCountFromUrl(
   url: string,
   options: ReadCountFetchOptions = {},
@@ -188,9 +248,9 @@ async function fetchReadCountFromUrl(
 
     let payload: unknown
     try {
-      payload = await response.json()
+      payload = await readLimitedJson(response)
     } catch (error) {
-      if (error instanceof SyntaxError) {
+      if (error instanceof InvalidReadCountResponseError) {
         return { ok: false, reason: 'invalid-response' }
       }
       const failure = classifyRequestFailure(

--- a/src/lib/read-count.ts
+++ b/src/lib/read-count.ts
@@ -1,7 +1,9 @@
 export const GOATCOUNTER_COUNTER_BASE_URL =
   'https://shariq-blog.goatcounter.com/counter'
 
+export const READ_COUNT_API_PATH = '/api/read-count'
 export const DEFAULT_READ_COUNT_TIMEOUT_MS = 4_000
+export const MAX_ARTICLE_PATH_LENGTH = 512
 
 const MAX_TIMER_DELAY_MS = 2_147_483_647
 
@@ -21,15 +23,56 @@ export interface ReadCountFetchOptions {
   timeoutMs?: number
 }
 
-// `path` is the exact URL pathname; GoatCounter's route encoding also escapes
-// any percent escapes already present in that pathname.
-export function buildReadCountUrl(path: string): string {
-  if (!path.startsWith('/') || path.includes('?') || path.includes('#')) {
-    throw new TypeError(
-      'Read count paths must be absolute paths without a query or hash',
-    )
+const INVALID_RAW_PATH_CHARACTERS = /[\u0000-\u0020\u007f\\?#]/
+const INVALID_DECODED_SEGMENT_CHARACTERS = /[\u0000-\u001f\u007f\\/]/
+
+export function isCanonicalArticlePath(path: unknown): path is string {
+  if (
+    typeof path !== 'string' ||
+    path.length > MAX_ARTICLE_PATH_LENGTH ||
+    !path.startsWith('/blog/') ||
+    !path.endsWith('/') ||
+    INVALID_RAW_PATH_CHARACTERS.test(path)
+  ) {
+    return false
   }
 
+  const segments = path.slice(1, -1).split('/')
+  if (segments.length < 2 || segments.some((segment) => segment.length === 0)) {
+    return false
+  }
+
+  return segments.every((segment) => {
+    let decoded: string
+    try {
+      decoded = decodeURIComponent(segment)
+    } catch {
+      return false
+    }
+
+    return (
+      decoded !== '.' &&
+      decoded !== '..' &&
+      !INVALID_DECODED_SEGMENT_CHARACTERS.test(decoded)
+    )
+  })
+}
+
+function assertCanonicalArticlePath(path: string): void {
+  if (!isCanonicalArticlePath(path)) {
+    throw new TypeError('Read counts require a canonical article pathname')
+  }
+}
+
+export function buildReadCountUrl(path: string): string {
+  assertCanonicalArticlePath(path)
+  return `${READ_COUNT_API_PATH}?${new URLSearchParams({ path }).toString()}`
+}
+
+// `path` is the exact URL pathname; GoatCounter's route encoding also escapes
+// any percent escapes already present in that pathname.
+export function buildGoatCounterReadCountUrl(path: string): string {
+  assertCanonicalArticlePath(path)
   return `${GOATCOUNTER_COUNTER_BASE_URL}/${encodeURIComponent(path)}.json`
 }
 
@@ -90,11 +133,10 @@ function classifyRequestFailure(
   return null
 }
 
-export async function fetchReadCount(
-  path: string,
+async function fetchReadCountFromUrl(
+  url: string,
   options: ReadCountFetchOptions = {},
 ): Promise<ReadCountResult> {
-  const url = buildReadCountUrl(path)
   const timeoutMs = options.timeoutMs ?? DEFAULT_READ_COUNT_TIMEOUT_MS
   if (
     !Number.isInteger(timeoutMs) ||
@@ -169,4 +211,18 @@ export async function fetchReadCount(
     clearTimeout(timeout)
     options.signal?.removeEventListener('abort', abortFromCaller)
   }
+}
+
+export async function fetchReadCount(
+  path: string,
+  options: ReadCountFetchOptions = {},
+): Promise<ReadCountResult> {
+  return fetchReadCountFromUrl(buildReadCountUrl(path), options)
+}
+
+export async function fetchGoatCounterReadCount(
+  path: string,
+  options: ReadCountFetchOptions = {},
+): Promise<ReadCountResult> {
+  return fetchReadCountFromUrl(buildGoatCounterReadCountUrl(path), options)
 }

--- a/src/lib/read-count.ts
+++ b/src/lib/read-count.ts
@@ -1,0 +1,161 @@
+export const GOATCOUNTER_COUNTER_BASE_URL =
+  'https://shariq-blog.goatcounter.com/counter'
+
+export const DEFAULT_READ_COUNT_TIMEOUT_MS = 4_000
+
+export type ReadCountResult =
+  | { ok: true; count: number }
+  | {
+      ok: false
+      reason: 'aborted' | 'http' | 'invalid-response' | 'network' | 'timeout'
+      status?: number
+    }
+
+type ReadCountFailure = Exclude<ReadCountResult, { ok: true }>
+
+export interface ReadCountFetchOptions {
+  fetch?: typeof globalThis.fetch
+  signal?: AbortSignal
+  timeoutMs?: number
+}
+
+export function buildReadCountUrl(path: string): string {
+  if (!path.startsWith('/') || path.includes('?') || path.includes('#')) {
+    throw new TypeError(
+      'Read count paths must be absolute paths without a query or hash',
+    )
+  }
+
+  return `${GOATCOUNTER_COUNTER_BASE_URL}/${encodeURIComponent(path)}.json`
+}
+
+export function parseReadCount(payload: unknown): number | null {
+  if (
+    typeof payload !== 'object' ||
+    payload === null ||
+    !('count' in payload) ||
+    typeof payload.count !== 'string'
+  ) {
+    return null
+  }
+
+  const value = payload.count
+  if (
+    !/^(?:0|[1-9]\d*|[1-9]\d{0,2}([,.'\u0020\u00a0\u202f])\d{3}(?:\1\d{3})*)$/.test(
+      value,
+    )
+  ) {
+    return null
+  }
+
+  const count = Number(value.replace(/[,.'\u0020\u00a0\u202f]/g, ''))
+  return Number.isSafeInteger(count) ? count : null
+}
+
+const countFormatter = new Intl.NumberFormat('en-US')
+
+export function formatReadCount(count: number): string {
+  if (!Number.isSafeInteger(count) || count < 0) {
+    throw new RangeError('Read counts must be non-negative safe integers')
+  }
+
+  return `${countFormatter.format(count)} ${count === 1 ? 'view' : 'views'}`
+}
+
+function classifyRequestFailure(
+  error: unknown,
+  timedOut: boolean,
+  signal: AbortSignal | undefined,
+  typeErrorIsNetwork: boolean,
+): ReadCountFailure | null {
+  if (timedOut) {
+    return { ok: false, reason: 'timeout' }
+  }
+  if (signal?.aborted) {
+    return { ok: false, reason: 'aborted' }
+  }
+  if (error instanceof DOMException && error.name === 'AbortError') {
+    return { ok: false, reason: 'aborted' }
+  }
+  if (
+    (typeErrorIsNetwork && error instanceof TypeError) ||
+    (error instanceof DOMException && error.name === 'NetworkError')
+  ) {
+    return { ok: false, reason: 'network' }
+  }
+  return null
+}
+
+export async function fetchReadCount(
+  path: string,
+  options: ReadCountFetchOptions = {},
+): Promise<ReadCountResult> {
+  const url = buildReadCountUrl(path)
+  const timeoutMs = options.timeoutMs ?? DEFAULT_READ_COUNT_TIMEOUT_MS
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new RangeError('Read count timeouts must be positive finite numbers')
+  }
+
+  if (options.signal?.aborted) {
+    return { ok: false, reason: 'aborted' }
+  }
+
+  const controller = new AbortController()
+  let timedOut = false
+  const abortFromCaller = () => controller.abort(options.signal?.reason)
+  options.signal?.addEventListener('abort', abortFromCaller, { once: true })
+
+  const timeout = setTimeout(() => {
+    timedOut = true
+    controller.abort()
+  }, timeoutMs)
+
+  try {
+    let response: Response
+    try {
+      response = await (options.fetch ?? globalThis.fetch)(url, {
+        credentials: 'omit',
+        headers: { accept: 'application/json' },
+        signal: controller.signal,
+      })
+    } catch (error) {
+      const failure = classifyRequestFailure(
+        error,
+        timedOut,
+        options.signal,
+        true,
+      )
+      if (failure) return failure
+      throw error
+    }
+
+    if (!response.ok) {
+      return { ok: false, reason: 'http', status: response.status }
+    }
+
+    let payload: unknown
+    try {
+      payload = await response.json()
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        return { ok: false, reason: 'invalid-response' }
+      }
+      const failure = classifyRequestFailure(
+        error,
+        timedOut,
+        options.signal,
+        false,
+      )
+      if (failure) return failure
+      throw error
+    }
+
+    const count = parseReadCount(payload)
+    return count === null
+      ? { ok: false, reason: 'invalid-response' }
+      : { ok: true, count }
+  } finally {
+    clearTimeout(timeout)
+    options.signal?.removeEventListener('abort', abortFromCaller)
+  }
+}

--- a/src/lib/read-count.ts
+++ b/src/lib/read-count.ts
@@ -19,6 +19,8 @@ export interface ReadCountFetchOptions {
   timeoutMs?: number
 }
 
+// `path` is the exact URL pathname; GoatCounter's route encoding also escapes
+// any percent escapes already present in that pathname.
 export function buildReadCountUrl(path: string): string {
   if (!path.startsWith('/') || path.includes('?') || path.includes('#')) {
     throw new TypeError(

--- a/src/lib/read-count.ts
+++ b/src/lib/read-count.ts
@@ -3,6 +3,8 @@ export const GOATCOUNTER_COUNTER_BASE_URL =
 
 export const DEFAULT_READ_COUNT_TIMEOUT_MS = 4_000
 
+const MAX_TIMER_DELAY_MS = 2_147_483_647
+
 export type ReadCountResult =
   | { ok: true; count: number }
   | {
@@ -94,8 +96,14 @@ export async function fetchReadCount(
 ): Promise<ReadCountResult> {
   const url = buildReadCountUrl(path)
   const timeoutMs = options.timeoutMs ?? DEFAULT_READ_COUNT_TIMEOUT_MS
-  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
-    throw new RangeError('Read count timeouts must be positive finite numbers')
+  if (
+    !Number.isInteger(timeoutMs) ||
+    timeoutMs < 1 ||
+    timeoutMs > MAX_TIMER_DELAY_MS
+  ) {
+    throw new RangeError(
+      `Read count timeouts must be integers from 1 to ${MAX_TIMER_DELAY_MS}`,
+    )
   }
 
   if (options.signal?.aborted) {

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -29,8 +29,9 @@ const readingMinutes = remarkPluginFrontmatter?.readingTime
   ? Math.ceil(remarkPluginFrontmatter.readingTime / 60)
   : undefined;
 const slug = post.id.replace(/\.mdx$/, "");
+const articlePath = Astro.url.pathname;
 const ogImage = new URL(`/og/${slug}.png`, SITE.url).toString();
-const postUrl = new URL(`/blog/${slug}`, SITE.url).toString();
+const postUrl = new URL(articlePath, SITE.url).toString();
 const jsonLd = [
   {
     "@context": "https://schema.org",
@@ -84,6 +85,7 @@ const jsonLd = [
       bucketLabel={bucket.label}
       summary={post.data.summary}
       readingMinutes={readingMinutes}
+      articlePath={articlePath}
     />
 
     {headings.length > 4 && <Toc headings={headings} />}
@@ -102,7 +104,7 @@ const jsonLd = [
     )}
 
     <ShareFooter
-      url={post.data.canonical ?? new URL(`/blog/${slug}`, SITE.url).toString()}
+      url={post.data.canonical ?? postUrl}
       title={post.data.title}
       xHandle="ShariqHirani"
       feedUrl="/feed.xml"

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -29,7 +29,9 @@ const readingMinutes = remarkPluginFrontmatter?.readingTime
   ? Math.ceil(remarkPluginFrontmatter.readingTime / 60)
   : undefined;
 const slug = post.id.replace(/\.mdx$/, "");
-const articlePath = Astro.url.pathname;
+const articlePath = Astro.url.pathname.endsWith("/")
+  ? Astro.url.pathname
+  : `${Astro.url.pathname}/`;
 const ogImage = new URL(`/og/${slug}.png`, SITE.url).toString();
 const postUrl = new URL(articlePath, SITE.url).toString();
 const jsonLd = [

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -22,6 +22,23 @@ function walkMdx(dir: string, prefix = ''): string[] {
 }
 
 const SLUGS = walkMdx('src/content/writing')
+const READ_COUNT_SLUG =
+  'rewriting-our-engine-with-anthropic-claude-opus-4-8-and-dynamic-workflows'
+const READ_COUNT_PATH = `/blog/${READ_COUNT_SLUG}/`
+const READ_COUNT_ROUTE = 'https://shariq-blog.goatcounter.com/counter/**'
+const READ_COUNT_URL = `https://shariq-blog.goatcounter.com/counter/${encodeURIComponent(READ_COUNT_PATH)}.json`
+
+test.beforeEach(async ({ page }) => {
+  await page.route('**/gc.zgo.at/count.js', (route) =>
+    route.fulfill({ contentType: 'application/javascript', body: '' }),
+  )
+  await page.route(READ_COUNT_ROUTE, (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({}),
+    }),
+  )
+})
 
 test('homepage renders the zine hero', async ({ page }) => {
   await page.goto('/')
@@ -252,6 +269,97 @@ for (const slug of SLUGS) {
     await expect(page.locator('h1').first()).toBeVisible()
   })
 }
+
+test('blog post reveals GoatCounter views without responsive or console regressions', async ({
+  page,
+}) => {
+  const errors: string[] = []
+  const requests: string[] = []
+  page.on('console', (message) => {
+    if (message.type() === 'error') errors.push(message.text())
+  })
+  page.on('pageerror', (error) => errors.push(error.message))
+  await page.unroute(READ_COUNT_ROUTE)
+  await page.route(READ_COUNT_ROUTE, (route) => {
+    requests.push(route.request().url())
+    return route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ count: '1,234' }),
+    })
+  })
+
+  for (const viewport of [
+    { width: 1280, height: 900 },
+    { width: 390, height: 844 },
+  ]) {
+    await page.setViewportSize(viewport)
+    await page.goto(READ_COUNT_PATH)
+
+    const readCount = page.locator('[data-read-count]')
+    await expect(readCount).toHaveAttribute('data-path', READ_COUNT_PATH)
+    await expect(readCount).toHaveAttribute('data-read-count-state', 'loaded')
+    await expect(readCount).toBeVisible()
+    await expect(readCount).toContainText('1,234 views')
+
+    const widths = await page.evaluate(() => ({
+      viewport: document.documentElement.clientWidth,
+      document: document.documentElement.scrollWidth,
+    }))
+    expect(widths.document).toBeLessThanOrEqual(widths.viewport)
+  }
+
+  expect(requests).toEqual([READ_COUNT_URL, READ_COUNT_URL])
+  expect(errors).toEqual([])
+})
+
+test('blog post keeps unavailable views hidden and non-blog pages omit them', async ({
+  page,
+}) => {
+  const pageErrors: string[] = []
+  await page.addInitScript(() => {
+    const consoleErrors: string[] = []
+    Object.defineProperty(window, '__readCountConsoleErrors', {
+      value: consoleErrors,
+      configurable: true,
+    })
+    const originalConsoleError = console.error
+    console.error = (...args) => {
+      consoleErrors.push(args.map(String).join(' '))
+      originalConsoleError(...args)
+    }
+  })
+  page.on('pageerror', (error) => pageErrors.push(error.message))
+  await page.unroute(READ_COUNT_ROUTE)
+  await page.route(READ_COUNT_ROUTE, (route) =>
+    route.fulfill({ status: 403 }),
+  )
+
+  for (const viewport of [
+    { width: 1280, height: 900 },
+    { width: 390, height: 844 },
+  ]) {
+    await page.setViewportSize(viewport)
+    await page.goto(READ_COUNT_PATH)
+    const readCount = page.locator('[data-read-count]')
+    await expect(readCount).toHaveAttribute(
+      'data-read-count-state',
+      'unavailable',
+    )
+    await expect(readCount).toBeHidden()
+    const consoleErrors = await page.evaluate(
+      () =>
+        (
+          window as Window &
+            typeof globalThis & { __readCountConsoleErrors: string[] }
+        ).__readCountConsoleErrors,
+    )
+    expect(consoleErrors).toEqual([])
+  }
+
+  await page.goto('/')
+  await expect(page.locator('[data-read-count]')).toHaveCount(0)
+  expect(pageErrors).toEqual([])
+})
 
 test('blog post exposes OG image meta and the PNG is built', async ({
   page,

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -25,8 +25,8 @@ const SLUGS = walkMdx('src/content/writing')
 const READ_COUNT_SLUG =
   'rewriting-our-engine-with-anthropic-claude-opus-4-8-and-dynamic-workflows'
 const READ_COUNT_PATH = `/blog/${READ_COUNT_SLUG}/`
-const READ_COUNT_ROUTE = 'https://shariq-blog.goatcounter.com/counter/**'
-const READ_COUNT_URL = `https://shariq-blog.goatcounter.com/counter/${encodeURIComponent(READ_COUNT_PATH)}.json`
+const READ_COUNT_ROUTE = /\/api\/read-count(?:\?|$)/
+const READ_COUNT_URL = `http://localhost:4321/api/read-count?path=${encodeURIComponent(READ_COUNT_PATH)}`
 
 test.beforeEach(async ({ page }) => {
   await page.route('**/gc.zgo.at/count.js', (route) =>
@@ -270,15 +270,21 @@ for (const slug of SLUGS) {
   })
 }
 
-test('blog post reveals GoatCounter views without responsive or console regressions', async ({
+test('blog post uses the same-origin view proxy without responsive or console regressions', async ({
   page,
 }) => {
   const errors: string[] = []
   const requests: string[] = []
+  const directGoatCounterRequests: string[] = []
   page.on('console', (message) => {
     if (message.type() === 'error') errors.push(message.text())
   })
   page.on('pageerror', (error) => errors.push(error.message))
+  page.on('request', (request) => {
+    if (new URL(request.url()).hostname.endsWith('goatcounter.com')) {
+      directGoatCounterRequests.push(request.url())
+    }
+  })
   await page.unroute(READ_COUNT_ROUTE)
   await page.route(READ_COUNT_ROUTE, (route) => {
     requests.push(route.request().url())
@@ -309,6 +315,7 @@ test('blog post reveals GoatCounter views without responsive or console regressi
   }
 
   expect(requests).toEqual([READ_COUNT_URL, READ_COUNT_URL])
+  expect(directGoatCounterRequests).toEqual([])
   expect(errors).toEqual([])
 })
 
@@ -331,7 +338,7 @@ test('blog post keeps unavailable views hidden and non-blog pages omit them', as
   page.on('pageerror', (error) => pageErrors.push(error.message))
   await page.unroute(READ_COUNT_ROUTE)
   await page.route(READ_COUNT_ROUTE, (route) =>
-    route.fulfill({ status: 403 }),
+    route.fulfill({ status: 502 }),
   )
 
   for (const viewport of [


### PR DESCRIPTION
Closes #5

## Summary
- add a reusable, typed GoatCounter read-count helper with exact path encoding, supported separator parsing, timeout/AbortSignal handling, and bounded response parsing
- proxy public counts through same-origin `GET /api/read-count` so Firefox Enhanced Tracking Protection and content blockers do not hide the counter
- validate one canonical `/blog/.../` path, use a fixed GoatCounter upstream, return minimal JSON, and cache successful responses for five minutes in browsers / four hours in shared caches
- progressively reveal accurate `view` / `views` metadata on published article pages while keeping unavailable or malformed results hidden
- keep Playwright hermetic with intercepted same-origin responses and document the required GoatCounter setting

## Validation
- `npm run astro check`
- `npm test` (284 tests)
- `npm run build`
- `npm run test:smoke` (31 Chromium tests)
- focused proxy/helper tests (80 tests)
- Impeccable design detector (no findings)

A focused Playwright Firefox run was attempted after installing Firefox 150.0.2, but this macOS host failed before test execution with a Playwright sandbox/SWGL framebuffer launch error. The deployed-preview network proof below verifies the browser-facing transport is same-origin and contains no direct GoatCounter `/counter/` request.

## Deployed preview evidence
On 2026-08-19, `https://fd8f6e6a.shariq-dev.pages.dev/api/read-count?path=%2Fblog%2Fai-became-my-operating-model%2F` returned HTTP 200, `Content-Type: application/json`, `Cache-Control: public, max-age=300, s-maxage=14400`, and `{"count":"8"}`. An invalid `/projects/` path returned no-store HTTP 400.

A real browser page load recorded:

```json
{"text":"· 8 views","proxyRequests":["https://fd8f6e6a.shariq-dev.pages.dev/api/read-count?path=%2Fblog%2Fai-became-my-operating-model%2F"],"directCounterRequests":[]}
```

CI remains fully mocked and does not depend on the live GoatCounter service.

## Screenshots

**Desktop**

![Article metadata showing 1,234 views at desktop width](https://github.com/user-attachments/assets/65c5f813-d239-4043-bdda-2a0737354930)

**390px mobile**

![Article metadata showing 1,234 views at 390px](https://github.com/user-attachments/assets/125b940c-3521-4aa1-b3d9-4c16a470c489)

## Review disposition
The proxy intentionally accepts any syntactically valid canonical `/blog/.../` pathname. It is not an open proxy or SSRF surface: the upstream host is fixed, the complete pathname is encoded as one GoatCounter counter segment, requests have a four-second timeout, and responses are capped at 4 KiB. A generated known-article allowlist or account-level rate limiter would add build/runtime infrastructure beyond issue #5. Reassess that boundary if Cloudflare function analytics show path-spray abuse.

## Operational note
Public visitor counts must remain enabled in GoatCounter. Successful proxy responses use `max-age=300` and `s-maxage=14400`; unavailable counts remain hidden.