### PR TITLE
Add most popular articles to homepage

### DIFF
--- a/src/components/PopularArticles.astro
+++ b/src/components/PopularArticles.astro
@@ -1,0 +1,238 @@
+---
+import type { PopularArticleCandidate } from "../lib/popular-articles";
+
+interface Props {
+  candidates: PopularArticleCandidate[];
+  featuredId?: string;
+}
+
+const { candidates, featuredId } = Astro.props;
+---
+
+<section
+  class="popular"
+  data-popular-articles
+  data-popular-articles-state="idle"
+  data-featured-id={featuredId}
+  aria-labelledby="popular-articles-heading"
+  aria-live="polite"
+  hidden
+>
+  <h2 id="popular-articles-heading">Most popular</h2>
+  <ol data-popular-list>
+    {
+      candidates.map((candidate) => (
+        <li
+          data-popular-candidate
+          data-article-id={candidate.id}
+          data-article-path={candidate.path}
+          data-published-at={candidate.publishedAt}
+          hidden
+        >
+          <a href={candidate.path}>
+            <span class="title" data-popular-title>
+              {candidate.title}
+            </span>
+            <span class="meta">
+              <span class="bucket" data-popular-bucket>
+                {candidate.bucket}
+              </span>
+              <span class="separator" aria-hidden="true">
+                ·
+              </span>
+              <span class="count" data-popular-count />
+            </span>
+          </a>
+        </li>
+      ))
+    }
+  </ol>
+</section>
+
+<script>
+  import { formatReadCount } from "../lib/read-count";
+  import {
+    resolvePopularArticles,
+    type PopularArticleCandidate,
+  } from "../lib/popular-articles";
+
+  interface CandidateElement {
+    article: PopularArticleCandidate;
+    element: HTMLElement;
+  }
+
+  function readCandidate(element: HTMLElement): CandidateElement | null {
+    const id = element.dataset.articleId;
+    const path = element.dataset.articlePath;
+    const title = element.querySelector<HTMLElement>(
+      "[data-popular-title]",
+    )?.textContent;
+    const bucket = element.querySelector<HTMLElement>(
+      "[data-popular-bucket]",
+    )?.textContent;
+    const publishedAt = Number(element.dataset.publishedAt);
+
+    if (!id || !path || !title || !bucket || !Number.isFinite(publishedAt)) {
+      return null;
+    }
+
+    return {
+      article: { id, path, title, bucket, publishedAt },
+      element,
+    };
+  }
+
+  async function loadPopularArticles(section: HTMLElement) {
+    if (section.dataset.popularArticlesState !== "idle") return;
+
+    const list = section.querySelector<HTMLOListElement>("[data-popular-list]");
+    const candidateElements = [
+      ...section.querySelectorAll<HTMLElement>("[data-popular-candidate]"),
+    ];
+    const candidates = candidateElements.map(readCandidate);
+    const availableCandidates = candidates.filter(
+      (candidate): candidate is CandidateElement => candidate !== null,
+    );
+    if (!list || availableCandidates.length !== candidateElements.length) {
+      section.dataset.popularArticlesState = "unavailable";
+      return;
+    }
+
+    section.dataset.popularArticlesState = "loading";
+    const ranked = await resolvePopularArticles(
+      availableCandidates.map((candidate) => candidate.article),
+      section.dataset.featuredId,
+    );
+    if (ranked.length === 0) {
+      section.dataset.popularArticlesState = "unavailable";
+      return;
+    }
+
+    const elementsById = new Map(
+      availableCandidates.map((candidate) => [
+        candidate.article.id,
+        candidate.element,
+      ]),
+    );
+    const rankedElements = ranked.map((article) => {
+      const element = elementsById.get(article.id);
+      const count = element?.querySelector<HTMLElement>("[data-popular-count]");
+      return element && count ? { article, count, element } : null;
+    });
+    const availableRankedElements = rankedElements.filter(
+      (
+        entry,
+      ): entry is {
+        article: (typeof ranked)[number];
+        count: HTMLElement;
+        element: HTMLElement;
+      } => entry !== null,
+    );
+    if (availableRankedElements.length !== ranked.length) {
+      section.dataset.popularArticlesState = "unavailable";
+      return;
+    }
+
+    const selected = new Set(ranked.map((article) => article.id));
+    candidateElements
+      .filter((element) => !selected.has(element.dataset.articleId ?? ""))
+      .forEach((element) => element.remove());
+
+    for (const { article, count, element } of availableRankedElements) {
+      count.textContent = formatReadCount(article.count);
+      element.hidden = false;
+      list.append(element);
+    }
+
+    section.hidden = false;
+    section.dataset.popularArticlesState = "loaded";
+  }
+
+  document
+    .querySelectorAll<HTMLElement>("[data-popular-articles]")
+    .forEach((section) => {
+      void loadPopularArticles(section);
+    });
+</script>
+
+<style>
+  .popular {
+    margin-bottom: 16px;
+  }
+  h2 {
+    margin-bottom: 24px;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    opacity: 0.5;
+  }
+  ol {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    border-top: 1px solid color-mix(in oklab, var(--fg) 22%, transparent);
+  }
+  li {
+    border-bottom: 1px dashed color-mix(in oklab, var(--fg) 22%, transparent);
+  }
+  a {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 32px;
+    padding: 22px 0;
+    color: inherit;
+    text-decoration: none;
+  }
+  .title {
+    min-width: 0;
+    font-family: var(--font-display);
+    font-size: clamp(21px, 2.6vw, 28px);
+    font-weight: 500;
+    line-height: 1.2;
+    letter-spacing: -0.015em;
+    overflow-wrap: anywhere;
+  }
+  .meta {
+    display: inline-flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 10px;
+    font-family: var(--font-mono);
+    font-size: 10px;
+  }
+  .bucket {
+    color: var(--color-terracotta);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+  .separator {
+    opacity: 0.3;
+  }
+  .count {
+    min-width: 8ch;
+    font-variant-numeric: tabular-nums;
+    text-align: right;
+    white-space: nowrap;
+    opacity: 0.65;
+  }
+  a:hover .title {
+    color: var(--color-terracotta);
+  }
+
+  @media (max-width: 600px) {
+    a {
+      grid-template-columns: 1fr;
+      gap: 10px;
+      padding: 20px 0;
+    }
+    .meta {
+      justify-content: flex-start;
+    }
+    .count {
+      min-width: 0;
+      text-align: left;
+    }
+  }
+</style>

--- a/src/components/PopularArticles.astro
+++ b/src/components/PopularArticles.astro
@@ -52,6 +52,7 @@ const { candidates, featuredId } = Astro.props;
 <script>
   import { formatReadCount } from "../lib/read-count";
   import {
+    hasUniquePopularArticleIds,
     resolvePopularArticles,
     type PopularArticleCandidate,
   } from "../lib/popular-articles";
@@ -93,7 +94,13 @@ const { candidates, featuredId } = Astro.props;
     const availableCandidates = candidates.filter(
       (candidate): candidate is CandidateElement => candidate !== null,
     );
-    if (!list || availableCandidates.length !== candidateElements.length) {
+    if (
+      !list ||
+      availableCandidates.length !== candidateElements.length ||
+      !hasUniquePopularArticleIds(
+        availableCandidates.map((candidate) => candidate.article),
+      )
+    ) {
       section.dataset.popularArticlesState = "unavailable";
       return;
     }

--- a/src/components/PopularArticles.astro
+++ b/src/components/PopularArticles.astro
@@ -54,6 +54,7 @@ const { candidates, featuredId } = Astro.props;
   import {
     hasUniquePopularArticleIds,
     resolvePopularArticles,
+    type PopularArticle,
     type PopularArticleCandidate,
   } from "../lib/popular-articles";
 
@@ -106,10 +107,16 @@ const { candidates, featuredId } = Astro.props;
     }
 
     section.dataset.popularArticlesState = "loading";
-    const ranked = await resolvePopularArticles(
-      availableCandidates.map((candidate) => candidate.article),
-      section.dataset.featuredId,
-    );
+    let ranked: PopularArticle[];
+    try {
+      ranked = await resolvePopularArticles(
+        availableCandidates.map((candidate) => candidate.article),
+        section.dataset.featuredId,
+      );
+    } catch {
+      section.dataset.popularArticlesState = "unavailable";
+      return;
+    }
     if (ranked.length === 0) {
       section.dataset.popularArticlesState = "unavailable";
       return;

--- a/src/lib/popular-articles.test.ts
+++ b/src/lib/popular-articles.test.ts
@@ -4,6 +4,7 @@ import {
   POPULAR_ARTICLE_FETCH_CONCURRENCY,
   buildArticlePath,
   fetchPopularArticleCounts,
+  hasUniquePopularArticleIds,
   rankPopularArticles,
   type CountedPopularArticle,
   type PopularArticleCandidate,
@@ -50,6 +51,29 @@ describe('buildArticlePath', () => {
 
     expect(buildReadCountUrl(articlePath)).toBe(
       'https://shariq-blog.goatcounter.com/counter/%2Fblog%2Fnested%2Fan%2520article%253F%2523%2525%2F.json',
+    )
+  })
+
+  it.each([
+    '',
+    '.mdx',
+    '/article.mdx',
+    'nested/article/',
+    'nested//article.mdx',
+    './article.mdx',
+    'nested/../article.mdx',
+  ])('rejects unsafe path segments in %j', (id) => {
+    expect(() => buildArticlePath(id)).toThrow(TypeError)
+  })
+})
+
+describe('hasUniquePopularArticleIds', () => {
+  it('accepts unique article IDs and rejects duplicates', () => {
+    expect(hasUniquePopularArticleIds([{ id: 'one' }, { id: 'two' }])).toBe(
+      true,
+    )
+    expect(hasUniquePopularArticleIds([{ id: 'same' }, { id: 'same' }])).toBe(
+      false,
     )
   })
 })

--- a/src/lib/popular-articles.test.ts
+++ b/src/lib/popular-articles.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  POPULAR_ARTICLE_FETCH_CONCURRENCY,
+  fetchPopularArticleCounts,
+  rankPopularArticles,
+  type CountedPopularArticle,
+  type PopularArticleCandidate,
+} from './popular-articles'
+
+function candidate(
+  id: string,
+  publishedAt = Date.parse('2026-01-01T00:00:00Z'),
+): PopularArticleCandidate {
+  return {
+    id,
+    path: `/blog/${id}/`,
+    title: `Article ${id}`,
+    bucket: 'Engineering',
+    publishedAt,
+  }
+}
+
+function counted(
+  id: string,
+  count: number,
+  publishedAt?: number,
+): CountedPopularArticle {
+  return {
+    ...candidate(id, publishedAt),
+    readCount: { ok: true, count },
+  }
+}
+
+describe('rankPopularArticles', () => {
+  it('ranks valid counts from highest to lowest', () => {
+    const ranked = rankPopularArticles([
+      counted('low', 2),
+      counted('high', 900),
+      counted('middle', 40),
+    ])
+
+    expect(ranked.map(({ id, count }) => ({ id, count }))).toEqual([
+      { id: 'high', count: 900 },
+      { id: 'middle', count: 40 },
+      { id: 'low', count: 2 },
+    ])
+  })
+
+  it('excludes the featured article even when it has the highest count', () => {
+    const ranked = rankPopularArticles(
+      [counted('featured', 10_000), counted('other', 50)],
+      'featured',
+    )
+
+    expect(ranked.map((article) => article.id)).toEqual(['other'])
+  })
+
+  it('returns at most three articles', () => {
+    const ranked = rankPopularArticles([
+      counted('one', 4),
+      counted('two', 3),
+      counted('three', 2),
+      counted('four', 1),
+    ])
+
+    expect(ranked.map((article) => article.id)).toEqual(['one', 'two', 'three'])
+  })
+
+  it('breaks count ties by newer date and then stable id order', () => {
+    const older = Date.parse('2025-01-01T00:00:00Z')
+    const newer = Date.parse('2026-01-01T00:00:00Z')
+    const ranked = rankPopularArticles([
+      counted('zeta', 10, newer),
+      counted('alpha', 10, newer),
+      counted('older', 10, older),
+    ])
+
+    expect(ranked.map((article) => article.id)).toEqual([
+      'alpha',
+      'zeta',
+      'older',
+    ])
+  })
+
+  it('keeps valid partial results and rejects invalid numeric successes', () => {
+    const ranked = rankPopularArticles([
+      counted('valid', 1),
+      {
+        ...candidate('failed'),
+        readCount: { ok: false, reason: 'http', status: 403 },
+      },
+      counted('negative', -1),
+      counted('unsafe', Number.MAX_SAFE_INTEGER + 1),
+    ])
+
+    expect(ranked.map((article) => article.id)).toEqual(['valid'])
+  })
+
+  it('returns no articles when every count fails', () => {
+    const ranked = rankPopularArticles([
+      {
+        ...candidate('forbidden'),
+        readCount: { ok: false, reason: 'http', status: 403 },
+      },
+      {
+        ...candidate('timed-out'),
+        readCount: { ok: false, reason: 'timeout' },
+      },
+    ])
+
+    expect(ranked).toEqual([])
+  })
+})
+
+describe('fetchPopularArticleCounts', () => {
+  it('bounds count requests to four concurrent fetches', async () => {
+    let active = 0
+    let peak = 0
+    const fetchMock = vi.fn<typeof fetch>(async () => {
+      active += 1
+      peak = Math.max(peak, active)
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      active -= 1
+      return new Response(JSON.stringify({ count: '1' }))
+    })
+    const candidates = Array.from({ length: 10 }, (_, index) =>
+      candidate(`article-${index}`),
+    )
+
+    const results = await fetchPopularArticleCounts(candidates, {
+      fetch: fetchMock,
+    })
+
+    expect(results).toHaveLength(candidates.length)
+    expect(fetchMock).toHaveBeenCalledTimes(candidates.length)
+    expect(peak).toBe(POPULAR_ARTICLE_FETCH_CONCURRENCY)
+  })
+})

