### PR TITLE
Serve stale article counts during GoatCounter outages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,33 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Enable incoming request cancellation
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          project_url="https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pages/projects/shariq-dev"
+          project="$(curl --fail-with-body --silent --show-error \
+            --header "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+            "${project_url}")"
+          production_flags="$(jq -c \
+            '[.result.deployment_configs.production.compatibility_flags[]?, "enable_request_signal"] | unique' \
+            <<<"${project}")"
+          preview_flags="$(jq -c \
+            '[.result.deployment_configs.preview.compatibility_flags[]?, "enable_request_signal"] | unique' \
+            <<<"${project}")"
+          payload="$(jq -nc \
+            --argjson production "${production_flags}" \
+            --argjson preview "${preview_flags}" \
+            '{deployment_configs:{production:{compatibility_flags:$production},preview:{compatibility_flags:$preview}}}')"
+          curl --fail-with-body --silent --show-error \
+            --request PATCH \
+            --header "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+            --header "Content-Type: application/json" \
+            --data "${payload}" \
+            "${project_url}" |
+            jq -e '.success == true' >/dev/null
+
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
         id: deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,8 +12,9 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: deploy-${{ github.ref }}
-  cancel-in-progress: true
+  group: deploy-shariq-dev
+  cancel-in-progress: false
+  queue: max
 
 jobs:
   deploy:
@@ -45,16 +46,21 @@ jobs:
           project="$(curl --fail-with-body --silent --show-error \
             --header "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
             "${project_url}")"
-          production_flags="$(jq -c \
-            '[.result.deployment_configs.production.compatibility_flags[]?, "enable_request_signal"] | unique' \
-            <<<"${project}")"
-          preview_flags="$(jq -c \
-            '[.result.deployment_configs.preview.compatibility_flags[]?, "enable_request_signal"] | unique' \
-            <<<"${project}")"
-          payload="$(jq -nc \
-            --argjson production "${production_flags}" \
-            --argjson preview "${preview_flags}" \
-            '{deployment_configs:{production:{compatibility_flags:$production},preview:{compatibility_flags:$preview}}}')"
+          if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
+            flags="$(jq -c \
+              '[.result.deployment_configs.production.compatibility_flags[]?, "enable_request_signal"] | unique' \
+              <<<"${project}")"
+            payload="$(jq -nc \
+              --argjson flags "${flags}" \
+              '{deployment_configs:{production:{compatibility_flags:$flags}}}')"
+          else
+            flags="$(jq -c \
+              '[.result.deployment_configs.preview.compatibility_flags[]?, "enable_request_signal"] | unique' \
+              <<<"${project}")"
+            payload="$(jq -nc \
+              --argjson flags "${flags}" \
+              '{deployment_configs:{preview:{compatibility_flags:$flags}}}')"
+          fi
           curl --fail-with-body --silent --show-error \
             --request PATCH \
             --header "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \

--- a/README.md
+++ b/README.md
@@ -132,12 +132,27 @@ Those stale responses use at most `max-age=60` and `s-maxage=300`, capped by the
 entry's remaining retention time, so public caches retry soon instead of
 pinning the fallback.
 
+Concurrent refreshes for the same article share one upstream request within a
+Pages Function isolate. GoatCounter pageview totals are treated as cumulative:
+immediately before writing, the function re-reads the count cache and preserves
+an observed higher count or equal count with newer fetch metadata. Availability
+failures write a separate 30-second internal backoff marker, never failure data
+in the count entry. While that marker is active, requests skip GoatCounter and
+serve retained stale data or remain unavailable when no valid count exists.
+
 Fresh responses use at most `max-age=300` for browsers and `s-maxage=14400` for
 shared caches, capped by the remaining four-hour freshness window. Invalid
 paths, upstream 404s, malformed responses, and entries older than seven days
 still fail closed. A cold or evicted edge cache also fails closed while
 GoatCounter is unavailable, so the count remains hidden until that edge has
 observed a valid upstream response.
+
+Cloudflare's Cache API remains per-edge and has no conditional write. Coalescing
+is isolate-local, backoff is edge-local, and a cross-isolate write can still
+race between the final re-read and `cache.put`. The cumulative-count guard
+prevents overwriting a higher value already observed by that re-read, but true
+global serialization would require Durable Objects or another coordinated
+store.
 
 ## Authoring posts
 

--- a/README.md
+++ b/README.md
@@ -133,12 +133,17 @@ entry's remaining retention time, so public caches retry soon instead of
 pinning the fallback.
 
 Concurrent refreshes for the same article share one upstream request within a
-Pages Function isolate. GoatCounter pageview totals are treated as cumulative:
-immediately before writing, the function re-reads the count cache and preserves
-an observed higher count or equal count with newer fetch metadata. Availability
-failures write a separate 30-second internal backoff marker, never failure data
-in the count entry. While that marker is active, requests skip GoatCounter and
-serve retained stale data or remain unavailable when no valid count exists.
+Pages Function isolate. A disconnected caller releases its interest without
+cancelling active peers; the shared fetch aborts when no consumers remain.
+The deploy workflow keeps Cloudflare's `enable_request_signal` compatibility
+flag enabled for preview and production so incoming disconnects reach that
+coordinator.
+GoatCounter pageview totals are treated as cumulative: immediately before
+writing, the function re-reads the count cache and preserves an observed higher
+count or equal count with newer fetch metadata. Availability failures write a
+separate 30-second internal backoff marker, never failure data in the count
+entry. While that marker is active, requests skip GoatCounter and serve retained
+stale data or remain unavailable when no valid count exists.
 
 Fresh responses use at most `max-age=300` for browsers and `s-maxage=14400` for
 shared caches, capped by the remaining four-hour freshness window. Invalid

--- a/README.md
+++ b/README.md
@@ -120,7 +120,9 @@ Article metadata reads public pageview totals through the same-origin
 Tracking Protection and other content blockers can block direct browser
 requests to GoatCounter. It validates canonical `/blog/.../` paths and forwards
 only to the fixed public GoatCounter JSON endpoint; there is no admin API,
-token, cookie, user data storage, or additional tracking.
+token, cookie, user data storage, or additional tracking. Internal cache keys
+accept only the production, Cloudflare Pages preview, and local-development
+origins.
 
 In GoatCounter, keep **Settings → Allow adding visitor counts on your website**
 enabled. The function stores only validated `{count:string}` responses in

--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ Pages Function isolate. A disconnected caller releases its interest without
 cancelling active peers; the shared fetch aborts when no consumers remain.
 The deploy workflow keeps Cloudflare's `enable_request_signal` compatibility
 flag enabled for preview and production so incoming disconnects reach that
-coordinator.
+coordinator. It serializes Pages project updates and changes only the target
+environment's flags, so preview deploys do not mutate production configuration.
 GoatCounter pageview totals are treated as cumulative: immediately before
 writing, the function re-reads the count cache and preserves an observed higher
 count or equal count with newer fetch metadata. Availability failures write a
@@ -157,7 +158,9 @@ is isolate-local, backoff is edge-local, and a cross-isolate write can still
 race between the final re-read and `cache.put`. The cumulative-count guard
 prevents overwriting a higher value already observed by that re-read, but true
 global serialization would require Durable Objects or another coordinated
-store.
+store. Cache API operations also do not accept an `AbortSignal`; request
+cancellation stops the shared upstream fetch but cannot cancel an already-issued
+edge cache operation.
 
 ## Authoring posts
 

--- a/README.md
+++ b/README.md
@@ -123,10 +123,21 @@ only to the fixed public GoatCounter JSON endpoint; there is no admin API,
 token, cookie, user data storage, or additional tracking.
 
 In GoatCounter, keep **Settings → Allow adding visitor counts on your website**
-enabled. When it is disabled or the upstream is unavailable, the count stays
-hidden. Successful proxy responses use `max-age=300` for browsers and
-`s-maxage=14400` (four hours) for shared caches, matching GoatCounter's
-up-to-four-hour response cache.
+enabled. The function stores only validated `{count:string}` responses in
+Cloudflare's per-edge Cache API under an internal same-origin key. Counts are
+fresh for four hours and retained for up to seven days. After four hours the
+function refreshes synchronously; an upstream timeout, network failure, HTTP
+429, or HTTP 5xx serves the retained value with `x-read-count-cache: stale`.
+Those stale responses use at most `max-age=60` and `s-maxage=300`, capped by the
+entry's remaining retention time, so public caches retry soon instead of
+pinning the fallback.
+
+Fresh responses use at most `max-age=300` for browsers and `s-maxage=14400` for
+shared caches, capped by the remaining four-hour freshness window. Invalid
+paths, upstream 404s, malformed responses, and entries older than seven days
+still fail closed. A cold or evicted edge cache also fails closed while
+GoatCounter is unavailable, so the count remains hidden until that edge has
+observed a valid upstream response.
 
 ## Authoring posts
 