--- a/src/lib/popular-articles.test.ts
+++ b/src/lib/popular-articles.test.ts
@@ -66,6 +66,9 @@ describe('buildArticlePath', () => {
     'nested//article.mdx',
     './article.mdx',
     'nested/../article.mdx',
+    'back\\slash.mdx',
+    'line\nbreak.mdx',
+    `delete-${String.fromCharCode(0x7f)}.mdx`,
   ])('rejects unsafe path segments in %j', (id) => {
     expect(() => buildArticlePath(id)).toThrow(TypeError)
   })

--- a/src/lib/popular-articles.test.ts
+++ b/src/lib/popular-articles.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
+import { buildReadCountUrl } from './read-count'
 import {
   POPULAR_ARTICLE_FETCH_CONCURRENCY,
+  buildArticlePath,
   fetchPopularArticleCounts,
   rankPopularArticles,
   type CountedPopularArticle,
@@ -13,7 +15,7 @@ function candidate(
 ): PopularArticleCandidate {
   return {
     id,
-    path: `/blog/${id}/`,
+    path: buildArticlePath(id),
     title: `Article ${id}`,
     bucket: 'Engineering',
     publishedAt,
@@ -30,6 +32,27 @@ function counted(
     readCount: { ok: true, count },
   }
 }
+
+describe('buildArticlePath', () => {
+  it.each([
+    ['nested/article.mdx', '/blog/nested/article/'],
+    ['an article.mdx', '/blog/an%20article/'],
+    ['what?.mdx', '/blog/what%3F/'],
+    ['hash#.mdx', '/blog/hash%23/'],
+    ['percent%.mdx', '/blog/percent%25/'],
+    ['café/日本語.mdx', '/blog/caf%C3%A9/%E6%97%A5%E6%9C%AC%E8%AA%9E/'],
+  ])('builds a canonical path for %s', (id, expected) => {
+    expect(buildArticlePath(id)).toBe(expected)
+  })
+
+  it('preserves encoded pathnames through GoatCounter route encoding', () => {
+    const articlePath = buildArticlePath('nested/an article?#%.mdx')
+
+    expect(buildReadCountUrl(articlePath)).toBe(
+      'https://shariq-blog.goatcounter.com/counter/%2Fblog%2Fnested%2Fan%2520article%253F%2523%2525%2F.json',
+    )
+  })
+})
 
 describe('rankPopularArticles', () => {
   it('ranks valid counts from highest to lowest', () => {

--- a/src/lib/popular-articles.test.ts
+++ b/src/lib/popular-articles.test.ts
@@ -6,6 +6,7 @@ import {
   fetchPopularArticleCounts,
   hasUniquePopularArticleIds,
   rankPopularArticles,
+  resolvePopularArticles,
   type CountedPopularArticle,
   type PopularArticleCandidate,
 } from './popular-articles'
@@ -132,7 +133,7 @@ describe('rankPopularArticles', () => {
     ])
   })
 
-  it('keeps valid partial results and rejects invalid numeric successes', () => {
+  it('rejects an incomplete ranking when any eligible count is unavailable', () => {
     const ranked = rankPopularArticles([
       counted('valid', 1),
       {
@@ -143,7 +144,7 @@ describe('rankPopularArticles', () => {
       counted('unsafe', Number.MAX_SAFE_INTEGER + 1),
     ])
 
-    expect(ranked.map((article) => article.id)).toEqual(['valid'])
+    expect(ranked).toEqual([])
   })
 
   it('returns no articles when every count fails', () => {
@@ -184,5 +185,25 @@ describe('fetchPopularArticleCounts', () => {
     expect(results).toHaveLength(candidates.length)
     expect(fetchMock).toHaveBeenCalledTimes(candidates.length)
     expect(peak).toBe(POPULAR_ARTICLE_FETCH_CONCURRENCY)
+  })
+})
+
+describe('resolvePopularArticles', () => {
+  it('excludes the featured article before requesting counts', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(JSON.stringify({ count: '5' })))
+
+    const ranked = await resolvePopularArticles(
+      [candidate('featured'), candidate('other')],
+      'featured',
+      { fetch: fetchMock },
+    )
+
+    expect(ranked.map((article) => article.id)).toEqual(['other'])
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0]?.[0]).toContain(
+      encodeURIComponent('/blog/other/'),
+    )
   })
 })

--- a/src/lib/popular-articles.ts
+++ b/src/lib/popular-articles.ts
@@ -1,0 +1,105 @@
+import {
+  fetchReadCount,
+  type ReadCountFetchOptions,
+  type ReadCountResult,
+} from './read-count'
+
+export const POPULAR_ARTICLE_LIMIT = 3
+export const POPULAR_ARTICLE_FETCH_CONCURRENCY = 4
+
+export interface PopularArticleCandidate {
+  id: string
+  path: string
+  title: string
+  bucket: string
+  publishedAt: number
+}
+
+export interface CountedPopularArticle extends PopularArticleCandidate {
+  readCount: ReadCountResult
+}
+
+export interface PopularArticle extends PopularArticleCandidate {
+  count: number
+}
+
+type SuccessfulReadCount = Extract<ReadCountResult, { ok: true }>
+type AvailablePopularArticle = CountedPopularArticle & {
+  readCount: SuccessfulReadCount
+}
+
+function compareIds(left: string, right: string): number {
+  if (left < right) return -1
+  if (left > right) return 1
+  return 0
+}
+
+function hasValidReadCount(
+  candidate: CountedPopularArticle,
+): candidate is AvailablePopularArticle {
+  return (
+    candidate.readCount.ok &&
+    Number.isSafeInteger(candidate.readCount.count) &&
+    candidate.readCount.count >= 0
+  )
+}
+
+export function rankPopularArticles(
+  candidates: readonly CountedPopularArticle[],
+  excludedId?: string,
+): PopularArticle[] {
+  return candidates
+    .filter((candidate) => candidate.id !== excludedId)
+    .filter(hasValidReadCount)
+    .map((candidate) => {
+      const { readCount, ...article } = candidate
+      return { ...article, count: readCount.count }
+    })
+    .sort(
+      (left, right) =>
+        right.count - left.count ||
+        right.publishedAt - left.publishedAt ||
+        compareIds(left.id, right.id),
+    )
+    .slice(0, POPULAR_ARTICLE_LIMIT)
+}
+
+export async function fetchPopularArticleCounts(
+  candidates: readonly PopularArticleCandidate[],
+  options: Pick<ReadCountFetchOptions, 'fetch' | 'signal'> = {},
+): Promise<CountedPopularArticle[]> {
+  const counted: CountedPopularArticle[] = []
+  let nextIndex = 0
+
+  async function worker() {
+    while (nextIndex < candidates.length) {
+      const index = nextIndex
+      nextIndex += 1
+      const candidate = candidates[index]
+      counted[index] = {
+        ...candidate,
+        readCount: await fetchReadCount(candidate.path, options),
+      }
+    }
+  }
+
+  await Promise.all(
+    Array.from(
+      {
+        length: Math.min(POPULAR_ARTICLE_FETCH_CONCURRENCY, candidates.length),
+      },
+      () => worker(),
+    ),
+  )
+
+  return counted
+}
+
+export async function resolvePopularArticles(
+  candidates: readonly PopularArticleCandidate[],
+  excludedId?: string,
+  options: Pick<ReadCountFetchOptions, 'fetch' | 'signal'> = {},
+): Promise<PopularArticle[]> {
+  const counted = await fetchPopularArticleCounts(candidates, options)
+  return rankPopularArticles(counted, excludedId)
+}

--- a/src/lib/popular-articles.ts
+++ b/src/lib/popular-articles.ts
@@ -1,5 +1,6 @@
 import {
   fetchReadCount,
+  isCanonicalArticlePath,
   type ReadCountFetchOptions,
   type ReadCountResult,
 } from './read-count'
@@ -37,16 +38,13 @@ function compareIds(left: string, right: string): number {
 export function buildArticlePath(id: string): string {
   const slug = id.replace(/\.mdx$/, '')
   const segments = slug.split('/')
-  if (
-    segments.some(
-      (segment) => segment.length === 0 || segment === '.' || segment === '..',
-    )
-  ) {
+  const path = `/blog/${segments.map(encodeURIComponent).join('/')}/`
+  if (!isCanonicalArticlePath(path)) {
     throw new TypeError(
       'Article IDs must contain safe, non-empty path segments',
     )
   }
-  return `/blog/${segments.map(encodeURIComponent).join('/')}/`
+  return path
 }
 
 export function hasUniquePopularArticleIds(

--- a/src/lib/popular-articles.ts
+++ b/src/lib/popular-articles.ts
@@ -74,9 +74,11 @@ export function rankPopularArticles(
   candidates: readonly CountedPopularArticle[],
   excludedId?: string,
 ): PopularArticle[] {
-  return candidates
-    .filter((candidate) => candidate.id !== excludedId)
-    .filter(hasValidReadCount)
+  const eligible = candidates.filter((candidate) => candidate.id !== excludedId)
+  const available = eligible.filter(hasValidReadCount)
+  if (available.length !== eligible.length) return []
+
+  return available
     .map((candidate) => {
       const { readCount, ...article } = candidate
       return { ...article, count: readCount.count }
@@ -126,6 +128,7 @@ export async function resolvePopularArticles(
   excludedId?: string,
   options: Pick<ReadCountFetchOptions, 'fetch' | 'signal'> = {},
 ): Promise<PopularArticle[]> {
-  const counted = await fetchPopularArticleCounts(candidates, options)
-  return rankPopularArticles(counted, excludedId)
+  const eligible = candidates.filter((candidate) => candidate.id !== excludedId)
+  const counted = await fetchPopularArticleCounts(eligible, options)
+  return rankPopularArticles(counted)
 }

--- a/src/lib/popular-articles.ts
+++ b/src/lib/popular-articles.ts
@@ -36,7 +36,28 @@ function compareIds(left: string, right: string): number {
 
 export function buildArticlePath(id: string): string {
   const slug = id.replace(/\.mdx$/, '')
-  return `/blog/${slug.split('/').map(encodeURIComponent).join('/')}/`
+  const segments = slug.split('/')
+  if (
+    segments.some(
+      (segment) => segment.length === 0 || segment === '.' || segment === '..',
+    )
+  ) {
+    throw new TypeError(
+      'Article IDs must contain safe, non-empty path segments',
+    )
+  }
+  return `/blog/${segments.map(encodeURIComponent).join('/')}/`
+}
+
+export function hasUniquePopularArticleIds(
+  candidates: readonly { id: string }[],
+): boolean {
+  const ids = new Set<string>()
+  for (const candidate of candidates) {
+    if (ids.has(candidate.id)) return false
+    ids.add(candidate.id)
+  }
+  return true
 }
 
 function hasValidReadCount(

--- a/src/lib/popular-articles.ts
+++ b/src/lib/popular-articles.ts
@@ -34,6 +34,11 @@ function compareIds(left: string, right: string): number {
   return 0
 }
 
+export function buildArticlePath(id: string): string {
+  const slug = id.replace(/\.mdx$/, '')
+  return `/blog/${slug.split('/').map(encodeURIComponent).join('/')}/`
+}
+
 function hasValidReadCount(
   candidate: CountedPopularArticle,
 ): candidate is AvailablePopularArticle {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,15 +3,28 @@ import { getCollection } from "astro:content";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import PortraitDeck from "../components/PortraitDeck.astro";
 import FeaturedCard from "../components/FeaturedCard.astro";
+import PopularArticles from "../components/PopularArticles.astro";
 import { HOME } from "../lib/home";
 import { active, safeHref } from "../lib/projects";
 import { pickFeatured } from "../lib/featured";
 import { resolveBucket } from "../lib/buckets";
+import type { PopularArticleCandidate } from "../lib/popular-articles";
 import { SITE } from "../lib/site";
 
 const all = await getCollection("writing", ({ data }) => !data.draft);
 const featured = pickFeatured(all);
 const fb = featured ? resolveBucket(featured.data.tags) : null;
+const featuredId = featured?.id.replace(/\.mdx$/, "");
+const popularCandidates: PopularArticleCandidate[] = all.map((post) => {
+  const id = post.id.replace(/\.mdx$/, "");
+  return {
+    id,
+    path: `/blog/${id}/`,
+    title: post.data.title,
+    bucket: resolveBucket(post.data.tags).label,
+    publishedAt: post.data.date.getTime(),
+  };
+});
 const m = HOME.manifesto;
 const focusNames = new Set(["Oris", "Agent Inbox", "AskDocs"]);
 const focusProjects = active.filter((project) => focusNames.has(project.name));
@@ -81,6 +94,8 @@ const homeLd = [
       coverData={featured.data}
     />
   )}
+
+  <PopularArticles candidates={popularCandidates} featuredId={featuredId} />
 
 </BaseLayout>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,7 +8,10 @@ import { HOME } from "../lib/home";
 import { active, safeHref } from "../lib/projects";
 import { pickFeatured } from "../lib/featured";
 import { resolveBucket } from "../lib/buckets";
-import type { PopularArticleCandidate } from "../lib/popular-articles";
+import {
+  buildArticlePath,
+  type PopularArticleCandidate,
+} from "../lib/popular-articles";
 import { SITE } from "../lib/site";
 
 const all = await getCollection("writing", ({ data }) => !data.draft);
@@ -19,7 +22,7 @@ const popularCandidates: PopularArticleCandidate[] = all.map((post) => {
   const id = post.id.replace(/\.mdx$/, "");
   return {
     id,
-    path: `/blog/${id}/`,
+    path: buildArticlePath(post.id),
     title: post.data.title,
     bucket: resolveBucket(post.data.tags).label,
     publishedAt: post.data.date.getTime(),
@@ -87,7 +90,7 @@ const homeLd = [
 
   {featured && fb && (
     <FeaturedCard
-      href={`/blog/${featured.id.replace(/\.mdx$/, "")}`}
+      href={buildArticlePath(featured.id)}
       category={`${fb.label} · Latest`}
       title={featured.data.title}
       hook={featured.data.summary}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,6 +10,7 @@ import { pickFeatured } from "../lib/featured";
 import { resolveBucket } from "../lib/buckets";
 import {
   buildArticlePath,
+  hasUniquePopularArticleIds,
   type PopularArticleCandidate,
 } from "../lib/popular-articles";
 import { SITE } from "../lib/site";
@@ -28,6 +29,9 @@ const popularCandidates: PopularArticleCandidate[] = all.map((post) => {
     publishedAt: post.data.date.getTime(),
   };
 });
+if (!hasUniquePopularArticleIds(popularCandidates)) {
+  throw new Error("Homepage popularity candidates must have unique article IDs");
+}
 const m = HOME.manifesto;
 const focusNames = new Set(["Oris", "Agent Inbox", "AskDocs"]);
 const focusProjects = active.filter((project) => focusNames.has(project.name));

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -1,7 +1,9 @@
 import { test, expect } from '@playwright/test'
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
 import { join } from 'node:path'
+import matter from 'gray-matter'
 import { active, built } from '../src/lib/projects'
+import { buildReadCountUrl } from '../src/lib/read-count'
 import { SITE } from '../src/lib/site'
 
 function walkMdx(dir: string, prefix = ''): string[] {
@@ -26,7 +28,62 @@ const READ_COUNT_SLUG =
   'rewriting-our-engine-with-anthropic-claude-opus-4-8-and-dynamic-workflows'
 const READ_COUNT_PATH = `/blog/${READ_COUNT_SLUG}/`
 const READ_COUNT_ROUTE = 'https://shariq-blog.goatcounter.com/counter/**'
-const READ_COUNT_URL = `https://shariq-blog.goatcounter.com/counter/${encodeURIComponent(READ_COUNT_PATH)}.json`
+const READ_COUNT_URL = buildReadCountUrl(READ_COUNT_PATH)
+
+interface HomeArticleFixture {
+  slug: string
+  title: string
+  publishedAt: number
+}
+
+function readHomeArticles(dir: string, prefix = ''): HomeArticleFixture[] {
+  const articles: HomeArticleFixture[] = []
+  for (const name of readdirSync(dir)) {
+    const path = join(dir, name)
+    const relativePath = prefix ? `${prefix}/${name}` : name
+    if (statSync(path).isDirectory()) {
+      if (name.startsWith('_')) continue
+      articles.push(...readHomeArticles(path, relativePath))
+      continue
+    }
+    if (!relativePath.endsWith('.mdx')) continue
+
+    const { data } = matter(readFileSync(path, 'utf8'))
+    if (data.draft === true) continue
+    const publishedAt = Date.parse(String(data.date))
+    if (typeof data.title !== 'string' || Number.isNaN(publishedAt)) {
+      throw new Error(`Invalid homepage article fixture: ${relativePath}`)
+    }
+    articles.push({
+      slug: relativePath.replace(/\.mdx$/, ''),
+      title: data.title,
+      publishedAt,
+    })
+  }
+  return articles
+}
+
+const HOME_ARTICLES = readHomeArticles('src/content/writing')
+const HOME_FEATURED = HOME_ARTICLES.toSorted(
+  (left, right) => right.publishedAt - left.publishedAt,
+)[0]
+const [POPULAR_FIRST, POPULAR_SECOND, POPULAR_THIRD] = HOME_ARTICLES.filter(
+  (article) => article.slug !== HOME_FEATURED?.slug,
+).toSorted((left, right) =>
+  left.slug < right.slug ? -1 : left.slug > right.slug ? 1 : 0,
+)
+
+if (!HOME_FEATURED || !POPULAR_FIRST || !POPULAR_SECOND || !POPULAR_THIRD) {
+  throw new Error(
+    'Homepage popularity smoke tests require four published posts',
+  )
+}
+
+const POPULAR_FIXTURES = [
+  { article: POPULAR_FIRST, count: '2,345', label: '2,345 views' },
+  { article: POPULAR_SECOND, count: '42', label: '42 views' },
+  { article: POPULAR_THIRD, count: '1', label: '1 view' },
+] as const
 
 test.beforeEach(async ({ page }) => {
   await page.route('**/gc.zgo.at/count.js', (route) =>
@@ -57,6 +114,125 @@ test('homepage renders the zine hero', async ({ page }) => {
   await expect(
     page.getByRole('link', { name: "More on what I'm doing now" }),
   ).toHaveAttribute('href', '/now')
+})
+
+test('homepage ranks popular articles without duplication or overflow', async ({
+  page,
+}) => {
+  const errors: string[] = []
+  page.on('console', (message) => {
+    if (message.type() === 'error') errors.push(message.text())
+  })
+  page.on('pageerror', (error) => errors.push(error.message))
+  const countByUrl = new Map<string, string>([
+    [buildReadCountUrl(`/blog/${HOME_FEATURED.slug}/`), '9,999'],
+    ...POPULAR_FIXTURES.map(
+      ({ article, count }) =>
+        [buildReadCountUrl(`/blog/${article.slug}/`), count] as const,
+    ),
+  ])
+  await page.unroute(READ_COUNT_ROUTE)
+  await page.route(READ_COUNT_ROUTE, (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        count: countByUrl.get(route.request().url()) ?? '0',
+      }),
+    }),
+  )
+
+  for (const viewport of [
+    { width: 1440, height: 1000 },
+    { width: 390, height: 844 },
+  ]) {
+    await page.setViewportSize(viewport)
+    await page.goto('/')
+
+    const popular = page.locator('[data-popular-articles]')
+    await expect(popular).toHaveAttribute(
+      'data-popular-articles-state',
+      'loaded',
+    )
+    await expect(popular).toBeVisible()
+    await expect(
+      popular.getByRole('heading', { name: 'Most popular' }),
+    ).toBeVisible()
+    await expect(popular.locator('[data-popular-candidate]')).toHaveCount(3)
+    await expect(popular.locator('[data-popular-title]')).toHaveText(
+      POPULAR_FIXTURES.map(({ article }) => article.title),
+    )
+    await expect(popular.locator('[data-popular-count]')).toHaveText(
+      POPULAR_FIXTURES.map(({ label }) => label),
+    )
+    await expect(
+      popular.locator(
+        `[data-popular-candidate][data-article-id="${HOME_FEATURED.slug}"]`,
+      ),
+    ).toHaveCount(0)
+
+    const widths = await page.evaluate(() => {
+      const section = document.querySelector<HTMLElement>(
+        '[data-popular-articles]',
+      )
+      return {
+        viewport: document.documentElement.clientWidth,
+        document: document.documentElement.scrollWidth,
+        section: section?.scrollWidth ?? 0,
+      }
+    })
+    expect(widths.document).toBeLessThanOrEqual(widths.viewport)
+    expect(widths.section).toBeLessThanOrEqual(widths.viewport)
+  }
+
+  expect(errors).toEqual([])
+})
+
+test('homepage shows partial popularity and hides total failure cleanly', async ({
+  page,
+}) => {
+  const errors: string[] = []
+  page.on('console', (message) => {
+    if (message.type() === 'error') errors.push(message.text())
+  })
+  page.on('pageerror', (error) => errors.push(error.message))
+  const validUrl = buildReadCountUrl(`/blog/${POPULAR_THIRD.slug}/`)
+  await page.unroute(READ_COUNT_ROUTE)
+  await page.route(READ_COUNT_ROUTE, (route) =>
+    route.request().url() === validUrl
+      ? route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({ count: '1' }),
+        })
+      : route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({}),
+        }),
+  )
+
+  await page.goto('/')
+  const popular = page.locator('[data-popular-articles]')
+  await expect(popular).toHaveAttribute('data-popular-articles-state', 'loaded')
+  await expect(popular).toBeVisible()
+  await expect(popular.locator('[data-popular-candidate]')).toHaveCount(1)
+  await expect(popular.locator('[data-popular-title]')).toHaveText([
+    POPULAR_THIRD.title,
+  ])
+  await expect(popular.locator('[data-popular-count]')).toHaveText(['1 view'])
+
+  await page.unroute(READ_COUNT_ROUTE)
+  await page.route(READ_COUNT_ROUTE, (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({}),
+    }),
+  )
+  await page.goto('/')
+  await expect(popular).toHaveAttribute(
+    'data-popular-articles-state',
+    'unavailable',
+  )
+  await expect(popular).toBeHidden()
+  expect(errors).toEqual([])
 })
 
 test('header nav + footer socials', async ({ page }) => {

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -3,6 +3,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import matter from 'gray-matter'
 import { active, built } from '../src/lib/projects'
+import { buildArticlePath } from '../src/lib/popular-articles'
 import { buildReadCountUrl } from '../src/lib/read-count'
 import { SITE } from '../src/lib/site'
 
@@ -125,10 +126,10 @@ test('homepage ranks popular articles without duplication or overflow', async ({
   })
   page.on('pageerror', (error) => errors.push(error.message))
   const countByUrl = new Map<string, string>([
-    [buildReadCountUrl(`/blog/${HOME_FEATURED.slug}/`), '9,999'],
+      [buildReadCountUrl(buildArticlePath(HOME_FEATURED.slug)), '9,999'],
     ...POPULAR_FIXTURES.map(
       ({ article, count }) =>
-        [buildReadCountUrl(`/blog/${article.slug}/`), count] as const,
+          [buildReadCountUrl(buildArticlePath(article.slug)), count] as const,
     ),
   ])
   await page.unroute(READ_COUNT_ROUTE)
@@ -195,7 +196,7 @@ test('homepage shows partial popularity and hides total failure cleanly', async 
     if (message.type() === 'error') errors.push(message.text())
   })
   page.on('pageerror', (error) => errors.push(error.message))
-  const validUrl = buildReadCountUrl(`/blog/${POPULAR_THIRD.slug}/`)
+  const validUrl = buildReadCountUrl(buildArticlePath(POPULAR_THIRD.slug))
   await page.unroute(READ_COUNT_ROUTE)
   await page.route(READ_COUNT_ROUTE, (route) =>
     route.request().url() === validUrl

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -128,6 +128,7 @@ test('homepage ranks popular articles without duplication or overflow', async ({
 }) => {
   const errors: string[] = []
   const directGoatCounterRequests: string[] = []
+  const proxyRequests: string[] = []
   page.on('console', (message) => {
     if (message.type() === 'error') errors.push(message.text())
   })
@@ -145,14 +146,16 @@ test('homepage ranks popular articles without duplication or overflow', async ({
     ),
   ])
   await page.unroute(READ_COUNT_ROUTE)
-  await page.route(READ_COUNT_ROUTE, (route) =>
-    route.fulfill({
+  await page.route(READ_COUNT_ROUTE, (route) => {
+    const requestUrl = relativeRequestUrl(route.request().url())
+    proxyRequests.push(requestUrl)
+    return route.fulfill({
       contentType: 'application/json',
       body: JSON.stringify({
-        count: countByUrl.get(relativeRequestUrl(route.request().url())) ?? '0',
+        count: countByUrl.get(requestUrl) ?? '0',
       }),
-    }),
-  )
+    })
+  })
 
   for (const viewport of [
     { width: 1440, height: 1000 },
@@ -197,11 +200,14 @@ test('homepage ranks popular articles without duplication or overflow', async ({
     expect(widths.section).toBeLessThanOrEqual(widths.viewport)
   }
 
+  expect(proxyRequests).not.toContain(
+    buildReadCountUrl(buildArticlePath(HOME_FEATURED.slug)),
+  )
   expect(directGoatCounterRequests).toEqual([])
   expect(errors).toEqual([])
 })
 
-test('homepage shows partial popularity and hides total failure cleanly', async ({
+test('homepage hides incomplete and unexpected popularity failures cleanly', async ({
   page,
 }) => {
   const errors: string[] = []
@@ -225,13 +231,11 @@ test('homepage shows partial popularity and hides total failure cleanly', async 
 
   await page.goto('/')
   const popular = page.locator('[data-popular-articles]')
-  await expect(popular).toHaveAttribute('data-popular-articles-state', 'loaded')
-  await expect(popular).toBeVisible()
-  await expect(popular.locator('[data-popular-candidate]')).toHaveCount(1)
-  await expect(popular.locator('[data-popular-title]')).toHaveText([
-    POPULAR_THIRD.title,
-  ])
-  await expect(popular.locator('[data-popular-count]')).toHaveText(['1 view'])
+  await expect(popular).toHaveAttribute(
+    'data-popular-articles-state',
+    'unavailable',
+  )
+  await expect(popular).toBeHidden()
 
   await page.unroute(READ_COUNT_ROUTE)
   await page.route(READ_COUNT_ROUTE, (route) =>
@@ -240,6 +244,22 @@ test('homepage shows partial popularity and hides total failure cleanly', async 
       body: JSON.stringify({}),
     }),
   )
+  await page.goto('/')
+  await expect(popular).toHaveAttribute(
+    'data-popular-articles-state',
+    'unavailable',
+  )
+  await expect(popular).toBeHidden()
+
+  await page.addInitScript(() => {
+    const originalFetch = window.fetch.bind(window)
+    window.fetch = (input, init) => {
+      if (String(input).startsWith('/api/read-count')) {
+        return Promise.reject(new Error('unexpected read-count failure'))
+      }
+      return originalFetch(input, init)
+    }
+  })
   await page.goto('/')
   await expect(popular).toHaveAttribute(
     'data-popular-articles-state',


### PR DESCRIPTION
## Summary
- add a progressively revealed **Most popular** homepage section backed by the layer-1 GoatCounter read-count contract
- rank valid results by views, publication date, and stable article ID while excluding the Latest feature and capping output at three
- bound browser count requests to four concurrent fetches and keep unavailable/failed results fully hidden
- cover ranking, partial/all-failed behavior, pluralization, exclusion, console cleanliness, and desktop/mobile overflow

## Validation
- `npm run astro check`
- `npm test` (250 tests)
- `npm run build`
- `npm run test:smoke` (33 tests)
- Vale on changed public prose
- Impeccable detector on changed homepage UI
- mocked 1440px and 390px production screenshots inspected

Depends on #84.
Closes #13.