--- a/functions/api/read-count.test.ts
+++ b/functions/api/read-count.test.ts
@@ -26,6 +26,9 @@ describe('read-count Pages Function', () => {
       async put() {
         throw new Error('fresh cache hits must not write')
       },
+      async delete() {
+        throw new Error('fresh cache hits must not delete')
+      },
     }
     const originalCaches = Object.getOwnPropertyDescriptor(globalThis, 'caches')
     Object.defineProperty(globalThis, 'caches', {

--- a/functions/api/read-count.test.ts
+++ b/functions/api/read-count.test.ts
@@ -26,9 +26,6 @@ describe('read-count Pages Function', () => {
       async put() {
         throw new Error('fresh cache hits must not write')
       },
-      async delete() {
-        throw new Error('fresh cache hits must not delete')
-      },
     }
     const originalCaches = Object.getOwnPropertyDescriptor(globalThis, 'caches')
     Object.defineProperty(globalThis, 'caches', {

--- a/functions/api/read-count.test.ts
+++ b/functions/api/read-count.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildReadCountCacheKey,
+  READ_COUNT_CACHE_FETCHED_AT_HEADER,
+  READ_COUNT_CACHE_STATUS_HEADER,
+  type ReadCountCache,
+} from '../../src/lib/read-count-proxy'
+import { onRequest } from './read-count'
+
+const ARTICLE_PATH = '/blog/example/'
+const REQUEST_URL = `https://shariq.dev/api/read-count?path=${encodeURIComponent(ARTICLE_PATH)}`
+
+describe('read-count Pages Function', () => {
+  it('passes caches.default to the proxy handler', async () => {
+    let matchedUrl: string | undefined
+    const cache: ReadCountCache = {
+      async match(request) {
+        matchedUrl = request.url
+        return new Response(JSON.stringify({ count: '123' }), {
+          headers: {
+            'content-type': 'application/json; charset=utf-8',
+            [READ_COUNT_CACHE_FETCHED_AT_HEADER]: String(Date.now()),
+          },
+        })
+      },
+      async put() {
+        throw new Error('fresh cache hits must not write')
+      },
+      async delete() {
+        throw new Error('fresh cache hits must not delete')
+      },
+    }
+    const originalCaches = Object.getOwnPropertyDescriptor(globalThis, 'caches')
+    Object.defineProperty(globalThis, 'caches', {
+      configurable: true,
+      value: { default: cache },
+    })
+
+    try {
+      const response = await onRequest({ request: new Request(REQUEST_URL) })
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get(READ_COUNT_CACHE_STATUS_HEADER)).toBe('fresh')
+      expect(await response.json()).toEqual({ count: '123' })
+      expect(matchedUrl).toBe(
+        buildReadCountCacheKey(REQUEST_URL, ARTICLE_PATH).url,
+      )
+    } finally {
+      if (originalCaches) {
+        Object.defineProperty(globalThis, 'caches', originalCaches)
+      } else {
+        Reflect.deleteProperty(globalThis, 'caches')
+      }
+    }
+  })
+})

--- a/functions/api/read-count.ts
+++ b/functions/api/read-count.ts
@@ -1,9 +1,18 @@
-import { handleReadCountRequest } from '../../src/lib/read-count-proxy'
+import {
+  handleReadCountRequest,
+  type ReadCountCache,
+} from '../../src/lib/read-count-proxy'
+
+interface CloudflareCacheStorage {
+  default: ReadCountCache
+}
+
+declare const caches: CloudflareCacheStorage
 
 interface Context {
   request: Request
 }
 
 export function onRequest({ request }: Context): Promise<Response> {
-  return handleReadCountRequest(request)
+  return handleReadCountRequest(request, { cache: caches.default })
 }

--- a/src/lib/read-count-proxy.test.ts
+++ b/src/lib/read-count-proxy.test.ts
@@ -671,6 +671,47 @@ describe('handleReadCountRequest', () => {
     expect(coordinator.size).toBe(0)
   })
 
+  it('does not coalesce the same key across different dependencies', async () => {
+    const firstCache = new MemoryReadCountCache()
+    const secondCache = new MemoryReadCountCache()
+    const coordinator = createReadCountRefreshCoordinator()
+    const firstUpstream = deferred<Response>()
+    const secondUpstream = deferred<Response>()
+    const firstFetch = vi
+      .fn<typeof fetch>()
+      .mockImplementation(() => firstUpstream.promise)
+    const secondFetch = vi
+      .fn<typeof fetch>()
+      .mockImplementation(() => secondUpstream.promise)
+    const clock = () => NOW
+
+    const first = handleReadCountRequest(request(), {
+      cache: firstCache,
+      coordinator,
+      fetch: firstFetch,
+      now: clock,
+    })
+    const second = handleReadCountRequest(request(), {
+      cache: secondCache,
+      coordinator,
+      fetch: secondFetch,
+      now: clock,
+    })
+    await vi.waitFor(() => {
+      expect(firstFetch).toHaveBeenCalledOnce()
+      expect(secondFetch).toHaveBeenCalledOnce()
+    })
+    expect(coordinator.size).toBe(2)
+
+    firstUpstream.resolve(upstreamResponse({ count: '1' }))
+    secondUpstream.resolve(upstreamResponse({ count: '2' }))
+    const responses = await Promise.all([first, second])
+
+    expect(await responses[0].json()).toEqual({ count: '1' })
+    expect(await responses[1].json()).toEqual({ count: '2' })
+    expect(coordinator.size).toBe(0)
+  })
+
   it('uses request start time as the successful refresh generation', async () => {
     const cache = new MemoryReadCountCache()
     let clock = NOW
@@ -980,6 +1021,37 @@ describe('handleReadCountRequest', () => {
     expect(cache.entries.has(cacheKey())).toBe(true)
     expect(cache.entries.has(backoffKey())).toBe(true)
     expect(coordinator.size).toBe(0)
+  })
+
+  it('keeps a validated stale snapshot when the fallback cache entry is evicted', async () => {
+    const cache = new MemoryReadCountCache()
+    seedCache(cache, {
+      body: { count: '321' },
+      fetchedAt: NOW - 5 * 60 * 60 * 1_000,
+    })
+    cache.onMatch = (matchedRequest) => {
+      const countMatches = cache.matchCalls.filter(
+        (url) => url === cacheKey(),
+      ).length
+      if (matchedRequest.url === cacheKey() && countMatches === 3) {
+        cache.entries.delete(cacheKey())
+      }
+    }
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(null, { status: 503 }))
+
+    const response = await handleReadCountRequest(request(), {
+      cache,
+      coordinator: createReadCountRefreshCoordinator(),
+      fetch: fetchMock,
+      now: () => NOW,
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get(READ_COUNT_CACHE_STATUS_HEADER)).toBe('stale')
+    expect(await response.json()).toEqual({ count: '321' })
+    expect(cache.entries.has(cacheKey())).toBe(false)
   })
 
   it('keeps a cold cache unavailable during failure backoff', async () => {

--- a/src/lib/read-count-proxy.test.ts
+++ b/src/lib/read-count-proxy.test.ts
@@ -192,6 +192,7 @@ describe('handleReadCountRequest', () => {
     'https://shariq.dev/api/read-count',
     `https://shariq.dev/api/read-count?path=${encodeURIComponent(ARTICLE_PATH)}&path=${encodeURIComponent(ARTICLE_PATH)}`,
     `https://shariq.dev/api/read-count?path=${encodeURIComponent(ARTICLE_PATH)}&extra=1`,
+    `https://attacker.example/api/read-count?path=${encodeURIComponent(ARTICLE_PATH)}`,
     'https://shariq.dev/api/read-count?path=blog%2Fexample%2F',
     'https://shariq.dev/api/read-count?path=%2Fprojects%2F',
     'https://shariq.dev/api/read-count?path=%2Fblog%2Fexample',

--- a/src/lib/read-count-proxy.test.ts
+++ b/src/lib/read-count-proxy.test.ts
@@ -1,12 +1,18 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  buildReadCountBackoffKey,
   buildReadCountCacheKey,
+  createReadCountRefreshCoordinator,
   handleReadCountRequest,
+  READ_COUNT_BACKOFF_STATUS_HEADER,
+  READ_COUNT_BACKOFF_UNTIL_HEADER,
   READ_COUNT_BROWSER_MAX_AGE_SECONDS,
   READ_COUNT_CACHE_FRESH_SECONDS,
   READ_COUNT_CACHE_FETCHED_AT_HEADER,
   READ_COUNT_CACHE_RETENTION_SECONDS,
   READ_COUNT_CACHE_STATUS_HEADER,
+  READ_COUNT_FAILURE_BACKOFF_SECONDS,
+  READ_COUNT_INTERNAL_BACKOFF_PATH,
   READ_COUNT_SHARED_MAX_AGE_SECONDS,
   READ_COUNT_STALE_BROWSER_MAX_AGE_SECONDS,
   READ_COUNT_STALE_SHARED_MAX_AGE_SECONDS,
@@ -47,28 +53,63 @@ function upstreamResponse(
   )
 }
 
+function deferred<T>(): {
+  promise: Promise<T>
+  reject: (reason?: unknown) => void
+  resolve: (value: T) => void
+} {
+  let reject!: (reason?: unknown) => void
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, reject, resolve }
+}
+
 class MemoryReadCountCache implements ReadCountCache {
   readonly entries = new Map<string, Response>()
+  readonly deleteCalls: string[] = []
   readonly matchCalls: string[] = []
   readonly putCalls: string[] = []
+  failBackoffPut = false
+  failDelete = false
   failMatch = false
   failPut = false
+  onMatch?: (request: Request) => Promise<void> | void
 
   async match(request: Request): Promise<Response | undefined> {
     this.matchCalls.push(request.url)
     if (this.failMatch) throw new Error('cache match failed')
+    await this.onMatch?.(request)
     return this.entries.get(request.url)?.clone()
   }
 
   async put(request: Request, response: Response): Promise<void> {
     this.putCalls.push(request.url)
-    if (this.failPut) throw new Error('cache put failed')
+    if (
+      this.failPut ||
+      (this.failBackoffPut &&
+        new URL(request.url).pathname === READ_COUNT_INTERNAL_BACKOFF_PATH)
+    ) {
+      throw new Error('cache put failed')
+    }
     this.entries.set(request.url, response.clone())
+  }
+
+  async delete(request: Request): Promise<boolean> {
+    this.deleteCalls.push(request.url)
+    if (this.failDelete) throw new Error('cache delete failed')
+    return this.entries.delete(request.url)
   }
 }
 
 function cacheKey(path = ARTICLE_PATH): string {
   return buildReadCountCacheKey(REQUEST_URL, path).url
+}
+
+function backoffKey(path = ARTICLE_PATH): string {
+  return buildReadCountBackoffKey(REQUEST_URL, path).url
 }
 
 function seedCache(
@@ -95,6 +136,30 @@ function seedCache(
         ...headers,
       },
     }),
+  )
+}
+
+function seedBackoff(
+  cache: MemoryReadCountCache,
+  {
+    failedAt = NOW,
+    status = 502,
+  }: { failedAt?: number; status?: 502 | 504 } = {},
+): void {
+  cache.entries.set(
+    backoffKey(),
+    upstreamResponse(
+      { status },
+      {
+        headers: {
+          'cache-control': `public, max-age=${READ_COUNT_FAILURE_BACKOFF_SECONDS}`,
+          'content-type': 'application/json; charset=utf-8',
+          [READ_COUNT_BACKOFF_UNTIL_HEADER]: String(
+            failedAt + READ_COUNT_FAILURE_BACKOFF_SECONDS * 1_000,
+          ),
+        },
+      },
+    ),
   )
 }
 
@@ -163,6 +228,7 @@ describe('handleReadCountRequest', () => {
 
     const response = await handleReadCountRequest(request(), {
       fetch: fetchMock,
+      now: () => NOW,
     })
 
     expect(fetchMock).toHaveBeenCalledWith(
@@ -366,6 +432,284 @@ describe('handleReadCountRequest', () => {
     expect(await stored?.clone().json()).toEqual({ count: '456' })
   })
 
+  it('coalesces concurrent refreshes within one isolate', async () => {
+    const cache = new MemoryReadCountCache()
+    const coordinator = createReadCountRefreshCoordinator()
+    const upstream = deferred<Response>()
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockImplementation(() => upstream.promise)
+    const options = {
+      cache,
+      coordinator,
+      fetch: fetchMock,
+      now: () => NOW,
+    }
+
+    const first = handleReadCountRequest(request(), options)
+    const second = handleReadCountRequest(request(), options)
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce())
+    expect(coordinator.size).toBe(1)
+
+    upstream.resolve(upstreamResponse({ count: '456' }))
+    const responses = await Promise.all([first, second])
+
+    await expect(responses[0].clone().json()).resolves.toEqual({ count: '456' })
+    await expect(responses[1].clone().json()).resolves.toEqual({ count: '456' })
+    expect(fetchMock).toHaveBeenCalledOnce()
+    expect(cache.putCalls).toEqual([cacheKey()])
+    expect(coordinator.size).toBe(0)
+  })
+
+  it('rechecks cache state when a late caller becomes refresh leader', async () => {
+    const cache = new MemoryReadCountCache()
+    const coordinator = createReadCountRefreshCoordinator()
+    const upstream = deferred<Response>()
+    const releaseBackoffLookup = deferred<void>()
+    let delayNextBackoffLookup = false
+    cache.onMatch = (matchedRequest) => {
+      if (delayNextBackoffLookup && matchedRequest.url === backoffKey()) {
+        delayNextBackoffLookup = false
+        return releaseBackoffLookup.promise
+      }
+    }
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockImplementation(() => upstream.promise)
+    const options = {
+      cache,
+      coordinator,
+      fetch: fetchMock,
+      now: () => NOW,
+    }
+
+    const first = handleReadCountRequest(request(), options)
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce())
+
+    delayNextBackoffLookup = true
+    const second = handleReadCountRequest(request(), options)
+    await vi.waitFor(() => expect(delayNextBackoffLookup).toBe(false))
+
+    upstream.resolve(upstreamResponse({ count: '456' }))
+    const firstResponse = await first
+    expect(firstResponse.status).toBe(200)
+    expect(coordinator.size).toBe(0)
+
+    releaseBackoffLookup.resolve(undefined)
+    const secondResponse = await second
+
+    expect(secondResponse.status).toBe(200)
+    expect(await secondResponse.json()).toEqual({ count: '456' })
+    expect(fetchMock).toHaveBeenCalledOnce()
+    expect(coordinator.size).toBe(0)
+  })
+
+  it('does not coalesce refreshes for different article keys', async () => {
+    const cache = new MemoryReadCountCache()
+    const coordinator = createReadCountRefreshCoordinator()
+    const firstPath = '/blog/first/'
+    const secondPath = '/blog/second/'
+    const firstUpstream = deferred<Response>()
+    const secondUpstream = deferred<Response>()
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockImplementation((input) =>
+        String(input).includes(encodeURIComponent(firstPath))
+          ? firstUpstream.promise
+          : secondUpstream.promise,
+      )
+    const options = {
+      cache,
+      coordinator,
+      fetch: fetchMock,
+      now: () => NOW,
+    }
+
+    const first = handleReadCountRequest(
+      request(
+        `https://shariq.dev/api/read-count?path=${encodeURIComponent(firstPath)}`,
+      ),
+      options,
+    )
+    const second = handleReadCountRequest(
+      request(
+        `https://shariq.dev/api/read-count?path=${encodeURIComponent(secondPath)}`,
+      ),
+      options,
+    )
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+    expect(coordinator.size).toBe(2)
+
+    firstUpstream.resolve(upstreamResponse({ count: '1' }))
+    secondUpstream.resolve(upstreamResponse({ count: '2' }))
+    const responses = await Promise.all([first, second])
+
+    expect(await responses[0].json()).toEqual({ count: '1' })
+    expect(await responses[1].json()).toEqual({ count: '2' })
+    expect(coordinator.size).toBe(0)
+  })
+
+  it('uses request start time as the successful refresh generation', async () => {
+    const cache = new MemoryReadCountCache()
+    let clock = NOW
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(async () => {
+      clock = NOW + 5_000
+      return upstreamResponse({ count: '456' })
+    })
+
+    const response = await handleReadCountRequest(request(), {
+      cache,
+      coordinator: createReadCountRefreshCoordinator(),
+      fetch: fetchMock,
+      now: () => clock,
+    })
+
+    expect(response.status).toBe(200)
+    expect(
+      cache.entries
+        .get(cacheKey())
+        ?.headers.get(READ_COUNT_CACHE_FETCHED_AT_HEADER),
+    ).toBe(String(NOW))
+    expect(response.headers.get('cache-control')).toBe(
+      `public, max-age=${READ_COUNT_BROWSER_MAX_AGE_SECONDS}, s-maxage=${
+        READ_COUNT_CACHE_FRESH_SECONDS - 5
+      }`,
+    )
+  })
+
+  it('cleans up an in-flight refresh after unexpected failure', async () => {
+    const cache = new MemoryReadCountCache()
+    const coordinator = createReadCountRefreshCoordinator()
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockRejectedValueOnce(new Error('broken upstream adapter'))
+      .mockResolvedValueOnce(upstreamResponse({ count: '456' }))
+
+    const failed = await handleReadCountRequest(request(), {
+      cache,
+      coordinator,
+      fetch: fetchMock,
+      now: () => NOW,
+    })
+    expect(failed.status).toBe(502)
+    expect(coordinator.size).toBe(0)
+
+    const recovered = await handleReadCountRequest(request(), {
+      cache,
+      coordinator,
+      fetch: fetchMock,
+      now: () => NOW,
+    })
+    expect(recovered.status).toBe(200)
+    expect(await recovered.json()).toEqual({ count: '456' })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(coordinator.size).toBe(0)
+  })
+
+  it('preserves a concurrent higher count over a slower lower refresh', async () => {
+    const cache = new MemoryReadCountCache()
+    const coordinator = createReadCountRefreshCoordinator()
+    let clock = NOW
+    seedCache(cache, {
+      body: { count: '100' },
+      fetchedAt: NOW - 5 * 60 * 60 * 1_000,
+    })
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(async () => {
+      clock = NOW + 1_000
+      seedCache(cache, { body: { count: '200' }, fetchedAt: clock })
+      return upstreamResponse({ count: '150' })
+    })
+
+    const response = await handleReadCountRequest(request(), {
+      cache,
+      coordinator,
+      fetch: fetchMock,
+      now: () => clock,
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get(READ_COUNT_CACHE_STATUS_HEADER)).toBe(
+      'preserved',
+    )
+    expect(await response.json()).toEqual({ count: '200' })
+    const stored = cache.entries.get(cacheKey())
+    expect(await stored?.clone().json()).toEqual({ count: '200' })
+    expect(stored?.headers.get(READ_COUNT_CACHE_FETCHED_AT_HEADER)).toBe(
+      String(clock),
+    )
+    expect(cache.putCalls).toEqual([])
+  })
+
+  it('classifies a concurrent winner with a post-read timestamp', async () => {
+    const cache = new MemoryReadCountCache()
+    let clock = NOW
+    seedCache(cache, {
+      body: { count: '100' },
+      fetchedAt: NOW - 5 * 60 * 60 * 1_000,
+    })
+    cache.onMatch = (matchedRequest) => {
+      const countMatches = cache.matchCalls.filter(
+        (url) => url === cacheKey(),
+      ).length
+      if (matchedRequest.url === cacheKey() && countMatches === 2) {
+        clock = NOW + 1_000
+        seedCache(cache, { body: { count: '200' }, fetchedAt: clock })
+      }
+    }
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(upstreamResponse({ count: '150' }))
+
+    const response = await handleReadCountRequest(request(), {
+      cache,
+      coordinator: createReadCountRefreshCoordinator(),
+      fetch: fetchMock,
+      now: () => clock,
+    })
+
+    expect(response.headers.get(READ_COUNT_CACHE_STATUS_HEADER)).toBe(
+      'preserved',
+    )
+    expect(await response.json()).toEqual({ count: '200' })
+    expect(await cache.entries.get(cacheKey())?.clone().json()).toEqual({
+      count: '200',
+    })
+    expect(cache.putCalls).toEqual([])
+  })
+
+  it('preserves newer metadata for an equal concurrent count', async () => {
+    const cache = new MemoryReadCountCache()
+    const coordinator = createReadCountRefreshCoordinator()
+    let clock = NOW
+    seedCache(cache, {
+      body: { count: '100' },
+      fetchedAt: NOW - 5 * 60 * 60 * 1_000,
+    })
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(async () => {
+      clock = NOW + 1_000
+      seedCache(cache, { body: { count: '150' }, fetchedAt: clock })
+      return upstreamResponse({ count: '150' })
+    })
+
+    const response = await handleReadCountRequest(request(), {
+      cache,
+      coordinator,
+      fetch: fetchMock,
+      now: () => clock,
+    })
+
+    expect(response.headers.get(READ_COUNT_CACHE_STATUS_HEADER)).toBe(
+      'preserved',
+    )
+    expect(await response.json()).toEqual({ count: '150' })
+    expect(
+      cache.entries
+        .get(cacheKey())
+        ?.headers.get(READ_COUNT_CACHE_FETCHED_AT_HEADER),
+    ).toBe(String(clock))
+    expect(cache.putCalls).toEqual([])
+  })
+
   it.each([
     {
       failure: 'network error',
@@ -417,7 +761,7 @@ describe('handleReadCountRequest', () => {
       )
       expect(await response.json()).toEqual({ count: '321' })
       expect(fetchMock).toHaveBeenCalledOnce()
-      expect(cache.putCalls).toEqual([])
+      expect(cache.putCalls).toEqual([backoffKey()])
     },
   )
 
@@ -449,6 +793,153 @@ describe('handleReadCountRequest', () => {
     expect(response.status).toBe(200)
     expect(response.headers.get(READ_COUNT_CACHE_STATUS_HEADER)).toBe('stale')
     expect(await response.json()).toEqual({ count: '321' })
+    const marker = cache.entries.get(backoffKey())
+    expect(marker?.headers.get('cache-control')).toBe(
+      `public, max-age=${READ_COUNT_FAILURE_BACKOFF_SECONDS}`,
+    )
+    expect(marker?.headers.get(READ_COUNT_BACKOFF_UNTIL_HEADER)).toBe(
+      String(NOW + READ_COUNT_FAILURE_BACKOFF_SECONDS * 1_000),
+    )
+    expect(await marker?.clone().json()).toEqual({ status: 504 })
+  })
+
+  it('uses a failure marker to suppress repeated stale refreshes', async () => {
+    const cache = new MemoryReadCountCache()
+    const coordinator = createReadCountRefreshCoordinator()
+    seedCache(cache, {
+      body: { count: '321' },
+      fetchedAt: NOW - 5 * 60 * 60 * 1_000,
+    })
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(null, { status: 503 }))
+    const options = {
+      cache,
+      coordinator,
+      fetch: fetchMock,
+      now: () => NOW,
+    }
+
+    const first = await handleReadCountRequest(request(), options)
+    const second = await handleReadCountRequest(request(), options)
+
+    expect(first.headers.get(READ_COUNT_BACKOFF_STATUS_HEADER)).toBe('stored')
+    expect(second.headers.get(READ_COUNT_BACKOFF_STATUS_HEADER)).toBe('active')
+    expect(second.headers.get(READ_COUNT_CACHE_STATUS_HEADER)).toBe('stale')
+    expect(await second.json()).toEqual({ count: '321' })
+    expect(fetchMock).toHaveBeenCalledOnce()
+    expect(cache.entries.has(cacheKey())).toBe(true)
+    expect(cache.entries.has(backoffKey())).toBe(true)
+    expect(coordinator.size).toBe(0)
+  })
+
+  it('keeps a cold cache unavailable during failure backoff', async () => {
+    const cache = new MemoryReadCountCache()
+    const coordinator = createReadCountRefreshCoordinator()
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockRejectedValue(new TypeError('Failed to fetch'))
+    const options = {
+      cache,
+      coordinator,
+      fetch: fetchMock,
+      now: () => NOW,
+    }
+
+    const first = await handleReadCountRequest(request(), options)
+    const second = await handleReadCountRequest(request(), options)
+
+    expect(first.status).toBe(502)
+    expect(first.headers.get(READ_COUNT_BACKOFF_STATUS_HEADER)).toBe('stored')
+    expect(second.status).toBe(502)
+    expect(second.headers.get(READ_COUNT_BACKOFF_STATUS_HEADER)).toBe('active')
+    expect(second.headers.get(READ_COUNT_CACHE_STATUS_HEADER)).toBe('miss')
+    expect(await second.json()).toEqual({ error: 'unavailable' })
+    expect(fetchMock).toHaveBeenCalledOnce()
+  })
+
+  it('refreshes again after failure backoff expires', async () => {
+    const cache = new MemoryReadCountCache()
+    const coordinator = createReadCountRefreshCoordinator()
+    let clock = NOW
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 503 }))
+      .mockResolvedValueOnce(upstreamResponse({ count: '456' }))
+    const options = {
+      cache,
+      coordinator,
+      fetch: fetchMock,
+      now: () => clock,
+    }
+
+    const failed = await handleReadCountRequest(request(), options)
+    expect(failed.status).toBe(502)
+
+    clock += (READ_COUNT_FAILURE_BACKOFF_SECONDS - 1) * 1_000
+    const blocked = await handleReadCountRequest(request(), options)
+    expect(blocked.status).toBe(502)
+    expect(blocked.headers.get(READ_COUNT_BACKOFF_STATUS_HEADER)).toBe('active')
+    expect(fetchMock).toHaveBeenCalledOnce()
+
+    clock += 1_000
+    const refreshed = await handleReadCountRequest(request(), options)
+
+    expect(refreshed.status).toBe(200)
+    expect(await refreshed.json()).toEqual({ count: '456' })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(cache.entries.has(backoffKey())).toBe(false)
+    expect(cache.deleteCalls).toContain(backoffKey())
+  })
+
+  it('keeps stale data available when failure marker writes fail', async () => {
+    const cache = new MemoryReadCountCache()
+    cache.failBackoffPut = true
+    seedCache(cache, {
+      body: { count: '321' },
+      fetchedAt: NOW - 5 * 60 * 60 * 1_000,
+    })
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(null, { status: 503 }))
+
+    const response = await handleReadCountRequest(request(), {
+      cache,
+      coordinator: createReadCountRefreshCoordinator(),
+      fetch: fetchMock,
+      now: () => NOW,
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get(READ_COUNT_BACKOFF_STATUS_HEADER)).toBe(
+      'write-error',
+    )
+    expect(await response.json()).toEqual({ count: '321' })
+  })
+
+  it('returns fresh data when failure marker cleanup fails', async () => {
+    const cache = new MemoryReadCountCache()
+    cache.failDelete = true
+    seedBackoff(cache, {
+      failedAt: NOW - (READ_COUNT_FAILURE_BACKOFF_SECONDS + 1) * 1_000,
+    })
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(upstreamResponse({ count: '456' }))
+
+    const response = await handleReadCountRequest(request(), {
+      cache,
+      coordinator: createReadCountRefreshCoordinator(),
+      fetch: fetchMock,
+      now: () => NOW,
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get(READ_COUNT_BACKOFF_STATUS_HEADER)).toBe(
+      'clear-error',
+    )
+    expect(await response.json()).toEqual({ count: '456' })
+    expect(cache.entries.has(cacheKey())).toBe(true)
   })
 
   it('caps stale response caching at the remaining retention window', async () => {
@@ -472,7 +963,7 @@ describe('handleReadCountRequest', () => {
     )
   })
 
-  it('revalidates retention after an upstream availability failure', async () => {
+  it('uses a concurrent fresh entry after an upstream availability failure', async () => {
     const cache = new MemoryReadCountCache()
     seedCache(cache, { fetchedAt: NOW })
     const retentionBoundary = NOW + READ_COUNT_CACHE_RETENTION_SECONDS * 1_000
@@ -495,10 +986,9 @@ describe('handleReadCountRequest', () => {
       now: () => times.shift() ?? retentionBoundary + 1,
     })
 
-    expect(response.status).toBe(502)
-    expect(response.headers.get(READ_COUNT_CACHE_STATUS_HEADER)).toBe('expired')
-    expect(response.headers.get('cache-control')).toBe('no-store')
-    expect(await response.json()).toEqual({ error: 'unavailable' })
+    expect(response.status).toBe(200)
+    expect(response.headers.get(READ_COUNT_CACHE_STATUS_HEADER)).toBe('fresh')
+    expect(await response.json()).toEqual({ count: '999' })
     const concurrentEntry = cache.entries.get(cacheKey())
     expect(await concurrentEntry?.clone().json()).toEqual({ count: '999' })
     expect(
@@ -631,11 +1121,17 @@ describe('handleReadCountRequest', () => {
 
   it('uses an internal same-origin cache key keyed by canonical path', () => {
     const key = buildReadCountCacheKey(REQUEST_URL, ARTICLE_PATH)
+    const failureKey = buildReadCountBackoffKey(REQUEST_URL, ARTICLE_PATH)
     const url = new URL(key.url)
+    const failureUrl = new URL(failureKey.url)
 
     expect(url.origin).toBe('https://shariq.dev')
     expect(url.pathname).toBe('/.internal/read-count-cache/v1')
     expect(url.searchParams.get('path')).toBe(ARTICLE_PATH)
     expect(url.pathname).not.toBe('/api/read-count')
+    expect(failureUrl.origin).toBe(url.origin)
+    expect(failureUrl.pathname).toBe('/.internal/read-count-backoff/v1')
+    expect(failureUrl.searchParams.get('path')).toBe(ARTICLE_PATH)
+    expect(failureKey.url).not.toBe(key.url)
   })
 })

--- a/src/lib/read-count-proxy.test.ts
+++ b/src/lib/read-count-proxy.test.ts
@@ -51,10 +51,8 @@ class MemoryReadCountCache implements ReadCountCache {
   readonly entries = new Map<string, Response>()
   readonly matchCalls: string[] = []
   readonly putCalls: string[] = []
-  readonly deleteCalls: string[] = []
   failMatch = false
   failPut = false
-  failDelete = false
 
   async match(request: Request): Promise<Response | undefined> {
     this.matchCalls.push(request.url)
@@ -66,12 +64,6 @@ class MemoryReadCountCache implements ReadCountCache {
     this.putCalls.push(request.url)
     if (this.failPut) throw new Error('cache put failed')
     this.entries.set(request.url, response.clone())
-  }
-
-  async delete(request: Request): Promise<boolean> {
-    this.deleteCalls.push(request.url)
-    if (this.failDelete) throw new Error('cache delete failed')
-    return this.entries.delete(request.url)
   }
 }
 
@@ -315,6 +307,32 @@ describe('handleReadCountRequest', () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
+  it('revalidates freshness after an asynchronous cache lookup', async () => {
+    const cache = new MemoryReadCountCache()
+    seedCache(cache, { fetchedAt: NOW })
+    const freshnessBoundary = NOW + READ_COUNT_CACHE_FRESH_SECONDS * 1_000
+    const times = [
+      freshnessBoundary - 1,
+      freshnessBoundary + 1,
+      freshnessBoundary + 1,
+    ]
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(upstreamResponse({ count: '456' }))
+
+    const response = await handleReadCountRequest(request(), {
+      cache,
+      fetch: fetchMock,
+      now: () => times.shift() ?? freshnessBoundary + 1,
+    })
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+    expect(response.headers.get(READ_COUNT_CACHE_STATUS_HEADER)).toBe(
+      'refreshed',
+    )
+    expect(await response.json()).toEqual({ count: '456' })
+  })
+
   it('refreshes a retained stale cache entry from upstream', async () => {
     const cache = new MemoryReadCountCache()
     seedCache(cache, {
@@ -454,6 +472,40 @@ describe('handleReadCountRequest', () => {
     )
   })
 
+  it('revalidates retention after an upstream availability failure', async () => {
+    const cache = new MemoryReadCountCache()
+    seedCache(cache, { fetchedAt: NOW })
+    const retentionBoundary = NOW + READ_COUNT_CACHE_RETENTION_SECONDS * 1_000
+    const times = [
+      retentionBoundary - 1,
+      retentionBoundary - 1,
+      retentionBoundary + 1,
+    ]
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(async () => {
+      seedCache(cache, {
+        body: { count: '999' },
+        fetchedAt: retentionBoundary,
+      })
+      return new Response(null, { status: 503 })
+    })
+
+    const response = await handleReadCountRequest(request(), {
+      cache,
+      fetch: fetchMock,
+      now: () => times.shift() ?? retentionBoundary + 1,
+    })
+
+    expect(response.status).toBe(502)
+    expect(response.headers.get(READ_COUNT_CACHE_STATUS_HEADER)).toBe('expired')
+    expect(response.headers.get('cache-control')).toBe('no-store')
+    expect(await response.json()).toEqual({ error: 'unavailable' })
+    const concurrentEntry = cache.entries.get(cacheKey())
+    expect(await concurrentEntry?.clone().json()).toEqual({ count: '999' })
+    expect(
+      concurrentEntry?.headers.get(READ_COUNT_CACHE_FETCHED_AT_HEADER),
+    ).toBe(String(retentionBoundary))
+  })
+
   it('does not serve a cache entry beyond the retention window', async () => {
     const cache = new MemoryReadCountCache()
     seedCache(cache, {
@@ -473,8 +525,7 @@ describe('handleReadCountRequest', () => {
     expect(response.headers.get(READ_COUNT_CACHE_STATUS_HEADER)).toBe('expired')
     expect(response.headers.get('cache-control')).toBe('no-store')
     expect(await response.json()).toEqual({ error: 'unavailable' })
-    expect(cache.deleteCalls).toEqual([cacheKey()])
-    expect(cache.entries.has(cacheKey())).toBe(false)
+    expect(cache.entries.has(cacheKey())).toBe(true)
   })
 
   it('fails closed when upstream fails and the cache is empty', async () => {
@@ -496,7 +547,7 @@ describe('handleReadCountRequest', () => {
   })
 
   it.each(INVALID_CACHE_CASES)(
-    'evicts $cacheProblem instead of serving it stale',
+    'ignores $cacheProblem instead of serving it stale',
     async ({ body, headers }) => {
       const cache = new MemoryReadCountCache()
       seedCache(cache, {
@@ -519,8 +570,7 @@ describe('handleReadCountRequest', () => {
         'invalid',
       )
       expect(await response.json()).toEqual({ error: 'unavailable' })
-      expect(cache.deleteCalls).toEqual([cacheKey()])
-      expect(cache.entries.has(cacheKey())).toBe(false)
+      expect(cache.entries.has(cacheKey())).toBe(true)
     },
   )
 

--- a/src/lib/read-count-proxy.test.ts
+++ b/src/lib/read-count-proxy.test.ts
@@ -39,8 +39,12 @@ const INVALID_CACHE_CASES: {
   },
 ]
 
-function request(url = REQUEST_URL, method = 'GET'): Request {
-  return new Request(url, { method })
+function request(
+  url = REQUEST_URL,
+  method = 'GET',
+  signal?: AbortSignal,
+): Request {
+  return new Request(url, { method, signal })
 }
 
 function upstreamResponse(
@@ -461,6 +465,124 @@ describe('handleReadCountRequest', () => {
     expect(coordinator.size).toBe(0)
   })
 
+  it('keeps a shared refresh alive while another consumer remains', async () => {
+    const cache = new MemoryReadCountCache()
+    const coordinator = createReadCountRefreshCoordinator()
+    const firstController = new AbortController()
+    const secondController = new AbortController()
+    const upstream = deferred<Response>()
+    let sharedSignal: AbortSignal | undefined
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockImplementation((_input, init) => {
+        sharedSignal = init?.signal ?? undefined
+        return upstream.promise
+      })
+    const options = {
+      cache,
+      coordinator,
+      fetch: fetchMock,
+      now: () => NOW,
+    }
+
+    const first = handleReadCountRequest(
+      request(REQUEST_URL, 'GET', firstController.signal),
+      options,
+    )
+    const second = handleReadCountRequest(
+      request(REQUEST_URL, 'GET', secondController.signal),
+      options,
+    )
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce())
+    await vi.waitFor(() => expect(coordinator.consumers).toBe(2))
+
+    firstController.abort()
+    const firstResponse = await first
+    expect(firstResponse.status).toBe(502)
+    expect(sharedSignal?.aborted).toBe(false)
+    expect(coordinator.size).toBe(1)
+    expect(coordinator.consumers).toBe(1)
+
+    upstream.resolve(upstreamResponse({ count: '456' }))
+    const secondResponse = await second
+    expect(secondResponse.status).toBe(200)
+    expect(await secondResponse.json()).toEqual({ count: '456' })
+    expect(coordinator.size).toBe(0)
+  })
+
+  it('aborts a shared refresh after its last consumer disconnects', async () => {
+    const cache = new MemoryReadCountCache()
+    const coordinator = createReadCountRefreshCoordinator()
+    const controller = new AbortController()
+    let sharedSignal: AbortSignal | undefined
+    const fetchMock: typeof fetch = async (_input, init) =>
+      new Promise<Response>((_resolve, reject) => {
+        sharedSignal = init?.signal ?? undefined
+        sharedSignal?.addEventListener(
+          'abort',
+          () => reject(new DOMException('Aborted', 'AbortError')),
+          { once: true },
+        )
+      })
+
+    const responsePromise = handleReadCountRequest(
+      request(REQUEST_URL, 'GET', controller.signal),
+      {
+        cache,
+        coordinator,
+        fetch: fetchMock,
+        now: () => NOW,
+      },
+    )
+    await vi.waitFor(() => expect(sharedSignal).toBeDefined())
+
+    controller.abort()
+    const response = await responsePromise
+
+    expect(response.status).toBe(502)
+    expect(sharedSignal?.aborted).toBe(true)
+    await vi.waitFor(() => expect(coordinator.size).toBe(0))
+  })
+
+  it('does not let a new caller join an aborted refresh', async () => {
+    const cache = new MemoryReadCountCache()
+    const coordinator = createReadCountRefreshCoordinator()
+    const controller = new AbortController()
+    const abandonedFetch = deferred<Response>()
+    let abandonedSignal: AbortSignal | undefined
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockImplementationOnce((_input, init) => {
+        abandonedSignal = init?.signal ?? undefined
+        return abandonedFetch.promise
+      })
+      .mockResolvedValueOnce(upstreamResponse({ count: '456' }))
+    const options = {
+      cache,
+      coordinator,
+      fetch: fetchMock,
+      now: () => NOW,
+    }
+
+    const abandoned = handleReadCountRequest(
+      request(REQUEST_URL, 'GET', controller.signal),
+      options,
+    )
+    await vi.waitFor(() => expect(abandonedSignal).toBeDefined())
+    controller.abort()
+    expect((await abandoned).status).toBe(502)
+    expect(abandonedSignal?.aborted).toBe(true)
+    expect(coordinator.size).toBe(1)
+
+    const recovered = await handleReadCountRequest(request(), options)
+    expect(recovered.status).toBe(200)
+    expect(await recovered.json()).toEqual({ count: '456' })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    abandonedFetch.reject(new DOMException('Aborted', 'AbortError'))
+    await vi.waitFor(() => expect(coordinator.size).toBe(0))
+  })
+
   it('rechecks cache state when a late caller becomes refresh leader', async () => {
     const cache = new MemoryReadCountCache()
     const coordinator = createReadCountRefreshCoordinator()
@@ -637,6 +759,33 @@ describe('handleReadCountRequest', () => {
     expect(stored?.headers.get(READ_COUNT_CACHE_FETCHED_AT_HEADER)).toBe(
       String(clock),
     )
+    expect(cache.putCalls).toEqual([])
+  })
+
+  it('never replaces an older cumulative count with a lower refresh', async () => {
+    const cache = new MemoryReadCountCache()
+    const fetchedAt = NOW - 5 * 60 * 60 * 1_000
+    seedCache(cache, { body: { count: '200' }, fetchedAt })
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(upstreamResponse({ count: '150' }))
+
+    const response = await handleReadCountRequest(request(), {
+      cache,
+      coordinator: createReadCountRefreshCoordinator(),
+      fetch: fetchMock,
+      now: () => NOW,
+    })
+
+    expect(response.headers.get(READ_COUNT_CACHE_STATUS_HEADER)).toBe(
+      'preserved',
+    )
+    expect(await response.json()).toEqual({ count: '200' })
+    expect(
+      cache.entries
+        .get(cacheKey())
+        ?.headers.get(READ_COUNT_CACHE_FETCHED_AT_HEADER),
+    ).toBe(String(fetchedAt))
     expect(cache.putCalls).toEqual([])
   })
 

--- a/src/lib/read-count-proxy.test.ts
+++ b/src/lib/read-count-proxy.test.ts
@@ -1,12 +1,37 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  buildReadCountCacheKey,
   handleReadCountRequest,
   READ_COUNT_BROWSER_MAX_AGE_SECONDS,
+  READ_COUNT_CACHE_FRESH_SECONDS,
+  READ_COUNT_CACHE_FETCHED_AT_HEADER,
+  READ_COUNT_CACHE_RETENTION_SECONDS,
+  READ_COUNT_CACHE_STATUS_HEADER,
   READ_COUNT_SHARED_MAX_AGE_SECONDS,
+  READ_COUNT_STALE_BROWSER_MAX_AGE_SECONDS,
+  READ_COUNT_STALE_SHARED_MAX_AGE_SECONDS,
+  type ReadCountCache,
 } from './read-count-proxy'
 
 const ARTICLE_PATH = '/blog/example/'
 const REQUEST_URL = `https://shariq.dev/api/read-count?path=${encodeURIComponent(ARTICLE_PATH)}`
+const NOW = Date.parse('2026-08-20T19:00:00.000Z')
+const INVALID_CACHE_CASES: {
+  cacheProblem: string
+  body: object
+  headers: Record<string, string>
+}[] = [
+  {
+    cacheProblem: 'a malformed payload',
+    body: { count: 'many' },
+    headers: {},
+  },
+  {
+    cacheProblem: 'untrusted fetch metadata',
+    body: { count: '123' },
+    headers: { [READ_COUNT_CACHE_FETCHED_AT_HEADER]: 'not-a-timestamp' },
+  },
+]
 
 function request(url = REQUEST_URL, method = 'GET'): Request {
   return new Request(url, { method })
@@ -19,6 +44,65 @@ function upstreamResponse(
   return new Response(
     typeof body === 'string' ? body : JSON.stringify(body),
     init,
+  )
+}
+
+class MemoryReadCountCache implements ReadCountCache {
+  readonly entries = new Map<string, Response>()
+  readonly matchCalls: string[] = []
+  readonly putCalls: string[] = []
+  readonly deleteCalls: string[] = []
+  failMatch = false
+  failPut = false
+  failDelete = false
+
+  async match(request: Request): Promise<Response | undefined> {
+    this.matchCalls.push(request.url)
+    if (this.failMatch) throw new Error('cache match failed')
+    return this.entries.get(request.url)?.clone()
+  }
+
+  async put(request: Request, response: Response): Promise<void> {
+    this.putCalls.push(request.url)
+    if (this.failPut) throw new Error('cache put failed')
+    this.entries.set(request.url, response.clone())
+  }
+
+  async delete(request: Request): Promise<boolean> {
+    this.deleteCalls.push(request.url)
+    if (this.failDelete) throw new Error('cache delete failed')
+    return this.entries.delete(request.url)
+  }
+}
+
+function cacheKey(path = ARTICLE_PATH): string {
+  return buildReadCountCacheKey(REQUEST_URL, path).url
+}
+
+function seedCache(
+  cache: MemoryReadCountCache,
+  {
+    body = { count: '123' },
+    fetchedAt = NOW - 60 * 60 * 1_000,
+    headers = {},
+    status = 200,
+  }: {
+    body?: object | string
+    fetchedAt?: number
+    headers?: Record<string, string>
+    status?: number
+  } = {},
+): void {
+  cache.entries.set(
+    cacheKey(),
+    upstreamResponse(body, {
+      status,
+      headers: {
+        'content-type': 'application/json; charset=utf-8',
+        [READ_COUNT_CACHE_FETCHED_AT_HEADER]: String(fetchedAt),
+        ...headers,
+      },
+    }),
   )
 }
 
@@ -105,6 +189,7 @@ describe('handleReadCountRequest', () => {
     expect(response.headers.get('cache-control')).toBe(
       `public, max-age=${READ_COUNT_BROWSER_MAX_AGE_SECONDS}, s-maxage=${READ_COUNT_SHARED_MAX_AGE_SECONDS}`,
     )
+    expect(response.headers.get(READ_COUNT_CACHE_FETCHED_AT_HEADER)).toBeNull()
     expect(await response.json()).toEqual({ count: '1234' })
   })
 
@@ -186,5 +271,321 @@ describe('handleReadCountRequest', () => {
 
     expect(response.status).toBe(504)
     expect(await response.json()).toEqual({ error: 'unavailable' })
+  })
+
+  it('returns a fresh cache hit without calling upstream', async () => {
+    const cache = new MemoryReadCountCache()
+    seedCache(cache, { body: { count: '1,234' } })
+    const fetchMock = vi.fn<typeof fetch>()
+
+    const response = await handleReadCountRequest(request(), {
+      cache,
+      fetch: fetchMock,
+      now: () => NOW,
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get(READ_COUNT_CACHE_STATUS_HEADER)).toBe('fresh')
+    expect(response.headers.get('cache-control')).toBe(
+      `public, max-age=${READ_COUNT_BROWSER_MAX_AGE_SECONDS}, s-maxage=${
+        READ_COUNT_CACHE_FRESH_SECONDS - 60 * 60
+      }`,
+    )
+    expect(await response.json()).toEqual({ count: '1234' })
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(cache.putCalls).toEqual([])
+  })
+
+  it('caps fresh response caching at the remaining freshness window', async () => {
+    const cache = new MemoryReadCountCache()
+    seedCache(cache, {
+      fetchedAt: NOW - (READ_COUNT_CACHE_FRESH_SECONDS * 1_000 - 90_000),
+    })
+    const fetchMock = vi.fn<typeof fetch>()
+
+    const response = await handleReadCountRequest(request(), {
+      cache,
+      fetch: fetchMock,
+      now: () => NOW,
+    })
+
+    expect(response.headers.get('cache-control')).toBe(
+      'public, max-age=90, s-maxage=90',
+    )
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('refreshes a retained stale cache entry from upstream', async () => {
+    const cache = new MemoryReadCountCache()
+    seedCache(cache, {
+      body: { count: '123' },
+      fetchedAt: NOW - 5 * 60 * 60 * 1_000,
+    })
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(upstreamResponse({ count: '456' }))
+
+    const response = await handleReadCountRequest(request(), {
+      cache,
+      fetch: fetchMock,
+      now: () => NOW,
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get(READ_COUNT_CACHE_STATUS_HEADER)).toBe(
+      'refreshed',
+    )
+    expect(await response.json()).toEqual({ count: '456' })
+    expect(cache.putCalls).toEqual([cacheKey()])
+
+    const stored = cache.entries.get(cacheKey())
+    expect(stored?.headers.get(READ_COUNT_CACHE_FETCHED_AT_HEADER)).toBe(
+      String(NOW),
+    )
+    expect(stored?.headers.get('cache-control')).toBe(
+      `public, max-age=${READ_COUNT_CACHE_RETENTION_SECONDS}`,
+    )
+    expect(await stored?.clone().json()).toEqual({ count: '456' })
+  })
+
+  it.each([
+    {
+      failure: 'network error',
+      fetch: async () => {
+        throw new TypeError('Failed to fetch')
+      },
+    },
+    {
+      failure: 'HTTP 429',
+      fetch: async () => new Response(null, { status: 429 }),
+    },
+    {
+      failure: 'HTTP 503',
+      fetch: async () => new Response(null, { status: 503 }),
+    },
+    {
+      failure: 'response stream network error',
+      fetch: async () =>
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.error(new TypeError('terminated'))
+            },
+          }),
+        ),
+    },
+  ] satisfies { failure: string; fetch: typeof fetch }[])(
+    'serves retained stale data on $failure',
+    async ({ fetch }) => {
+      const cache = new MemoryReadCountCache()
+      seedCache(cache, {
+        body: { count: '321' },
+        fetchedAt: NOW - 5 * 60 * 60 * 1_000,
+      })
+      const fetchMock = vi
+        .fn<typeof globalThis.fetch>()
+        .mockImplementation(fetch)
+
+      const response = await handleReadCountRequest(request(), {
+        cache,
+        fetch: fetchMock,
+        now: () => NOW,
+      })
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get(READ_COUNT_CACHE_STATUS_HEADER)).toBe('stale')
+      expect(response.headers.get('cache-control')).toBe(
+        `public, max-age=${READ_COUNT_STALE_BROWSER_MAX_AGE_SECONDS}, s-maxage=${READ_COUNT_STALE_SHARED_MAX_AGE_SECONDS}`,
+      )
+      expect(await response.json()).toEqual({ count: '321' })
+      expect(fetchMock).toHaveBeenCalledOnce()
+      expect(cache.putCalls).toEqual([])
+    },
+  )
+
+  it('serves retained stale data when upstream times out', async () => {
+    vi.useFakeTimers()
+    const cache = new MemoryReadCountCache()
+    seedCache(cache, {
+      body: { count: '321' },
+      fetchedAt: NOW - 5 * 60 * 60 * 1_000,
+    })
+    const fetchMock: typeof fetch = async (_input, init) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener(
+          'abort',
+          () => reject(new DOMException('Aborted', 'AbortError')),
+          { once: true },
+        )
+      })
+
+    const responsePromise = handleReadCountRequest(request(), {
+      cache,
+      fetch: fetchMock,
+      now: () => NOW,
+      timeoutMs: 50,
+    })
+    await vi.advanceTimersByTimeAsync(50)
+    const response = await responsePromise
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get(READ_COUNT_CACHE_STATUS_HEADER)).toBe('stale')
+    expect(await response.json()).toEqual({ count: '321' })
+  })
+
+  it('caps stale response caching at the remaining retention window', async () => {
+    const cache = new MemoryReadCountCache()
+    seedCache(cache, {
+      fetchedAt: NOW - (READ_COUNT_CACHE_RETENTION_SECONDS * 1_000 - 45_000),
+    })
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(null, { status: 503 }))
+
+    const response = await handleReadCountRequest(request(), {
+      cache,
+      fetch: fetchMock,
+      now: () => NOW,
+    })
+
+    expect(response.headers.get(READ_COUNT_CACHE_STATUS_HEADER)).toBe('stale')
+    expect(response.headers.get('cache-control')).toBe(
+      'public, max-age=45, s-maxage=45',
+    )
+  })
+
+  it('does not serve a cache entry beyond the retention window', async () => {
+    const cache = new MemoryReadCountCache()
+    seedCache(cache, {
+      fetchedAt: NOW - (READ_COUNT_CACHE_RETENTION_SECONDS * 1_000 + 1),
+    })
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(null, { status: 503 }))
+
+    const response = await handleReadCountRequest(request(), {
+      cache,
+      fetch: fetchMock,
+      now: () => NOW,
+    })
+
+    expect(response.status).toBe(502)
+    expect(response.headers.get(READ_COUNT_CACHE_STATUS_HEADER)).toBe('expired')
+    expect(response.headers.get('cache-control')).toBe('no-store')
+    expect(await response.json()).toEqual({ error: 'unavailable' })
+    expect(cache.deleteCalls).toEqual([cacheKey()])
+    expect(cache.entries.has(cacheKey())).toBe(false)
+  })
+
+  it('fails closed when upstream fails and the cache is empty', async () => {
+    const cache = new MemoryReadCountCache()
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockRejectedValue(new TypeError('Failed to fetch'))
+
+    const response = await handleReadCountRequest(request(), {
+      cache,
+      fetch: fetchMock,
+      now: () => NOW,
+    })
+
+    expect(response.status).toBe(502)
+    expect(response.headers.get(READ_COUNT_CACHE_STATUS_HEADER)).toBe('miss')
+    expect(response.headers.get('cache-control')).toBe('no-store')
+    expect(await response.json()).toEqual({ error: 'unavailable' })
+  })
+
+  it.each(INVALID_CACHE_CASES)(
+    'evicts $cacheProblem instead of serving it stale',
+    async ({ body, headers }) => {
+      const cache = new MemoryReadCountCache()
+      seedCache(cache, {
+        body,
+        fetchedAt: NOW - 5 * 60 * 60 * 1_000,
+        headers,
+      })
+      const fetchMock = vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(new Response(null, { status: 503 }))
+
+      const response = await handleReadCountRequest(request(), {
+        cache,
+        fetch: fetchMock,
+        now: () => NOW,
+      })
+
+      expect(response.status).toBe(502)
+      expect(response.headers.get(READ_COUNT_CACHE_STATUS_HEADER)).toBe(
+        'invalid',
+      )
+      expect(await response.json()).toEqual({ error: 'unavailable' })
+      expect(cache.deleteCalls).toEqual([cacheKey()])
+      expect(cache.entries.has(cacheKey())).toBe(false)
+    },
+  )
+
+  it('returns fresh upstream data when the cache write fails', async () => {
+    const cache = new MemoryReadCountCache()
+    cache.failPut = true
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(upstreamResponse({ count: '777' }))
+
+    const response = await handleReadCountRequest(request(), {
+      cache,
+      fetch: fetchMock,
+      now: () => NOW,
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get(READ_COUNT_CACHE_STATUS_HEADER)).toBe('miss')
+    expect(response.headers.get('x-read-count-cache-write')).toBe('error')
+    expect(await response.json()).toEqual({ count: '777' })
+  })
+
+  it.each([
+    {
+      upstream: new Response(null, { status: 404 }),
+      expectedStatus: 404,
+      expectedBody: { error: 'not_found' },
+    },
+    {
+      upstream: upstreamResponse({ count: 'many' }),
+      expectedStatus: 502,
+      expectedBody: { error: 'unavailable' },
+    },
+  ])(
+    'rejects stale data when the upstream response is not an availability failure',
+    async ({ upstream, expectedStatus, expectedBody }) => {
+      const cache = new MemoryReadCountCache()
+      seedCache(cache, {
+        fetchedAt: NOW - 5 * 60 * 60 * 1_000,
+      })
+      const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(upstream)
+
+      const response = await handleReadCountRequest(request(), {
+        cache,
+        fetch: fetchMock,
+        now: () => NOW,
+      })
+
+      expect(response.status).toBe(expectedStatus)
+      expect(response.headers.get(READ_COUNT_CACHE_STATUS_HEADER)).toBe(
+        'stale-rejected',
+      )
+      expect(response.headers.get('cache-control')).toBe('no-store')
+      expect(await response.json()).toEqual(expectedBody)
+      expect(cache.putCalls).toEqual([])
+    },
+  )
+
+  it('uses an internal same-origin cache key keyed by canonical path', () => {
+    const key = buildReadCountCacheKey(REQUEST_URL, ARTICLE_PATH)
+    const url = new URL(key.url)
+
+    expect(url.origin).toBe('https://shariq.dev')
+    expect(url.pathname).toBe('/.internal/read-count-cache/v1')
+    expect(url.searchParams.get('path')).toBe(ARTICLE_PATH)
+    expect(url.pathname).not.toBe('/api/read-count')
   })
 })

--- a/src/lib/read-count-proxy.test.ts
+++ b/src/lib/read-count-proxy.test.ts
@@ -1023,6 +1023,36 @@ describe('handleReadCountRequest', () => {
     expect(coordinator.size).toBe(0)
   })
 
+  it('uses a concurrent fresh count while backoff is active', async () => {
+    const cache = new MemoryReadCountCache()
+    seedCache(cache, {
+      body: { count: '321' },
+      fetchedAt: NOW - 5 * 60 * 60 * 1_000,
+    })
+    seedBackoff(cache)
+    cache.onMatch = (matchedRequest) => {
+      if (matchedRequest.url === backoffKey()) {
+        seedCache(cache, { body: { count: '999' }, fetchedAt: NOW })
+      }
+    }
+    const fetchMock = vi.fn<typeof fetch>()
+
+    const response = await handleReadCountRequest(request(), {
+      cache,
+      coordinator: createReadCountRefreshCoordinator(),
+      fetch: fetchMock,
+      now: () => NOW,
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get(READ_COUNT_CACHE_STATUS_HEADER)).toBe('fresh')
+    expect(response.headers.get(READ_COUNT_BACKOFF_STATUS_HEADER)).toBe(
+      'active',
+    )
+    expect(await response.json()).toEqual({ count: '999' })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
   it('keeps a validated stale snapshot when the fallback cache entry is evicted', async () => {
     const cache = new MemoryReadCountCache()
     seedCache(cache, {

--- a/src/lib/read-count-proxy.ts
+++ b/src/lib/read-count-proxy.ts
@@ -101,39 +101,104 @@ type ReadCountRefreshOutcome =
       result: ReadCountFailure
     }
 
+interface InFlightReadCountRefresh {
+  consumers: number
+  controller: AbortController
+  promise: Promise<ReadCountRefreshOutcome>
+}
+
 export interface ReadCountRefreshCoordinator {
+  readonly consumers: number
   readonly size: number
   reset(): void
   run(
     key: string,
-    refresh: () => Promise<ReadCountRefreshOutcome>,
+    signal: AbortSignal,
+    refresh: (signal: AbortSignal) => Promise<ReadCountRefreshOutcome>,
   ): Promise<ReadCountRefreshOutcome>
 }
 
 function coordinatorFor(
-  inFlight: Map<string, Promise<ReadCountRefreshOutcome>>,
+  inFlight: Map<string, InFlightReadCountRefresh>,
 ): ReadCountRefreshCoordinator {
   return {
+    get consumers() {
+      let consumers = 0
+      for (const refresh of inFlight.values()) {
+        consumers += refresh.consumers
+      }
+      return consumers
+    },
     get size() {
       return inFlight.size
     },
     reset() {
+      for (const refresh of inFlight.values()) {
+        refresh.controller.abort()
+      }
       inFlight.clear()
     },
-    run(key, refresh) {
-      const pending = inFlight.get(key)
-      if (pending) return pending
+    run(key, signal, refresh) {
+      let pending = inFlight.get(key)
+      if (pending?.controller.signal.aborted) {
+        if (inFlight.get(key) === pending) {
+          inFlight.delete(key)
+        }
+        pending = undefined
+      }
+      if (!pending) {
+        const controller = new AbortController()
+        let created: InFlightReadCountRefresh
+        const tracked = Promise.resolve()
+          .then(() => refresh(controller.signal))
+          .finally(() => {
+            if (inFlight.get(key) === created) {
+              inFlight.delete(key)
+            }
+          })
+        created = { consumers: 0, controller, promise: tracked }
+        inFlight.set(key, created)
+        void tracked.catch(() => undefined)
+        pending = created
+      }
 
-      let tracked: Promise<ReadCountRefreshOutcome>
-      tracked = Promise.resolve()
-        .then(refresh)
-        .finally(() => {
-          if (inFlight.get(key) === tracked) {
-            inFlight.delete(key)
+      pending.consumers += 1
+      return new Promise<ReadCountRefreshOutcome>((resolve, reject) => {
+        let active = true
+        const release = () => {
+          if (!active) return
+          active = false
+          signal.removeEventListener('abort', onAbort)
+          pending.consumers -= 1
+          if (pending.consumers === 0 && inFlight.get(key) === pending) {
+            pending.controller.abort()
           }
-        })
-      inFlight.set(key, tracked)
-      return tracked
+        }
+        const onAbort = () => {
+          release()
+          reject(
+            signal.reason instanceof Error
+              ? signal.reason
+              : new DOMException('Aborted', 'AbortError'),
+          )
+        }
+
+        if (signal.aborted) {
+          onAbort()
+          return
+        }
+        signal.addEventListener('abort', onAbort, { once: true })
+        pending.promise.then(
+          (value) => {
+            release()
+            resolve(value)
+          },
+          (error: unknown) => {
+            release()
+            reject(error)
+          },
+        )
+      })
     },
   }
 }
@@ -142,10 +207,7 @@ export function createReadCountRefreshCoordinator(): ReadCountRefreshCoordinator
   return coordinatorFor(new Map())
 }
 
-const inFlightReadCountRefreshes = new Map<
-  string,
-  Promise<ReadCountRefreshOutcome>
->()
+const inFlightReadCountRefreshes = new Map<string, InFlightReadCountRefresh>()
 const defaultReadCountRefreshCoordinator = coordinatorFor(
   inFlightReadCountRefreshes,
 )
@@ -528,6 +590,7 @@ async function guardedWriteReadCountCache(
     revalidatedCurrent.state === 'stale'
   ) {
     const currentCount = Number(revalidatedCurrent.count)
+    // GoatCounter pageview totals are cumulative; time never authorizes regression.
     if (
       currentCount > count ||
       (currentCount === count &&
@@ -607,6 +670,7 @@ async function refreshReadCount(
   backoffCacheKey: Request,
   refreshStartedAt: number,
   options: ReadCountProxyOptions,
+  signal: AbortSignal,
 ): Promise<ReadCountRefreshOutcome> {
   const now = options.now ?? Date.now
   const current = revalidateReadCountCache(
@@ -638,6 +702,7 @@ async function refreshReadCount(
 
   const result = await fetchGoatCounterReadCount(articlePath, {
     fetch: options.fetch,
+    signal,
     timeoutMs: options.timeoutMs ?? DEFAULT_READ_COUNT_TIMEOUT_MS,
   })
 
@@ -736,13 +801,14 @@ export async function handleReadCountRequest(
   try {
     outcome = await (
       options.coordinator ?? defaultReadCountRefreshCoordinator
-    ).run(cacheKey.url, () =>
+    ).run(cacheKey.url, request.signal, (signal) =>
       refreshReadCount(
         articlePath,
         cacheKey,
         backoffKey,
         requestStartedAt,
         options,
+        signal,
       ),
     )
   } catch {

--- a/src/lib/read-count-proxy.ts
+++ b/src/lib/read-count-proxy.ts
@@ -211,6 +211,33 @@ const inFlightReadCountRefreshes = new Map<string, InFlightReadCountRefresh>()
 const defaultReadCountRefreshCoordinator = coordinatorFor(
   inFlightReadCountRefreshes,
 )
+const coordinationDependencyIds = new WeakMap<object, number>()
+let nextCoordinationDependencyId = 1
+
+function coordinationDependencyId(dependency: object | undefined): string {
+  if (!dependency) return 'none'
+
+  let id = coordinationDependencyIds.get(dependency)
+  if (id === undefined) {
+    id = nextCoordinationDependencyId
+    nextCoordinationDependencyId += 1
+    coordinationDependencyIds.set(dependency, id)
+  }
+  return String(id)
+}
+
+function refreshCoordinationKey(
+  cacheKey: Request,
+  options: ReadCountProxyOptions,
+): string {
+  return [
+    cacheKey.url,
+    coordinationDependencyId(options.cache),
+    coordinationDependencyId(options.fetch ?? globalThis.fetch),
+    coordinationDependencyId(options.now ?? Date.now),
+    String(options.timeoutMs ?? DEFAULT_READ_COUNT_TIMEOUT_MS),
+  ].join('|')
+}
 
 function cacheControl(
   stale: boolean,
@@ -518,6 +545,26 @@ function revalidateReadCountCache(
   )
 }
 
+function preferLatestValidReadCount(
+  latest: ReadCountCacheLookup,
+  original: ReadCountCacheLookup,
+  now: number,
+): ReadCountCacheLookup {
+  const revalidatedLatest = revalidateReadCountCache(latest, now)
+  if (
+    revalidatedLatest.state === 'fresh' ||
+    revalidatedLatest.state === 'stale'
+  ) {
+    return revalidatedLatest
+  }
+
+  const revalidatedOriginal = revalidateReadCountCache(original, now)
+  return revalidatedOriginal.state === 'fresh' ||
+    revalidatedOriginal.state === 'stale'
+    ? revalidatedOriginal
+    : revalidatedLatest
+}
+
 function validReadCountEntry(
   count: number,
   fetchedAt: number,
@@ -801,7 +848,7 @@ export async function handleReadCountRequest(
   try {
     outcome = await (
       options.coordinator ?? defaultReadCountRefreshCoordinator
-    ).run(cacheKey.url, request.signal, (signal) =>
+    ).run(refreshCoordinationKey(cacheKey, options), request.signal, (signal) =>
       refreshReadCount(
         articlePath,
         cacheKey,
@@ -854,12 +901,7 @@ export async function handleReadCountRequest(
 
   if (outcome.backoffActive) {
     const latest = await lookupReadCountCache(options.cache, cacheKey, now)
-    const original = revalidateReadCountCache(lookup, now())
-    lookup =
-      latest.state === 'error' &&
-      (original.state === 'fresh' || original.state === 'stale')
-        ? original
-        : revalidateReadCountCache(latest, now())
+    lookup = preferLatestValidReadCount(latest, lookup, now())
     if (lookup.state === 'fresh') {
       return countResponse(lookup.count, 'fresh', {
         backoff: 'active',
@@ -894,12 +936,7 @@ export async function handleReadCountRequest(
 
   if (availabilityFailure) {
     const latest = await lookupReadCountCache(options.cache, cacheKey, now)
-    const original = revalidateReadCountCache(lookup, now())
-    lookup =
-      latest.state === 'error' &&
-      (original.state === 'fresh' || original.state === 'stale')
-        ? original
-        : revalidateReadCountCache(latest, now())
+    lookup = preferLatestValidReadCount(latest, lookup, now())
     if (lookup.state === 'fresh') {
       return countResponse(lookup.count, 'fresh', {
         backoff: backoffDiagnostic,

--- a/src/lib/read-count-proxy.ts
+++ b/src/lib/read-count-proxy.ts
@@ -2,21 +2,91 @@ import {
   DEFAULT_READ_COUNT_TIMEOUT_MS,
   fetchGoatCounterReadCount,
   isCanonicalArticlePath,
+  parseReadCount,
+  readLimitedJson,
   type ReadCountFetchOptions,
+  type ReadCountResult,
 } from './read-count'
 
 export const READ_COUNT_BROWSER_MAX_AGE_SECONDS = 300
 export const READ_COUNT_SHARED_MAX_AGE_SECONDS = 14_400
+export const READ_COUNT_CACHE_FRESH_SECONDS = READ_COUNT_SHARED_MAX_AGE_SECONDS
+export const READ_COUNT_CACHE_RETENTION_SECONDS = 7 * 24 * 60 * 60
+export const READ_COUNT_STALE_BROWSER_MAX_AGE_SECONDS = 60
+export const READ_COUNT_STALE_SHARED_MAX_AGE_SECONDS = 300
+export const READ_COUNT_INTERNAL_CACHE_PATH = '/.internal/read-count-cache/v1'
+export const READ_COUNT_CACHE_FETCHED_AT_HEADER =
+  'x-read-count-cache-fetched-at'
+export const READ_COUNT_CACHE_STATUS_HEADER = 'x-read-count-cache'
+
+const READ_COUNT_CACHE_WRITE_HEADER = 'x-read-count-cache-write'
+const READ_COUNT_CACHE_DELETE_HEADER = 'x-read-count-cache-delete'
+const JSON_CONTENT_TYPE = 'application/json'
 
 const JSON_HEADERS = {
-  'content-type': 'application/json; charset=utf-8',
+  'content-type': `${JSON_CONTENT_TYPE}; charset=utf-8`,
   'x-content-type-options': 'nosniff',
+}
+
+export interface ReadCountCache {
+  match(request: Request): Promise<Response | undefined>
+  put(request: Request, response: Response): Promise<void>
+  delete(request: Request): Promise<boolean>
 }
 
 export interface ReadCountProxyOptions extends Pick<
   ReadCountFetchOptions,
   'fetch' | 'timeoutMs'
-> {}
+> {
+  cache?: ReadCountCache
+  now?: () => number
+}
+
+type ReadCountCacheEntry =
+  | {
+      state: 'fresh' | 'stale'
+      count: string
+      remainingSeconds: number
+    }
+  | { state: 'expired' | 'invalid' }
+
+type ReadCountFailure = Exclude<ReadCountResult, { ok: true }>
+
+type ReadCountCacheLookup =
+  | {
+      state: 'fresh' | 'stale'
+      count: string
+      remainingSeconds: number
+      deleteFailed: false
+    }
+  | {
+      state: 'bypass' | 'error' | 'expired' | 'invalid' | 'miss'
+      deleteFailed: boolean
+    }
+
+type PublicReadCountCacheStatus =
+  | ReadCountCacheLookup['state']
+  | 'refreshed'
+  | 'stale-rejected'
+
+function cacheControl(
+  stale: boolean,
+  remainingSeconds: number | undefined,
+): string {
+  const browserMaxAge = Math.min(
+    stale
+      ? READ_COUNT_STALE_BROWSER_MAX_AGE_SECONDS
+      : READ_COUNT_BROWSER_MAX_AGE_SECONDS,
+    remainingSeconds ?? Number.POSITIVE_INFINITY,
+  )
+  const sharedMaxAge = Math.min(
+    stale
+      ? READ_COUNT_STALE_SHARED_MAX_AGE_SECONDS
+      : READ_COUNT_SHARED_MAX_AGE_SECONDS,
+    remainingSeconds ?? Number.POSITIVE_INFINITY,
+  )
+  return `public, max-age=${browserMaxAge}, s-maxage=${sharedMaxAge}`
+}
 
 function jsonResponse(
   body: object,
@@ -42,6 +112,200 @@ function errorResponse(
   return jsonResponse({ error }, status, 'no-store', headers)
 }
 
+function publicCacheHeaders(
+  status: PublicReadCountCacheStatus,
+  lookup: ReadCountCacheLookup,
+  writeFailed = false,
+): Record<string, string> {
+  return {
+    [READ_COUNT_CACHE_STATUS_HEADER]: status,
+    ...(lookup.deleteFailed
+      ? { [READ_COUNT_CACHE_DELETE_HEADER]: 'error' }
+      : {}),
+    ...(writeFailed ? { [READ_COUNT_CACHE_WRITE_HEADER]: 'error' } : {}),
+  }
+}
+
+function countResponse(
+  count: string,
+  status: PublicReadCountCacheStatus,
+  lookup: ReadCountCacheLookup,
+  {
+    remainingSeconds,
+    stale = false,
+    writeFailed = false,
+  }: {
+    remainingSeconds?: number
+    stale?: boolean
+    writeFailed?: boolean
+  } = {},
+): Response {
+  return jsonResponse(
+    { count },
+    200,
+    cacheControl(stale, remainingSeconds),
+    publicCacheHeaders(status, lookup, writeFailed),
+  )
+}
+
+export function buildReadCountCacheKey(
+  requestUrl: string,
+  articlePath: string,
+): Request {
+  if (!isCanonicalArticlePath(articlePath)) {
+    throw new TypeError(
+      'Read count cache keys require a canonical article path',
+    )
+  }
+
+  const url = new URL(READ_COUNT_INTERNAL_CACHE_PATH, requestUrl)
+  url.search = new URLSearchParams({ path: articlePath }).toString()
+  return new Request(url, { method: 'GET' })
+}
+
+export function classifyReadCountCacheEntry(
+  payload: unknown,
+  fetchedAtHeader: string | null,
+  now: number,
+): ReadCountCacheEntry {
+  const count = parseReadCount(payload)
+  if (
+    count === null ||
+    fetchedAtHeader === null ||
+    !/^(?:0|[1-9]\d*)$/.test(fetchedAtHeader)
+  ) {
+    return { state: 'invalid' }
+  }
+
+  const fetchedAt = Number(fetchedAtHeader)
+  const age = now - fetchedAt
+  if (
+    !Number.isSafeInteger(fetchedAt) ||
+    !Number.isSafeInteger(now) ||
+    fetchedAt < 0 ||
+    age < 0
+  ) {
+    return { state: 'invalid' }
+  }
+
+  if (age < READ_COUNT_CACHE_FRESH_SECONDS * 1_000) {
+    return {
+      state: 'fresh',
+      count: String(count),
+      remainingSeconds: Math.floor(
+        (READ_COUNT_CACHE_FRESH_SECONDS * 1_000 - age) / 1_000,
+      ),
+    }
+  }
+  if (age <= READ_COUNT_CACHE_RETENTION_SECONDS * 1_000) {
+    return {
+      state: 'stale',
+      count: String(count),
+      remainingSeconds: Math.floor(
+        (READ_COUNT_CACHE_RETENTION_SECONDS * 1_000 - age) / 1_000,
+      ),
+    }
+  }
+  return { state: 'expired' }
+}
+
+async function readCacheEntry(
+  response: Response,
+  now: number,
+): Promise<ReadCountCacheEntry> {
+  if (
+    response.status !== 200 ||
+    response.headers
+      .get('content-type')
+      ?.split(';', 1)[0]
+      ?.trim()
+      .toLowerCase() !== JSON_CONTENT_TYPE
+  ) {
+    return { state: 'invalid' }
+  }
+
+  let payload: unknown
+  try {
+    payload = await readLimitedJson(response)
+  } catch {
+    return { state: 'invalid' }
+  }
+
+  return classifyReadCountCacheEntry(
+    payload,
+    response.headers.get(READ_COUNT_CACHE_FETCHED_AT_HEADER),
+    now,
+  )
+}
+
+async function lookupReadCountCache(
+  cache: ReadCountCache | undefined,
+  key: Request,
+  now: number,
+): Promise<ReadCountCacheLookup> {
+  if (!cache) {
+    return { state: 'bypass', deleteFailed: false }
+  }
+
+  let response: Response | undefined
+  try {
+    response = await cache.match(key)
+  } catch {
+    return { state: 'error', deleteFailed: false }
+  }
+  if (!response) {
+    return { state: 'miss', deleteFailed: false }
+  }
+
+  const entry = await readCacheEntry(response, now)
+  if (entry.state === 'fresh' || entry.state === 'stale') {
+    return { ...entry, deleteFailed: false }
+  }
+
+  let deleteFailed = false
+  try {
+    await cache.delete(key)
+  } catch {
+    deleteFailed = true
+  }
+  return { state: entry.state, deleteFailed }
+}
+
+function cachedResponse(count: number, fetchedAt: number): Response {
+  return jsonResponse(
+    { count: String(count) },
+    200,
+    `public, max-age=${READ_COUNT_CACHE_RETENTION_SECONDS}`,
+    { [READ_COUNT_CACHE_FETCHED_AT_HEADER]: String(fetchedAt) },
+  )
+}
+
+async function writeReadCountCache(
+  cache: ReadCountCache | undefined,
+  key: Request,
+  count: number,
+  fetchedAt: number,
+): Promise<boolean> {
+  if (!cache) return false
+
+  try {
+    await cache.put(key, cachedResponse(count, fetchedAt))
+    return false
+  } catch {
+    return true
+  }
+}
+
+export function canServeStaleReadCount(result: ReadCountFailure): boolean {
+  return (
+    result.reason === 'network' ||
+    result.reason === 'timeout' ||
+    (result.reason === 'http' &&
+      (result.status === 429 ||
+        (result.status !== undefined && result.status >= 500)))
+  )
+}
+
 export async function handleReadCountRequest(
   request: Request,
   options: ReadCountProxyOptions = {},
@@ -63,7 +327,19 @@ export async function handleReadCountRequest(
     return errorResponse(400, 'invalid_path')
   }
 
-  let result
+  const cacheKey = buildReadCountCacheKey(request.url, paths[0])
+  const lookup = await lookupReadCountCache(
+    options.cache,
+    cacheKey,
+    (options.now ?? Date.now)(),
+  )
+  if (lookup.state === 'fresh') {
+    return countResponse(lookup.count, 'fresh', lookup, {
+      remainingSeconds: lookup.remainingSeconds,
+    })
+  }
+
+  let result: ReadCountResult
   try {
     result = await fetchGoatCounterReadCount(paths[0], {
       fetch: options.fetch,
@@ -71,21 +347,46 @@ export async function handleReadCountRequest(
       timeoutMs: options.timeoutMs ?? DEFAULT_READ_COUNT_TIMEOUT_MS,
     })
   } catch {
-    return errorResponse(502, 'unavailable')
+    return errorResponse(
+      502,
+      'unavailable',
+      publicCacheHeaders(
+        lookup.state === 'stale' ? 'stale-rejected' : lookup.state,
+        lookup,
+      ),
+    )
   }
 
   if (result.ok) {
-    return jsonResponse(
-      { count: String(result.count) },
-      200,
-      `public, max-age=${READ_COUNT_BROWSER_MAX_AGE_SECONDS}, s-maxage=${READ_COUNT_SHARED_MAX_AGE_SECONDS}`,
+    const writeFailed = await writeReadCountCache(
+      options.cache,
+      cacheKey,
+      result.count,
+      (options.now ?? Date.now)(),
+    )
+    return countResponse(
+      String(result.count),
+      lookup.state === 'stale' ? 'refreshed' : lookup.state,
+      lookup,
+      { writeFailed },
     )
   }
+  if (lookup.state === 'stale' && canServeStaleReadCount(result)) {
+    return countResponse(lookup.count, 'stale', lookup, {
+      remainingSeconds: lookup.remainingSeconds,
+      stale: true,
+    })
+  }
+
+  const headers = publicCacheHeaders(
+    lookup.state === 'stale' ? 'stale-rejected' : lookup.state,
+    lookup,
+  )
   if (result.reason === 'http' && result.status === 404) {
-    return errorResponse(404, 'not_found')
+    return errorResponse(404, 'not_found', headers)
   }
   if (result.reason === 'timeout') {
-    return errorResponse(504, 'unavailable')
+    return errorResponse(504, 'unavailable', headers)
   }
-  return errorResponse(502, 'unavailable')
+  return errorResponse(502, 'unavailable', headers)
 }

--- a/src/lib/read-count-proxy.ts
+++ b/src/lib/read-count-proxy.ts
@@ -829,7 +829,14 @@ export async function handleReadCountRequest(
 
   const backoff = await lookupReadCountBackoff(options.cache, backoffKey, now)
   if (backoff.state === 'active') {
-    lookup = revalidateReadCountCache(lookup, now())
+    const latest = await lookupReadCountCache(options.cache, cacheKey, now)
+    lookup = preferLatestValidReadCount(latest, lookup, now())
+    if (lookup.state === 'fresh') {
+      return countResponse(lookup.count, 'fresh', {
+        backoff: 'active',
+        remainingSeconds: lookup.remainingSeconds,
+      })
+    }
     if (lookup.state === 'stale') {
       return countResponse(lookup.count, 'stale', {
         backoff: 'active',

--- a/src/lib/read-count-proxy.ts
+++ b/src/lib/read-count-proxy.ts
@@ -15,9 +15,14 @@ export const READ_COUNT_CACHE_RETENTION_SECONDS = 7 * 24 * 60 * 60
 export const READ_COUNT_STALE_BROWSER_MAX_AGE_SECONDS = 60
 export const READ_COUNT_STALE_SHARED_MAX_AGE_SECONDS = 300
 export const READ_COUNT_INTERNAL_CACHE_PATH = '/.internal/read-count-cache/v1'
+export const READ_COUNT_INTERNAL_BACKOFF_PATH =
+  '/.internal/read-count-backoff/v1'
+export const READ_COUNT_FAILURE_BACKOFF_SECONDS = 30
 export const READ_COUNT_CACHE_FETCHED_AT_HEADER =
   'x-read-count-cache-fetched-at'
 export const READ_COUNT_CACHE_STATUS_HEADER = 'x-read-count-cache'
+export const READ_COUNT_BACKOFF_UNTIL_HEADER = 'x-read-count-backoff-until'
+export const READ_COUNT_BACKOFF_STATUS_HEADER = 'x-read-count-backoff'
 
 const READ_COUNT_CACHE_WRITE_HEADER = 'x-read-count-cache-write'
 const JSON_CONTENT_TYPE = 'application/json'
@@ -30,6 +35,7 @@ const JSON_HEADERS = {
 export interface ReadCountCache {
   match(request: Request): Promise<Response | undefined>
   put(request: Request, response: Response): Promise<void>
+  delete(request: Request): Promise<boolean>
 }
 
 export interface ReadCountProxyOptions extends Pick<
@@ -37,33 +43,112 @@ export interface ReadCountProxyOptions extends Pick<
   'fetch' | 'timeoutMs'
 > {
   cache?: ReadCountCache
+  coordinator?: ReadCountRefreshCoordinator
   now?: () => number
 }
 
+interface ValidReadCountCacheEntry {
+  state: 'fresh' | 'stale'
+  count: string
+  fetchedAt: number
+  remainingSeconds: number
+}
+
 type ReadCountCacheEntry =
-  | {
-      state: 'fresh' | 'stale'
-      count: string
-      fetchedAt: number
-      remainingSeconds: number
-    }
+  | ValidReadCountCacheEntry
   | { state: 'expired' | 'invalid' }
 
 type ReadCountFailure = Exclude<ReadCountResult, { ok: true }>
 
 type ReadCountCacheLookup =
-  | {
-      state: 'fresh' | 'stale'
-      count: string
-      fetchedAt: number
-      remainingSeconds: number
-    }
+  | ValidReadCountCacheEntry
   | { state: 'bypass' | 'error' | 'expired' | 'invalid' | 'miss' }
 
 type PublicReadCountCacheStatus =
   | ReadCountCacheLookup['state']
+  | 'preserved'
   | 'refreshed'
   | 'stale-rejected'
+
+type BackoffDiagnostic =
+  | 'active'
+  | 'clear-error'
+  | 'read-error'
+  | 'stored'
+  | 'write-error'
+
+type ReadCountBackoffLookup =
+  | { state: 'active'; status: 502 | 504 }
+  | { state: 'bypass' | 'error' | 'expired' | 'invalid' | 'miss' }
+
+type ReadCountRefreshOutcome =
+  | {
+      ok: true
+      backoffClearFailed: boolean
+      cacheWriteFailed: boolean
+      entry: ValidReadCountCacheEntry
+      source: 'cache' | 'upstream'
+    }
+  | {
+      ok: false
+      backoffActive: true
+      status: 502 | 504
+    }
+  | {
+      ok: false
+      backoffActive: false
+      backoffWriteFailed: boolean
+      result: ReadCountFailure
+    }
+
+export interface ReadCountRefreshCoordinator {
+  readonly size: number
+  reset(): void
+  run(
+    key: string,
+    refresh: () => Promise<ReadCountRefreshOutcome>,
+  ): Promise<ReadCountRefreshOutcome>
+}
+
+function coordinatorFor(
+  inFlight: Map<string, Promise<ReadCountRefreshOutcome>>,
+): ReadCountRefreshCoordinator {
+  return {
+    get size() {
+      return inFlight.size
+    },
+    reset() {
+      inFlight.clear()
+    },
+    run(key, refresh) {
+      const pending = inFlight.get(key)
+      if (pending) return pending
+
+      let tracked: Promise<ReadCountRefreshOutcome>
+      tracked = Promise.resolve()
+        .then(refresh)
+        .finally(() => {
+          if (inFlight.get(key) === tracked) {
+            inFlight.delete(key)
+          }
+        })
+      inFlight.set(key, tracked)
+      return tracked
+    },
+  }
+}
+
+export function createReadCountRefreshCoordinator(): ReadCountRefreshCoordinator {
+  return coordinatorFor(new Map())
+}
+
+const inFlightReadCountRefreshes = new Map<
+  string,
+  Promise<ReadCountRefreshOutcome>
+>()
+const defaultReadCountRefreshCoordinator = coordinatorFor(
+  inFlightReadCountRefreshes,
+)
 
 function cacheControl(
   stale: boolean,
@@ -110,10 +195,17 @@ function errorResponse(
 
 function publicCacheHeaders(
   status: PublicReadCountCacheStatus,
-  writeFailed = false,
+  {
+    backoff,
+    writeFailed = false,
+  }: {
+    backoff?: BackoffDiagnostic
+    writeFailed?: boolean
+  } = {},
 ): Record<string, string> {
   return {
     [READ_COUNT_CACHE_STATUS_HEADER]: status,
+    ...(backoff ? { [READ_COUNT_BACKOFF_STATUS_HEADER]: backoff } : {}),
     ...(writeFailed ? { [READ_COUNT_CACHE_WRITE_HEADER]: 'error' } : {}),
   }
 }
@@ -122,10 +214,12 @@ function countResponse(
   count: string,
   status: PublicReadCountCacheStatus,
   {
+    backoff,
     remainingSeconds,
     stale = false,
     writeFailed = false,
   }: {
+    backoff?: BackoffDiagnostic
     remainingSeconds?: number
     stale?: boolean
     writeFailed?: boolean
@@ -135,13 +229,14 @@ function countResponse(
     { count },
     200,
     cacheControl(stale, remainingSeconds),
-    publicCacheHeaders(status, writeFailed),
+    publicCacheHeaders(status, { backoff, writeFailed }),
   )
 }
 
-export function buildReadCountCacheKey(
+function buildInternalReadCountCacheKey(
   requestUrl: string,
   articlePath: string,
+  internalPath: string,
 ): Request {
   if (!isCanonicalArticlePath(articlePath)) {
     throw new TypeError(
@@ -149,9 +244,31 @@ export function buildReadCountCacheKey(
     )
   }
 
-  const url = new URL(READ_COUNT_INTERNAL_CACHE_PATH, requestUrl)
+  const url = new URL(internalPath, requestUrl)
   url.search = new URLSearchParams({ path: articlePath }).toString()
   return new Request(url, { method: 'GET' })
+}
+
+export function buildReadCountCacheKey(
+  requestUrl: string,
+  articlePath: string,
+): Request {
+  return buildInternalReadCountCacheKey(
+    requestUrl,
+    articlePath,
+    READ_COUNT_INTERNAL_CACHE_PATH,
+  )
+}
+
+export function buildReadCountBackoffKey(
+  requestUrl: string,
+  articlePath: string,
+): Request {
+  return buildInternalReadCountCacheKey(
+    requestUrl,
+    articlePath,
+    READ_COUNT_INTERNAL_BACKOFF_PATH,
+  )
 }
 
 export function classifyReadCountCacheEntry(
@@ -204,7 +321,7 @@ export function classifyReadCountCacheEntry(
 
 async function readCacheEntry(
   response: Response,
-  now: number,
+  now: () => number,
 ): Promise<ReadCountCacheEntry> {
   if (
     response.status !== 200 ||
@@ -227,14 +344,64 @@ async function readCacheEntry(
   return classifyReadCountCacheEntry(
     payload,
     response.headers.get(READ_COUNT_CACHE_FETCHED_AT_HEADER),
-    now,
+    now(),
   )
+}
+
+async function readBackoffEntry(
+  response: Response,
+  now: () => number,
+): Promise<ReadCountBackoffLookup> {
+  if (
+    response.status !== 200 ||
+    response.headers
+      .get('content-type')
+      ?.split(';', 1)[0]
+      ?.trim()
+      .toLowerCase() !== JSON_CONTENT_TYPE
+  ) {
+    return { state: 'invalid' }
+  }
+
+  let payload: unknown
+  try {
+    payload = await readLimitedJson(response)
+  } catch {
+    return { state: 'invalid' }
+  }
+
+  const untilHeader = response.headers.get(READ_COUNT_BACKOFF_UNTIL_HEADER)
+  if (
+    typeof payload !== 'object' ||
+    payload === null ||
+    !('status' in payload) ||
+    (payload.status !== 502 && payload.status !== 504) ||
+    untilHeader === null ||
+    !/^(?:0|[1-9]\d*)$/.test(untilHeader)
+  ) {
+    return { state: 'invalid' }
+  }
+
+  const until = Number(untilHeader)
+  const readAt = now()
+  const remaining = until - readAt
+  if (
+    !Number.isSafeInteger(until) ||
+    !Number.isSafeInteger(readAt) ||
+    remaining > READ_COUNT_FAILURE_BACKOFF_SECONDS * 1_000
+  ) {
+    return { state: 'invalid' }
+  }
+  if (remaining <= 0) {
+    return { state: 'expired' }
+  }
+  return { state: 'active', status: payload.status }
 }
 
 async function lookupReadCountCache(
   cache: ReadCountCache | undefined,
   key: Request,
-  now: number,
+  now: () => number,
 ): Promise<ReadCountCacheLookup> {
   if (!cache) {
     return { state: 'bypass' }
@@ -253,6 +420,27 @@ async function lookupReadCountCache(
   return readCacheEntry(response, now)
 }
 
+async function lookupReadCountBackoff(
+  cache: ReadCountCache | undefined,
+  key: Request,
+  now: () => number,
+): Promise<ReadCountBackoffLookup> {
+  if (!cache) {
+    return { state: 'bypass' }
+  }
+
+  let response: Response | undefined
+  try {
+    response = await cache.match(key)
+  } catch {
+    return { state: 'error' }
+  }
+  if (!response) {
+    return { state: 'miss' }
+  }
+  return readBackoffEntry(response, now)
+}
+
 function revalidateReadCountCache(
   lookup: ReadCountCacheLookup,
   now: number,
@@ -268,28 +456,218 @@ function revalidateReadCountCache(
   )
 }
 
-function cachedResponse(count: number, fetchedAt: number): Response {
+function validReadCountEntry(
+  count: number,
+  fetchedAt: number,
+  now: number,
+): ValidReadCountCacheEntry {
+  const entry = classifyReadCountCacheEntry(
+    { count: String(count) },
+    String(fetchedAt),
+    now,
+  )
+  if (entry.state !== 'fresh' && entry.state !== 'stale') {
+    throw new RangeError('Read count refresh time must not be in the future')
+  }
+  return entry
+}
+
+function cachedResponse(
+  count: number,
+  fetchedAt: number,
+  storedAt: number,
+): Response {
+  const remainingRetentionSeconds = Math.max(
+    0,
+    Math.floor(
+      (fetchedAt + READ_COUNT_CACHE_RETENTION_SECONDS * 1_000 - storedAt) /
+        1_000,
+    ),
+  )
   return jsonResponse(
     { count: String(count) },
     200,
-    `public, max-age=${READ_COUNT_CACHE_RETENTION_SECONDS}`,
+    `public, max-age=${remainingRetentionSeconds}`,
     { [READ_COUNT_CACHE_FETCHED_AT_HEADER]: String(fetchedAt) },
   )
 }
 
-async function writeReadCountCache(
+async function guardedWriteReadCountCache(
   cache: ReadCountCache | undefined,
   key: Request,
   count: number,
-  fetchedAt: number,
+  refreshStartedAt: number,
+  now: () => number,
+): Promise<{
+  cacheWriteFailed: boolean
+  entry: ValidReadCountCacheEntry
+  source: 'cache' | 'upstream'
+}> {
+  if (!cache) {
+    const candidate = validReadCountEntry(count, refreshStartedAt, now())
+    return {
+      cacheWriteFailed: false,
+      entry: candidate,
+      source: 'upstream',
+    }
+  }
+
+  const current = await lookupReadCountCache(cache, key, now)
+  const comparedAt = now()
+  const candidate = validReadCountEntry(count, refreshStartedAt, comparedAt)
+  if (current.state === 'error') {
+    return {
+      cacheWriteFailed: true,
+      entry: candidate,
+      source: 'upstream',
+    }
+  }
+  const revalidatedCurrent = revalidateReadCountCache(current, comparedAt)
+  if (
+    revalidatedCurrent.state === 'fresh' ||
+    revalidatedCurrent.state === 'stale'
+  ) {
+    const currentCount = Number(revalidatedCurrent.count)
+    if (
+      currentCount > count ||
+      (currentCount === count &&
+        revalidatedCurrent.fetchedAt >= refreshStartedAt)
+    ) {
+      return {
+        cacheWriteFailed: false,
+        entry: revalidatedCurrent,
+        source: 'cache',
+      }
+    }
+  }
+
+  try {
+    await cache.put(key, cachedResponse(count, refreshStartedAt, comparedAt))
+    return {
+      cacheWriteFailed: false,
+      entry: candidate,
+      source: 'upstream',
+    }
+  } catch {
+    return {
+      cacheWriteFailed: true,
+      entry: candidate,
+      source: 'upstream',
+    }
+  }
+}
+
+function failureStatus(result: ReadCountFailure): 502 | 504 {
+  return result.reason === 'timeout' ? 504 : 502
+}
+
+function backoffResponse(result: ReadCountFailure, failedAt: number): Response {
+  const until = failedAt + READ_COUNT_FAILURE_BACKOFF_SECONDS * 1_000
+  return jsonResponse(
+    { status: failureStatus(result) },
+    200,
+    `public, max-age=${READ_COUNT_FAILURE_BACKOFF_SECONDS}`,
+    { [READ_COUNT_BACKOFF_UNTIL_HEADER]: String(until) },
+  )
+}
+
+async function writeReadCountBackoff(
+  cache: ReadCountCache | undefined,
+  key: Request,
+  result: ReadCountFailure,
+  failedAt: number,
 ): Promise<boolean> {
   if (!cache) return false
 
   try {
-    await cache.put(key, cachedResponse(count, fetchedAt))
+    await cache.put(key, backoffResponse(result, failedAt))
     return false
   } catch {
     return true
+  }
+}
+
+async function clearReadCountBackoff(
+  cache: ReadCountCache | undefined,
+  key: Request,
+): Promise<boolean> {
+  if (!cache) return false
+
+  try {
+    await cache.delete(key)
+    return false
+  } catch {
+    return true
+  }
+}
+
+async function refreshReadCount(
+  articlePath: string,
+  countCacheKey: Request,
+  backoffCacheKey: Request,
+  refreshStartedAt: number,
+  options: ReadCountProxyOptions,
+): Promise<ReadCountRefreshOutcome> {
+  const now = options.now ?? Date.now
+  const current = revalidateReadCountCache(
+    await lookupReadCountCache(options.cache, countCacheKey, now),
+    now(),
+  )
+  if (current.state === 'fresh') {
+    return {
+      ok: true,
+      backoffClearFailed: false,
+      cacheWriteFailed: false,
+      entry: current,
+      source: 'cache',
+    }
+  }
+
+  const backoff = await lookupReadCountBackoff(
+    options.cache,
+    backoffCacheKey,
+    now,
+  )
+  if (backoff.state === 'active') {
+    return {
+      ok: false,
+      backoffActive: true,
+      status: backoff.status,
+    }
+  }
+
+  const result = await fetchGoatCounterReadCount(articlePath, {
+    fetch: options.fetch,
+    timeoutMs: options.timeoutMs ?? DEFAULT_READ_COUNT_TIMEOUT_MS,
+  })
+
+  if (result.ok) {
+    const write = await guardedWriteReadCountCache(
+      options.cache,
+      countCacheKey,
+      result.count,
+      refreshStartedAt,
+      now,
+    )
+    const backoffClearFailed = await clearReadCountBackoff(
+      options.cache,
+      backoffCacheKey,
+    )
+    return {
+      ok: true,
+      backoffClearFailed,
+      ...write,
+    }
+  }
+
+  const backoffWriteFailed = canServeStaleReadCount(result)
+    ? await writeReadCountBackoff(options.cache, backoffCacheKey, result, now())
+    : false
+  return {
+    ok: false,
+    backoffActive: false,
+    backoffWriteFailed,
+    result,
   }
 }
 
@@ -324,53 +702,147 @@ export async function handleReadCountRequest(
     return errorResponse(400, 'invalid_path')
   }
 
-  const cacheKey = buildReadCountCacheKey(request.url, paths[0])
-  let lookup = await lookupReadCountCache(
-    options.cache,
-    cacheKey,
-    (options.now ?? Date.now)(),
-  )
-  lookup = revalidateReadCountCache(lookup, (options.now ?? Date.now)())
+  const articlePath = paths[0]
+  const now = options.now ?? Date.now
+  const requestStartedAt = now()
+  const cacheKey = buildReadCountCacheKey(request.url, articlePath)
+  const backoffKey = buildReadCountBackoffKey(request.url, articlePath)
+  let lookup = await lookupReadCountCache(options.cache, cacheKey, now)
+  lookup = revalidateReadCountCache(lookup, now())
   if (lookup.state === 'fresh') {
     return countResponse(lookup.count, 'fresh', {
       remainingSeconds: lookup.remainingSeconds,
     })
   }
 
-  let result: ReadCountResult
+  const backoff = await lookupReadCountBackoff(options.cache, backoffKey, now)
+  if (backoff.state === 'active') {
+    lookup = revalidateReadCountCache(lookup, now())
+    if (lookup.state === 'stale') {
+      return countResponse(lookup.count, 'stale', {
+        backoff: 'active',
+        remainingSeconds: lookup.remainingSeconds,
+        stale: true,
+      })
+    }
+    return errorResponse(
+      backoff.status,
+      'unavailable',
+      publicCacheHeaders(lookup.state, { backoff: 'active' }),
+    )
+  }
+
+  let outcome: ReadCountRefreshOutcome
   try {
-    result = await fetchGoatCounterReadCount(paths[0], {
-      fetch: options.fetch,
-      signal: request.signal,
-      timeoutMs: options.timeoutMs ?? DEFAULT_READ_COUNT_TIMEOUT_MS,
-    })
+    outcome = await (
+      options.coordinator ?? defaultReadCountRefreshCoordinator
+    ).run(cacheKey.url, () =>
+      refreshReadCount(
+        articlePath,
+        cacheKey,
+        backoffKey,
+        requestStartedAt,
+        options,
+      ),
+    )
   } catch {
     return errorResponse(
       502,
       'unavailable',
       publicCacheHeaders(
         lookup.state === 'stale' ? 'stale-rejected' : lookup.state,
+        { backoff: backoff.state === 'error' ? 'read-error' : undefined },
       ),
     )
   }
 
-  if (result.ok) {
-    const writeFailed = await writeReadCountCache(
-      options.cache,
-      cacheKey,
-      result.count,
-      (options.now ?? Date.now)(),
-    )
+  if (outcome.ok) {
+    const entry = revalidateReadCountCache(outcome.entry, now())
+    const backoffDiagnostic = outcome.backoffClearFailed
+      ? 'clear-error'
+      : backoff.state === 'error'
+        ? 'read-error'
+        : undefined
+    if (entry.state !== 'fresh' && entry.state !== 'stale') {
+      return errorResponse(
+        502,
+        'unavailable',
+        publicCacheHeaders(entry.state, { backoff: backoffDiagnostic }),
+      )
+    }
     return countResponse(
-      String(result.count),
-      lookup.state === 'stale' ? 'refreshed' : lookup.state,
-      { writeFailed },
+      entry.count,
+      outcome.source === 'cache'
+        ? 'preserved'
+        : lookup.state === 'stale'
+          ? 'refreshed'
+          : lookup.state,
+      {
+        backoff: backoffDiagnostic,
+        remainingSeconds: entry.remainingSeconds,
+        stale: entry.state === 'stale',
+        writeFailed: outcome.cacheWriteFailed,
+      },
     )
   }
-  if (lookup.state === 'stale' && canServeStaleReadCount(result)) {
-    lookup = revalidateReadCountCache(lookup, (options.now ?? Date.now)())
+
+  if (outcome.backoffActive) {
+    const latest = await lookupReadCountCache(options.cache, cacheKey, now)
+    const original = revalidateReadCountCache(lookup, now())
+    lookup =
+      latest.state === 'error' &&
+      (original.state === 'fresh' || original.state === 'stale')
+        ? original
+        : revalidateReadCountCache(latest, now())
+    if (lookup.state === 'fresh') {
+      return countResponse(lookup.count, 'fresh', {
+        backoff: 'active',
+        remainingSeconds: lookup.remainingSeconds,
+      })
+    }
     if (lookup.state === 'stale') {
       return countResponse(lookup.count, 'stale', {
+        backoff: 'active',
+        remainingSeconds: lookup.remainingSeconds,
+        stale: true,
+      })
+    }
+    return errorResponse(
+      outcome.status,
+      'unavailable',
+      publicCacheHeaders(lookup.state, { backoff: 'active' }),
+    )
+  }
+
+  const result = outcome.result
+  const availabilityFailure = canServeStaleReadCount(result)
+  const backoffDiagnostic: BackoffDiagnostic | undefined = availabilityFailure
+    ? outcome.backoffWriteFailed
+      ? 'write-error'
+      : options.cache
+        ? 'stored'
+        : undefined
+    : backoff.state === 'error'
+      ? 'read-error'
+      : undefined
+
+  if (availabilityFailure) {
+    const latest = await lookupReadCountCache(options.cache, cacheKey, now)
+    const original = revalidateReadCountCache(lookup, now())
+    lookup =
+      latest.state === 'error' &&
+      (original.state === 'fresh' || original.state === 'stale')
+        ? original
+        : revalidateReadCountCache(latest, now())
+    if (lookup.state === 'fresh') {
+      return countResponse(lookup.count, 'fresh', {
+        backoff: backoffDiagnostic,
+        remainingSeconds: lookup.remainingSeconds,
+      })
+    }
+    if (lookup.state === 'stale') {
+      return countResponse(lookup.count, 'stale', {
+        backoff: backoffDiagnostic,
         remainingSeconds: lookup.remainingSeconds,
         stale: true,
       })
@@ -379,6 +851,7 @@ export async function handleReadCountRequest(
 
   const headers = publicCacheHeaders(
     lookup.state === 'stale' ? 'stale-rejected' : lookup.state,
+    { backoff: backoffDiagnostic },
   )
   if (result.reason === 'http' && result.status === 404) {
     return errorResponse(404, 'not_found', headers)

--- a/src/lib/read-count-proxy.ts
+++ b/src/lib/read-count-proxy.ts
@@ -20,7 +20,6 @@ export const READ_COUNT_CACHE_FETCHED_AT_HEADER =
 export const READ_COUNT_CACHE_STATUS_HEADER = 'x-read-count-cache'
 
 const READ_COUNT_CACHE_WRITE_HEADER = 'x-read-count-cache-write'
-const READ_COUNT_CACHE_DELETE_HEADER = 'x-read-count-cache-delete'
 const JSON_CONTENT_TYPE = 'application/json'
 
 const JSON_HEADERS = {
@@ -31,7 +30,6 @@ const JSON_HEADERS = {
 export interface ReadCountCache {
   match(request: Request): Promise<Response | undefined>
   put(request: Request, response: Response): Promise<void>
-  delete(request: Request): Promise<boolean>
 }
 
 export interface ReadCountProxyOptions extends Pick<
@@ -46,6 +44,7 @@ type ReadCountCacheEntry =
   | {
       state: 'fresh' | 'stale'
       count: string
+      fetchedAt: number
       remainingSeconds: number
     }
   | { state: 'expired' | 'invalid' }
@@ -56,13 +55,10 @@ type ReadCountCacheLookup =
   | {
       state: 'fresh' | 'stale'
       count: string
+      fetchedAt: number
       remainingSeconds: number
-      deleteFailed: false
     }
-  | {
-      state: 'bypass' | 'error' | 'expired' | 'invalid' | 'miss'
-      deleteFailed: boolean
-    }
+  | { state: 'bypass' | 'error' | 'expired' | 'invalid' | 'miss' }
 
 type PublicReadCountCacheStatus =
   | ReadCountCacheLookup['state']
@@ -114,14 +110,10 @@ function errorResponse(
 
 function publicCacheHeaders(
   status: PublicReadCountCacheStatus,
-  lookup: ReadCountCacheLookup,
   writeFailed = false,
 ): Record<string, string> {
   return {
     [READ_COUNT_CACHE_STATUS_HEADER]: status,
-    ...(lookup.deleteFailed
-      ? { [READ_COUNT_CACHE_DELETE_HEADER]: 'error' }
-      : {}),
     ...(writeFailed ? { [READ_COUNT_CACHE_WRITE_HEADER]: 'error' } : {}),
   }
 }
@@ -129,7 +121,6 @@ function publicCacheHeaders(
 function countResponse(
   count: string,
   status: PublicReadCountCacheStatus,
-  lookup: ReadCountCacheLookup,
   {
     remainingSeconds,
     stale = false,
@@ -144,7 +135,7 @@ function countResponse(
     { count },
     200,
     cacheControl(stale, remainingSeconds),
-    publicCacheHeaders(status, lookup, writeFailed),
+    publicCacheHeaders(status, writeFailed),
   )
 }
 
@@ -192,6 +183,7 @@ export function classifyReadCountCacheEntry(
     return {
       state: 'fresh',
       count: String(count),
+      fetchedAt,
       remainingSeconds: Math.floor(
         (READ_COUNT_CACHE_FRESH_SECONDS * 1_000 - age) / 1_000,
       ),
@@ -201,6 +193,7 @@ export function classifyReadCountCacheEntry(
     return {
       state: 'stale',
       count: String(count),
+      fetchedAt,
       remainingSeconds: Math.floor(
         (READ_COUNT_CACHE_RETENTION_SECONDS * 1_000 - age) / 1_000,
       ),
@@ -244,31 +237,35 @@ async function lookupReadCountCache(
   now: number,
 ): Promise<ReadCountCacheLookup> {
   if (!cache) {
-    return { state: 'bypass', deleteFailed: false }
+    return { state: 'bypass' }
   }
 
   let response: Response | undefined
   try {
     response = await cache.match(key)
   } catch {
-    return { state: 'error', deleteFailed: false }
+    return { state: 'error' }
   }
   if (!response) {
-    return { state: 'miss', deleteFailed: false }
+    return { state: 'miss' }
   }
 
-  const entry = await readCacheEntry(response, now)
-  if (entry.state === 'fresh' || entry.state === 'stale') {
-    return { ...entry, deleteFailed: false }
+  return readCacheEntry(response, now)
+}
+
+function revalidateReadCountCache(
+  lookup: ReadCountCacheLookup,
+  now: number,
+): ReadCountCacheLookup {
+  if (lookup.state !== 'fresh' && lookup.state !== 'stale') {
+    return lookup
   }
 
-  let deleteFailed = false
-  try {
-    await cache.delete(key)
-  } catch {
-    deleteFailed = true
-  }
-  return { state: entry.state, deleteFailed }
+  return classifyReadCountCacheEntry(
+    { count: lookup.count },
+    String(lookup.fetchedAt),
+    now,
+  )
 }
 
 function cachedResponse(count: number, fetchedAt: number): Response {
@@ -328,13 +325,14 @@ export async function handleReadCountRequest(
   }
 
   const cacheKey = buildReadCountCacheKey(request.url, paths[0])
-  const lookup = await lookupReadCountCache(
+  let lookup = await lookupReadCountCache(
     options.cache,
     cacheKey,
     (options.now ?? Date.now)(),
   )
+  lookup = revalidateReadCountCache(lookup, (options.now ?? Date.now)())
   if (lookup.state === 'fresh') {
-    return countResponse(lookup.count, 'fresh', lookup, {
+    return countResponse(lookup.count, 'fresh', {
       remainingSeconds: lookup.remainingSeconds,
     })
   }
@@ -352,7 +350,6 @@ export async function handleReadCountRequest(
       'unavailable',
       publicCacheHeaders(
         lookup.state === 'stale' ? 'stale-rejected' : lookup.state,
-        lookup,
       ),
     )
   }
@@ -367,20 +364,21 @@ export async function handleReadCountRequest(
     return countResponse(
       String(result.count),
       lookup.state === 'stale' ? 'refreshed' : lookup.state,
-      lookup,
       { writeFailed },
     )
   }
   if (lookup.state === 'stale' && canServeStaleReadCount(result)) {
-    return countResponse(lookup.count, 'stale', lookup, {
-      remainingSeconds: lookup.remainingSeconds,
-      stale: true,
-    })
+    lookup = revalidateReadCountCache(lookup, (options.now ?? Date.now)())
+    if (lookup.state === 'stale') {
+      return countResponse(lookup.count, 'stale', {
+        remainingSeconds: lookup.remainingSeconds,
+        stale: true,
+      })
+    }
   }
 
   const headers = publicCacheHeaders(
     lookup.state === 'stale' ? 'stale-rejected' : lookup.state,
-    lookup,
   )
   if (result.reason === 'http' && result.status === 404) {
     return errorResponse(404, 'not_found', headers)

--- a/src/lib/read-count-proxy.ts
+++ b/src/lib/read-count-proxy.ts
@@ -26,6 +26,7 @@ export const READ_COUNT_BACKOFF_STATUS_HEADER = 'x-read-count-backoff'
 
 const READ_COUNT_CACHE_WRITE_HEADER = 'x-read-count-cache-write'
 const JSON_CONTENT_TYPE = 'application/json'
+const LOCAL_READ_COUNT_HOSTS = new Set(['127.0.0.1', '[::1]', 'localhost'])
 
 const JSON_HEADERS = {
   'content-type': `${JSON_CONTENT_TYPE}; charset=utf-8`,
@@ -357,6 +358,23 @@ export function buildReadCountBackoffKey(
     requestUrl,
     articlePath,
     READ_COUNT_INTERNAL_BACKOFF_PATH,
+  )
+}
+
+function isTrustedReadCountRequestOrigin(url: URL): boolean {
+  if (
+    url.protocol === 'https:' &&
+    (url.hostname === 'shariq.dev' ||
+      url.hostname === 'www.shariq.dev' ||
+      url.hostname === 'shariq-dev.pages.dev' ||
+      url.hostname.endsWith('.shariq-dev.pages.dev'))
+  ) {
+    return true
+  }
+
+  return (
+    (url.protocol === 'http:' || url.protocol === 'https:') &&
+    LOCAL_READ_COUNT_HOSTS.has(url.hostname)
   )
 }
 
@@ -809,6 +827,7 @@ export async function handleReadCountRequest(
   if (
     paths.length !== 1 ||
     hasUnexpectedParameter ||
+    !isTrustedReadCountRequestOrigin(url) ||
     !isCanonicalArticlePath(paths[0])
   ) {
     return errorResponse(400, 'invalid_path')

--- a/src/lib/read-count.test.ts
+++ b/src/lib/read-count.test.ts
@@ -200,6 +200,22 @@ describe('fetchReadCount', () => {
     ).resolves.toEqual({ ok: false, reason: 'network' })
   })
 
+  it('returns a network failure when the response stream terminates', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.error(new TypeError('terminated'))
+          },
+        }),
+      ),
+    )
+
+    await expect(
+      fetchReadCount(ARTICLE_PATH, { fetch: fetchMock }),
+    ).resolves.toEqual({ ok: false, reason: 'network' })
+  })
+
   it('aborts and returns a timeout failure', async () => {
     vi.useFakeTimers()
     const fetchMock: typeof fetch = async (_input, init) =>

--- a/src/lib/read-count.ts
+++ b/src/lib/read-count.ts
@@ -136,7 +136,7 @@ function classifyRequestFailure(
 
 class InvalidReadCountResponseError extends Error {}
 
-async function readLimitedJson(response: Response): Promise<unknown> {
+export async function readLimitedJson(response: Response): Promise<unknown> {
   const contentLength = response.headers.get('content-length')
   if (contentLength !== null) {
     const declaredBytes = Number(contentLength)
@@ -257,7 +257,7 @@ async function fetchReadCountFromUrl(
         error,
         timedOut,
         options.signal,
-        false,
+        true,
       )
       if (failure) return failure
       throw error

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -58,10 +58,6 @@ class SmokeReadCountCache implements ReadCountCache {
   async put(request: Request, response: Response): Promise<void> {
     this.entries.set(request.url, response.clone())
   }
-
-  async delete(request: Request): Promise<boolean> {
-    return this.entries.delete(request.url)
-  }
 }
 
 async function warmReadCountCache(

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -58,6 +58,10 @@ class SmokeReadCountCache implements ReadCountCache {
   async put(request: Request, response: Response): Promise<void> {
     this.entries.set(request.url, response.clone())
   }
+
+  async delete(request: Request): Promise<boolean> {
+    return this.entries.delete(request.url)
+  }
 }
 
 async function warmReadCountCache(

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -4,6 +4,11 @@ import { join } from 'node:path'
 import matter from 'gray-matter'
 import { active, built } from '../src/lib/projects'
 import { buildArticlePath } from '../src/lib/popular-articles'
+import {
+  handleReadCountRequest,
+  READ_COUNT_CACHE_STATUS_HEADER,
+  type ReadCountCache,
+} from '../src/lib/read-count-proxy'
 import { buildReadCountUrl } from '../src/lib/read-count'
 import { SITE } from '../src/lib/site'
 
@@ -41,6 +46,47 @@ interface HomeArticleFixture {
   slug: string
   title: string
   publishedAt: number
+}
+
+class SmokeReadCountCache implements ReadCountCache {
+  private readonly entries = new Map<string, Response>()
+
+  async match(request: Request): Promise<Response | undefined> {
+    return this.entries.get(request.url)?.clone()
+  }
+
+  async put(request: Request, response: Response): Promise<void> {
+    this.entries.set(request.url, response.clone())
+  }
+
+  async delete(request: Request): Promise<boolean> {
+    return this.entries.delete(request.url)
+  }
+}
+
+async function warmReadCountCache(
+  cache: ReadCountCache,
+  articlePath: string,
+  count: string,
+  fetchedAt: number,
+): Promise<void> {
+  const fetchCount: typeof fetch = async () =>
+    new Response(JSON.stringify({ count }), {
+      headers: { 'content-type': 'application/json' },
+    })
+  const response = await handleReadCountRequest(
+    new Request(
+      new URL(buildReadCountUrl(articlePath), 'http://localhost:4321'),
+    ),
+    {
+      cache,
+      fetch: fetchCount,
+      now: () => fetchedAt,
+    },
+  )
+  if (!response.ok) {
+    throw new Error(`Unable to warm read count cache for ${articlePath}`)
+  }
 }
 
 function readHomeArticles(dir: string, prefix = ''): HomeArticleFixture[] {
@@ -205,6 +251,71 @@ test('homepage ranks popular articles without duplication or overflow', async ({
   )
   expect(directGoatCounterRequests).toEqual([])
   expect(errors).toEqual([])
+})
+
+test('cached counts keep articles and popularity visible during an upstream outage', async ({
+  page,
+}) => {
+  const cache = new SmokeReadCountCache()
+  const now = Date.parse('2026-08-20T19:00:00.000Z')
+  const fetchedAt = now - 5 * 60 * 60 * 1_000
+  const candidates = HOME_ARTICLES.filter(
+    (article) => article.slug !== HOME_FEATURED.slug,
+  )
+  for (const article of candidates) {
+    const count =
+      POPULAR_FIXTURES.find((fixture) => fixture.article.slug === article.slug)
+        ?.count ?? '0'
+    await warmReadCountCache(
+      cache,
+      buildArticlePath(article.slug),
+      count,
+      fetchedAt,
+    )
+  }
+
+  const cacheStates: (string | null)[] = []
+  const upstreamRequests: string[] = []
+  const unavailableFetch: typeof fetch = async (input) => {
+    upstreamRequests.push(String(input))
+    return new Response(null, { status: 503 })
+  }
+  await page.unroute(READ_COUNT_ROUTE)
+  await page.route(READ_COUNT_ROUTE, async (route) => {
+    const response = await handleReadCountRequest(
+      new Request(route.request().url()),
+      {
+        cache,
+        fetch: unavailableFetch,
+        now: () => now,
+      },
+    )
+    cacheStates.push(response.headers.get(READ_COUNT_CACHE_STATUS_HEADER))
+    await route.fulfill({
+      body: await response.text(),
+      headers: Object.fromEntries(response.headers),
+      status: response.status,
+    })
+  })
+
+  await page.goto('/')
+  const popular = page.locator('[data-popular-articles]')
+  await expect(popular).toHaveAttribute('data-popular-articles-state', 'loaded')
+  await expect(popular.locator('[data-popular-count]')).toHaveText(
+    POPULAR_FIXTURES.map(({ label }) => label),
+  )
+
+  const cachedArticlePath = buildArticlePath(HOME_FEATURED.slug)
+  await warmReadCountCache(cache, cachedArticlePath, '1,234', fetchedAt)
+  await page.goto(cachedArticlePath)
+  const readCount = page.locator('[data-read-count]')
+  await expect(readCount).toHaveAttribute('data-path', cachedArticlePath)
+  await expect(readCount).toHaveAttribute('data-read-count-state', 'loaded')
+  await expect(readCount).toContainText('1,234 views')
+
+  expect(cacheStates).toHaveLength(candidates.length + 1)
+  expect(cacheStates.every((state) => state === 'stale')).toBe(true)
+  expect(upstreamRequests).toHaveLength(candidates.length + 1)
 })
 
 test('homepage hides incomplete and unexpected popularity failures cleanly', async ({


### PR DESCRIPTION
## Summary
- wrap Cloudflare `caches.default` behind dependency-injectable count, backoff, and isolate-coordination abstractions keyed by canonical article path and dependency identity
- validate request origins before deriving same-origin internal keys; only production, Cloudflare Pages previews, and local development are accepted
- treat validated counts as fresh for four hours and retain them for bounded stale-if-error fallback for seven days
- coalesce same-article refreshes within one Pages Function isolate, with leader preflight rechecks, dependency isolation, and guaranteed in-flight cleanup
- track request consumers so one disconnect cannot cancel active peers, abort the shared fetch when no consumers remain, and never let new callers join an aborted refresh
- serialize Pages config/deploy runs with the current Actions queue, scope compatibility updates to the target environment, and keep Cloudflare's `enable_request_signal` flag enabled without letting PR previews mutate production
- assign refresh generation at request start and re-read the count cache immediately before writes; preserve cumulative higher counts and equal counts with newer trusted metadata
- store timeout/network/429/5xx backoff only under a separate 30-second internal key; active backoff skips GoatCounter and rechecks for a concurrent fresh value before serving stale/unavailable
- retain an already-validated stale snapshot when a post-failure cache reread is evicted, malformed, or unavailable
- cap public cache headers by remaining freshness/retention, fail closed for invalid paths/404/malformed/expired entries, and keep count/marker cache failures non-fatal

## Validation
- `npm run astro check`
- `npm test` (352 tests)
- `npm run build`
- `npm run test:smoke` (34 tests)

## Cumulative-count contract
GoatCounter public pageview totals are cumulative for this feature. A higher cached count intentionally wins over a lower refresh even when its trusted timestamp is older; the original older timestamp is preserved, so this does not reset or extend its retention window. Supporting legitimate count decreases would require an explicit product/contract change rather than weakening the monotonic guard added for #88.

## Residual limitations
Cloudflare's Cache API is per-edge and has no conditional write or cross-isolate compare-and-swap. Coalescing is isolate-local and backoff is edge-local. The final cache re-read plus cumulative monotonic guard prevents overwriting any higher count or equal-count newer generation observed before `cache.put`, but a cross-isolate write can still race after that read. True global serialization would require Durable Objects/KV and remains future architecture if production evidence warrants it.

Cache API operations themselves do not accept an `AbortSignal`; request cancellation safely stops the shared upstream fetch but cannot cancel an already-issued edge cache operation. Adding a local Promise timeout would not cancel the operation and could permit late writes/deletes, so this remains bounded by the Workers runtime rather than adding success-shaped timeout races.

Closes #88